### PR TITLE
DMP-499: Introduce an error handling layer to ensure response consiste…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -340,7 +340,7 @@ dependencies {
   testImplementation 'org.xmlunit:xmlunit-matchers:2.9.1'
 
   // we can use a dynamic variable to target 0.x at this moment
-  openapispec 'uk.gov.hmcts:darts-api:0.0.1:openapi'
+  openapispec 'com.github.hmcts:darts-api:master-SNAPSHOT:openapi'
 }
 
 mainClassName = 'uk.gov.hmcts.darts.Application'

--- a/build.gradle
+++ b/build.gradle
@@ -340,7 +340,7 @@ dependencies {
   testImplementation 'org.xmlunit:xmlunit-matchers:2.9.1'
 
   // we can use a dynamic variable to target 0.x at this moment
-  openapispec 'com.github.hmcts:darts-api:master-SNAPSHOT:openapi'
+  openapispec 'uk.gov.hmcts:darts-api:0.0.1:openapi'
 }
 
 mainClassName = 'uk.gov.hmcts.darts.Application'

--- a/build.gradle
+++ b/build.gradle
@@ -340,7 +340,7 @@ dependencies {
   testImplementation 'org.xmlunit:xmlunit-matchers:2.9.1'
 
   // we can use a dynamic variable to target 0.x at this moment
-  openapispec 'com.github.hmcts:darts-api:master-SNAPSHOT:openapi'
+  openapispec 'com.github.hmcts:darts-api:DMP-985-Add-Known-Legacy-Errors-To-OpenAPI-SNAPSHOT:openapi'
 }
 
 mainClassName = 'uk.gov.hmcts.darts.Application'

--- a/src/integrationTest/java/uk/gov/hmcts/darts/utils/AddCasesApiStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/utils/AddCasesApiStub.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 
 import java.io.IOException;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 
 public class AddCasesApiStub {
     public void returnsFailureWhenPostingNewCase() throws JsonProcessingException, IOException {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/utils/AddCasesApiStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/utils/AddCasesApiStub.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.darts.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import java.io.IOException;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+
+public class AddCasesApiStub {
+    public void returnsFailureWhenPostingNewCase() throws JsonProcessingException, IOException {
+        String dartsApiResponseStr = TestUtils.getContentsFromFile(
+                "payloads/addCase/problemResponse.json");
+
+        stubFor(post(urlPathEqualTo("/cases"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withStatus(400)
+                        .withBody(dartsApiResponseStr)));
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/darts/utils/DailyListApiStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/utils/DailyListApiStub.java
@@ -1,5 +1,9 @@
 package uk.gov.hmcts.darts.utils;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import java.io.IOException;
+
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
@@ -32,5 +36,16 @@ public class DailyListApiStub extends DartsApiStub {
     public void verifySentRequest() {
         verify(exactly(1), postRequestedFor(urlPathEqualTo(DAILY_LIST_API_PATH))
               .withQueryParam("source_system", equalTo("XHB")));
+    }
+
+    public void returnsFailureWhenPostingDailyList() throws JsonProcessingException, IOException {
+        String dartsApiResponseStr = TestUtils.getContentsFromFile(
+                "payloads/events/problemDailyListResponse.json");
+
+        stubFor(post(urlPathEqualTo(DAILY_LIST_API_PATH))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withStatus(404)
+                        .withBody(dartsApiResponseStr)));
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/utils/GetCasesApiStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/utils/GetCasesApiStub.java
@@ -13,7 +13,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 public class GetCasesApiStub {
     public void returnsFailureWhenGettingCases() throws JsonProcessingException, IOException {
         String dartsApiResponseStr = TestUtils.getContentsFromFile(
-                "payloads/getcases/problemResponse.json");
+                "payloads/getCases/problemResponse.json");
 
         stubFor(get(urlPathEqualTo("/cases"))
                 .willReturn(aResponse()

--- a/src/integrationTest/java/uk/gov/hmcts/darts/utils/GetCasesApiStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/utils/GetCasesApiStub.java
@@ -4,7 +4,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 
 import java.io.IOException;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+
 
 public class GetCasesApiStub {
     public void returnsFailureWhenGettingCases() throws JsonProcessingException, IOException {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/utils/GetCasesApiStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/utils/GetCasesApiStub.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.darts.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import java.io.IOException;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+public class GetCasesApiStub {
+    public void returnsFailureWhenGettingCases() throws JsonProcessingException, IOException {
+        String dartsApiResponseStr = TestUtils.getContentsFromFile(
+                "payloads/getcases/problemResponse.json");
+
+        stubFor(get(urlPathEqualTo("/cases"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withStatus(400)
+                        .withBody(dartsApiResponseStr)));
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/darts/utils/IntegrationBase.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/utils/IntegrationBase.java
@@ -20,6 +20,8 @@ public class IntegrationBase {
     protected DailyListApiStub dailyListApiStub = new DailyListApiStub();
     protected GetCourtLogsApiStub courtLogsApi = new GetCourtLogsApiStub();
     protected PostCourtLogsApiStub postCourtLogsApi = new PostCourtLogsApiStub();
+    protected AddCasesApiStub addCasesApiStub = new AddCasesApiStub();
+    protected GetCasesApiStub getCasesApiStub = new GetCasesApiStub();
 
     @BeforeEach
     void clearStubs() {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/utils/PostCourtLogsApiStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/utils/PostCourtLogsApiStub.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.darts.utils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
+import java.io.IOException;
+
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.containing;
 import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
@@ -39,4 +41,13 @@ public class PostCourtLogsApiStub extends DartsApiStub {
             .withRequestBody(containing(caseNumber)));
     }
 
+    public void returnsFailureWhenAddingCourtLogs() throws JsonProcessingException, IOException {
+        String dartsApiResponseStr = TestUtils.getContentsFromFile(
+            "payloads/courtlogs/problemResponse.json");
+
+        stubFor(post(urlPathEqualTo(POST_COURT_LOGS_API_PATH)).willReturn(aResponse().withHeader(
+            "Content-Type",
+            "application/json"
+        ).withStatus(404).withBody(dartsApiResponseStr)));
+    }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/CasesWebServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/CasesWebServiceTest.java
@@ -19,7 +19,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.springframework.ws.test.server.RequestCreators.withPayload;
-import static org.springframework.ws.test.server.ResponseMatchers.*;
+import static org.springframework.ws.test.server.ResponseMatchers.clientOrSenderFault;
+import static org.springframework.ws.test.server.ResponseMatchers.noFault;
 import static org.springframework.ws.test.server.ResponseMatchers.xpath;
 
 @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
@@ -52,14 +53,12 @@ class CasesWebServiceTest extends IntegrationBase {
 
     @Test
     void handlesGetCasesServiceFailure() throws IOException {
-        getCasesApiStub.returnsFailureWhenGettingCases();;
+        getCasesApiStub.returnsFailureWhenGettingCases();
 
         String soapRequestStr = TestUtils.getContentsFromFile(
                 "payloads/getCases/soapRequest.xml");
 
         StringSource soapRequest = new StringSource(soapRequestStr);
-        String dartsApiResponseStr = TestUtils.getContentsFromFile(
-                "payloads/getCases/dartsApiResponse.json");
 
         wsClient.sendRequest(withPayload(soapRequest))
                 .andExpect(noFault()).andExpect(noFault())

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/CourtLogsWebServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/CourtLogsWebServiceTest.java
@@ -49,6 +49,7 @@ class CourtLogsWebServiceTest extends IntegrationBase {
         courtLogsApi.verifyReceivedGetCourtLogsRequestFor(SOME_COURTHOUSE, "some-case");
     }
 
+
     @Test
     void rejectsInvalidSoapMessage(@Value(INVALID_COURTLOGS_XML) Resource invalidSoapMessage) throws IOException {
         courtLogsApi.returnsCourtLogs(someListOfCourtLog(1));
@@ -66,6 +67,18 @@ class CourtLogsWebServiceTest extends IntegrationBase {
         wsClient.sendRequest(withPayload(postCourtLogs)).andExpect(noFault())
             .andExpect(xpath("//code").evaluatesTo("200"))
             .andExpect(xpath("//message").evaluatesTo("OK"));
+
+
+        postCourtLogsApi.verifyReceivedPostCourtLogsRequestForCaseNumber("CASE000001");
+    }
+
+    @Test
+    void postCourtLogsRouteFailOnInvalidServiceResponse(@Value(VALID_POST_COURTLOGS_XML) Resource postCourtLogs) throws Exception {
+        postCourtLogsApi.returnsFailureWhenAddingCourtLogs();
+
+        wsClient.sendRequest(withPayload(postCourtLogs)).andExpect(noFault())
+            .andExpect(xpath("//code").evaluatesTo("404"))
+            .andExpect(xpath("//message").evaluatesTo("Courthouse Not Found"));
 
 
         postCourtLogsApi.verifyReceivedPostCourtLogsRequestForCaseNumber("CASE000001");

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/EventWebServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/EventWebServiceTest.java
@@ -15,8 +15,8 @@ import java.nio.charset.Charset;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.springframework.ws.test.server.RequestCreators.withPayload;
-import static org.springframework.ws.test.server.ResponseMatchers.clientOrSenderFault;
-import static org.springframework.ws.test.server.ResponseMatchers.noFault;
+import static org.springframework.ws.test.server.ResponseMatchers.*;
+import static org.springframework.ws.test.server.ResponseMatchers.xpath;
 
 @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 class EventWebServiceTest extends IntegrationBase {
@@ -63,6 +63,18 @@ class EventWebServiceTest extends IntegrationBase {
         assertThat(actualResponse, CompareMatcher.isSimilarTo(expectedResponse).ignoreWhitespace());
 
         dailyListApiStub.verifySentRequest();
+    }
+
+    @Test
+    void routesValidDailyListPayloadButInvalidServiceResponse(
+            @Value("classpath:payloads/events/valid-dailyList.xml") Resource validEvent,
+            @Value("classpath:payloads/events/valid-event-response.xml") Resource validEventResponse
+    ) throws IOException {
+        dailyListApiStub.returnsFailureWhenPostingDailyList();
+
+        wsClient.sendRequest(withPayload(validEvent))
+                .andExpect(noFault()).andExpect(xpath("//code").evaluatesTo("404"))
+                .andExpect(xpath("//message").evaluatesTo("Handler Not Found"));
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/EventWebServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/EventWebServiceTest.java
@@ -15,7 +15,8 @@ import java.nio.charset.Charset;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.springframework.ws.test.server.RequestCreators.withPayload;
-import static org.springframework.ws.test.server.ResponseMatchers.*;
+import static org.springframework.ws.test.server.ResponseMatchers.clientOrSenderFault;
+import static org.springframework.ws.test.server.ResponseMatchers.noFault;
 import static org.springframework.ws.test.server.ResponseMatchers.xpath;
 
 @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
@@ -66,7 +67,7 @@ class EventWebServiceTest extends IntegrationBase {
     }
 
     @Test
-    void routesValidDailyListPayloadButInvalidServiceResponse(
+    void routesValidDailyListPayloadWithInvalidServiceResponse(
             @Value("classpath:payloads/events/valid-dailyList.xml") Resource validEvent,
             @Value("classpath:payloads/events/valid-event-response.xml") Resource validEventResponse
     ) throws IOException {

--- a/src/integrationTest/resources/payloads/addCase/problemResponse.json
+++ b/src/integrationTest/resources/payloads/addCase/problemResponse.json
@@ -1,0 +1,6 @@
+{
+  "type": "ADD_CASE_102",
+  "title": "",
+  "status": "434",
+  "detail" : ""
+}

--- a/src/integrationTest/resources/payloads/courtlogs/problemResponse.json
+++ b/src/integrationTest/resources/payloads/courtlogs/problemResponse.json
@@ -1,0 +1,6 @@
+{
+  "type": "ADD_COURTLOG_101",
+  "title": "",
+  "status": "434",
+  "detail" : ""
+}

--- a/src/integrationTest/resources/payloads/events/problemDailyListResponse.json
+++ b/src/integrationTest/resources/payloads/events/problemDailyListResponse.json
@@ -2,5 +2,5 @@
   "type": "ADD_DAILYLIST_103",
   "title": "",
   "status": "434",
-  "detail" : ""
+  "detail": ""
 }

--- a/src/integrationTest/resources/payloads/events/problemDailyListResponse.json
+++ b/src/integrationTest/resources/payloads/events/problemDailyListResponse.json
@@ -1,0 +1,6 @@
+{
+  "type": "ADD_DAILYLIST_103",
+  "title": "",
+  "status": "434",
+  "detail" : ""
+}

--- a/src/integrationTest/resources/payloads/getCases/problemResponse.json
+++ b/src/integrationTest/resources/payloads/getCases/problemResponse.json
@@ -1,0 +1,6 @@
+{
+  "type": "GET_CASE_101",
+  "title": "",
+  "status": "434",
+  "detail" : ""
+}

--- a/src/main/java/uk/gov/hmcts/darts/cases/CasesRoute.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/CasesRoute.java
@@ -2,12 +2,14 @@ package uk.gov.hmcts.darts.cases;
 
 import com.service.mojdarts.synapps.com.AddCase;
 import com.service.mojdarts.synapps.com.GetCases;
-import com.service.mojdarts.synapps.com.GetCasesResponse;
+import com.synapps.moj.dfs.response.GetCasesResponse;
+import com.synapps.moj.dfs.response.DARTSResponse;
 
 public interface CasesRoute {
+
     GetCasesResponse route(GetCases getCasesRequest);
 
-    void route(AddCase addCase);
+    DARTSResponse route(AddCase addCase);
 
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/cases/CasesRoute.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/CasesRoute.java
@@ -2,14 +2,11 @@ package uk.gov.hmcts.darts.cases;
 
 import com.service.mojdarts.synapps.com.AddCase;
 import com.service.mojdarts.synapps.com.GetCases;
-import com.synapps.moj.dfs.response.GetCasesResponse;
 import com.synapps.moj.dfs.response.DARTSResponse;
+import com.synapps.moj.dfs.response.GetCasesResponse;
 
 public interface CasesRoute {
-
     GetCasesResponse route(GetCases getCasesRequest);
 
     DARTSResponse route(AddCase addCase);
-
-
 }

--- a/src/main/java/uk/gov/hmcts/darts/cases/impl/CasesRouteImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/impl/CasesRouteImpl.java
@@ -2,9 +2,9 @@ package uk.gov.hmcts.darts.cases.impl;
 
 import com.service.mojdarts.synapps.com.AddCase;
 import com.service.mojdarts.synapps.com.GetCases;
-import com.synapps.moj.dfs.response.GetCasesResponse;
 import com.service.mojdarts.synapps.com.addcase.Case;
 import com.synapps.moj.dfs.response.DARTSResponse;
+import com.synapps.moj.dfs.response.GetCasesResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
@@ -58,6 +58,7 @@ public class CasesRouteImpl implements CasesRoute {
 
         casesClient.casesPost(addCaseRequest);
 
-        return CodeAndMessage.OK.getResponse();
+        CodeAndMessage okResponse = CodeAndMessage.OK;
+        return okResponse.getResponse();
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/cases/impl/CasesRouteImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/impl/CasesRouteImpl.java
@@ -2,8 +2,9 @@ package uk.gov.hmcts.darts.cases.impl;
 
 import com.service.mojdarts.synapps.com.AddCase;
 import com.service.mojdarts.synapps.com.GetCases;
-import com.service.mojdarts.synapps.com.GetCasesResponse;
+import com.synapps.moj.dfs.response.GetCasesResponse;
 import com.service.mojdarts.synapps.com.addcase.Case;
+import com.synapps.moj.dfs.response.DARTSResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +16,7 @@ import uk.gov.hmcts.darts.common.client.CasesClient;
 import uk.gov.hmcts.darts.model.cases.ScheduledCase;
 import uk.gov.hmcts.darts.utilities.XmlParser;
 import uk.gov.hmcts.darts.utilities.XmlValidator;
+import uk.gov.hmcts.darts.ws.CodeAndMessage;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -41,11 +43,11 @@ public class CasesRouteImpl implements CasesRoute {
             getCasesRequest.getCourtroom(),
             LocalDate.parse(getCasesRequest.getDate())
         );
-        return GetCasesMapper.mapToMojDartsResponse(getCasesRequest, modernisedDartsResponse.getBody());
+        return GetCasesMapper.mapToDfsResponse(getCasesRequest, modernisedDartsResponse.getBody());
     }
 
     @Override
-    public void route(AddCase addCase) {
+    public DARTSResponse route(AddCase addCase) {
         var caseDocumentXmlStr = addCase.getDocument();
         if (validateAddCase) {
             xmlValidator.validate(caseDocumentXmlStr, addCaseSchemaPath);
@@ -55,5 +57,7 @@ public class CasesRouteImpl implements CasesRoute {
         var addCaseRequest = addCaseMapper.mapToDartsApi(caseDocument);
 
         casesClient.casesPost(addCaseRequest);
+
+        return CodeAndMessage.OK.getResponse();
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/cases/mapper/GetCasesMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/mapper/GetCasesMapper.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.darts.cases.mapper;
 
 import com.service.mojdarts.synapps.com.GetCases;
-import com.service.mojdarts.synapps.com.GetCasesResponse;
+import com.synapps.moj.dfs.response.GetCasesResponse;
 import com.synapps.moj.dfs.response.Case;
 import com.synapps.moj.dfs.response.Cases;
 import com.synapps.moj.dfs.response.Defendants;
@@ -16,14 +16,8 @@ import java.util.List;
 
 @UtilityClass
 public class GetCasesMapper {
-
-    public GetCasesResponse mapToMojDartsResponse(GetCases getCasesRequest, List<ScheduledCase> modernisedDartsResponse) {
-        GetCasesResponse getCasesResponse = new GetCasesResponse();
-        getCasesResponse.setReturn(mapToDfsResponse(getCasesRequest, modernisedDartsResponse));
-        return getCasesResponse;
-    }
-
-    private com.synapps.moj.dfs.response.GetCasesResponse mapToDfsResponse(GetCases getCasesRequest, List<ScheduledCase> modernisedDartsResponse) {
+    
+    public com.synapps.moj.dfs.response.GetCasesResponse mapToDfsResponse(GetCases getCasesRequest, List<ScheduledCase> modernisedDartsResponse) {
         Cases cases = new Cases();
         setCasesAttributes(getCasesRequest, cases);
         List<Case> caseList = cases.getCase();

--- a/src/main/java/uk/gov/hmcts/darts/cases/mapper/GetCasesMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/mapper/GetCasesMapper.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.cases.mapper;
 
 import com.service.mojdarts.synapps.com.GetCases;
-import com.synapps.moj.dfs.response.GetCasesResponse;
 import com.synapps.moj.dfs.response.Case;
 import com.synapps.moj.dfs.response.Cases;
 import com.synapps.moj.dfs.response.Defendants;
@@ -16,7 +15,7 @@ import java.util.List;
 
 @UtilityClass
 public class GetCasesMapper {
-    
+
     public com.synapps.moj.dfs.response.GetCasesResponse mapToDfsResponse(GetCases getCasesRequest, List<ScheduledCase> modernisedDartsResponse) {
         Cases cases = new Cases();
         setCasesAttributes(getCasesRequest, cases);

--- a/src/main/java/uk/gov/hmcts/darts/common/client/exeption/AbstractClientProblemDecoder.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/exeption/AbstractClientProblemDecoder.java
@@ -1,0 +1,56 @@
+package uk.gov.hmcts.darts.common.client.exeption;
+
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import uk.gov.hmcts.darts.common.client.mapper.APIProblemResponseMapper;
+import uk.gov.hmcts.darts.model.audio.Problem;
+import uk.gov.hmcts.darts.ws.CodeAndMessage;
+import uk.gov.hmcts.darts.ws.DartsException;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@RequiredArgsConstructor
+public abstract class AbstractClientProblemDecoder implements ErrorDecoder {
+
+    private final List<APIProblemResponseMapper> responseMappers;
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        Exception returnEx;
+        try {
+            Problem problem = getProblem(response);
+            returnEx = getExceptionForProblem(problem);
+        } catch (IOException ioEx) {
+            log.error("Failed to read the problem json", ioEx);
+            returnEx = new DartsException(ioEx, CodeAndMessage.ERROR);
+        }
+
+        return returnEx;
+    }
+
+    private ClientProblemException getExceptionForProblem(Problem problem) {
+        ClientProblemException returnEx = null;
+        Optional<APIProblemResponseMapper> identifiedProblem
+            = responseMappers.stream().filter(e -> e.getExceptionForProblem(problem).isPresent()).findFirst();
+
+        if (identifiedProblem.isPresent()) {
+            Optional<ClientProblemException> exception = identifiedProblem.get().getExceptionForProblem(problem);
+
+            if (exception.isPresent()) {
+                returnEx = exception.get();
+            }
+        }
+        else {
+            returnEx = new ClientProblemException(problem);
+        }
+
+        return returnEx;
+    }
+
+    protected abstract Problem getProblem(Response response) throws IOException;
+}

--- a/src/main/java/uk/gov/hmcts/darts/common/client/exeption/AbstractClientProblemDecoder.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/exeption/AbstractClientProblemDecoder.java
@@ -44,8 +44,7 @@ public abstract class AbstractClientProblemDecoder implements ErrorDecoder {
             if (exception.isPresent()) {
                 returnEx = exception.get();
             }
-        }
-        else {
+        } else {
             returnEx = new ClientProblemException(problem);
         }
 

--- a/src/main/java/uk/gov/hmcts/darts/common/client/exeption/ClientProblemException.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/exeption/ClientProblemException.java
@@ -10,7 +10,7 @@ public class ClientProblemException extends DartsException {
 
     @SuppressWarnings("java:S1135")
     //TODO: Work out why we cant have a central problem type when generating the API spec
-    private transient final Problem problem;
+    private final transient Problem problem;
 
     public ClientProblemException(Throwable cause, CodeAndMessage codeAndMessage, Problem problem) {
         super(cause, codeAndMessage);

--- a/src/main/java/uk/gov/hmcts/darts/common/client/exeption/ClientProblemException.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/exeption/ClientProblemException.java
@@ -19,6 +19,7 @@ public class ClientProblemException extends DartsException {
     public ClientProblemException(CodeAndMessage codeAndMessage, Problem problem) {
         this(null, codeAndMessage, problem);
     }
+
     public ClientProblemException(Problem problem) {
         this(CodeAndMessage.ERROR, problem);
     }

--- a/src/main/java/uk/gov/hmcts/darts/common/client/exeption/ClientProblemException.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/exeption/ClientProblemException.java
@@ -8,8 +8,9 @@ import uk.gov.hmcts.darts.ws.DartsException;
 @Getter
 public class ClientProblemException extends DartsException {
 
+    @SuppressWarnings("java:S1135")
     //TODO: Work out why we cant have a central problem type when generating the API spec
-    private Problem problem;
+    private transient final Problem problem;
 
     public ClientProblemException(Throwable cause, CodeAndMessage codeAndMessage, Problem problem) {
         super(cause, codeAndMessage);

--- a/src/main/java/uk/gov/hmcts/darts/common/client/exeption/ClientProblemException.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/exeption/ClientProblemException.java
@@ -1,0 +1,25 @@
+package uk.gov.hmcts.darts.common.client.exeption;
+
+import lombok.Getter;
+import uk.gov.hmcts.darts.model.audio.Problem;
+import uk.gov.hmcts.darts.ws.CodeAndMessage;
+import uk.gov.hmcts.darts.ws.DartsException;
+
+@Getter
+public class ClientProblemException extends DartsException {
+
+    //TODO: Work out why we cant have a central problem type when generating the API spec
+    private Problem problem;
+
+    public ClientProblemException(Throwable cause, CodeAndMessage codeAndMessage, Problem problem) {
+        super(cause, codeAndMessage);
+        this.problem = problem;
+    }
+
+    public ClientProblemException(CodeAndMessage codeAndMessage, Problem problem) {
+        this(null, codeAndMessage, problem);
+    }
+    public ClientProblemException(Problem problem) {
+        this(CodeAndMessage.ERROR, problem);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/common/client/exeption/JacksonClientProblemDecoder.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/exeption/JacksonClientProblemDecoder.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.darts.common.client.exeption;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.Response;
+import uk.gov.hmcts.darts.common.client.mapper.APIProblemResponseMapper;
+import uk.gov.hmcts.darts.config.ServiceConfig;
+import uk.gov.hmcts.darts.model.audio.Problem;
+
+import java.io.IOException;
+import java.util.List;
+
+public class JacksonClientProblemDecoder extends AbstractClientProblemDecoder {
+
+    public JacksonClientProblemDecoder(List<APIProblemResponseMapper> responseMappers) {
+        super(responseMappers);
+    }
+
+    @Override
+    protected Problem getProblem(Response response) throws IOException {
+        ObjectMapper mapper = ServiceConfig.getServiceObjectMapper();
+        return  mapper.readValue(response.body().asInputStream(), Problem.class);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/common/client/exeption/JacksonClientProblemDecoder.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/exeption/JacksonClientProblemDecoder.java
@@ -18,6 +18,6 @@ public class JacksonClientProblemDecoder extends AbstractClientProblemDecoder {
     @Override
     protected Problem getProblem(Response response) throws IOException {
         ObjectMapper mapper = ServiceConfig.getServiceObjectMapper();
-        return  mapper.readValue(response.body().asInputStream(), Problem.class);
+        return mapper.readValue(response.body().asInputStream(), Problem.class);
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/client/exeption/cases/CasesAPIGetCasesException.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/exeption/cases/CasesAPIGetCasesException.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.darts.common.client.exeption.cases;
+
+import lombok.Getter;
+import uk.gov.hmcts.darts.common.client.exeption.ClientProblemException;
+import uk.gov.hmcts.darts.common.client.mapper.ProblemResponseMapping;
+import uk.gov.hmcts.darts.model.audio.Problem;
+import uk.gov.hmcts.darts.model.cases.GetCasesErrorCode;
+
+@Getter
+public class CasesAPIGetCasesException extends ClientProblemException {
+    private ProblemResponseMapping<GetCasesErrorCode> mapping;
+
+    public CasesAPIGetCasesException(Throwable cause, ProblemResponseMapping<GetCasesErrorCode> addCases, Problem problem) {
+        super(cause, addCases.getMessage(), problem);
+        this.mapping = addCases;
+    }
+
+    public CasesAPIGetCasesException(ProblemResponseMapping<GetCasesErrorCode> addCases, Problem problem) {
+        this(null, addCases, problem);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/common/client/exeption/cases/CasesAPIGetCasesException.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/exeption/cases/CasesAPIGetCasesException.java
@@ -7,8 +7,9 @@ import uk.gov.hmcts.darts.model.audio.Problem;
 import uk.gov.hmcts.darts.model.cases.GetCasesErrorCode;
 
 @Getter
+@SuppressWarnings("java:S110")
 public class CasesAPIGetCasesException extends ClientProblemException {
-    private ProblemResponseMapping<GetCasesErrorCode> mapping;
+    private final transient ProblemResponseMapping<GetCasesErrorCode> mapping;
 
     public CasesAPIGetCasesException(Throwable cause, ProblemResponseMapping<GetCasesErrorCode> addCases, Problem problem) {
         super(cause, addCases.getMessage(), problem);

--- a/src/main/java/uk/gov/hmcts/darts/common/client/exeption/cases/CasesAPIPostCaseException.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/exeption/cases/CasesAPIPostCaseException.java
@@ -8,8 +8,9 @@ import uk.gov.hmcts.darts.model.audio.Problem;
 import uk.gov.hmcts.darts.model.cases.PostCasesErrorCode;
 
 @Getter
+@SuppressWarnings("java:S110")
 public class CasesAPIPostCaseException extends ClientProblemException {
-    private ProblemResponseMapping<PostCasesErrorCode> mapping;
+    private final transient ProblemResponseMapping<PostCasesErrorCode> mapping;
 
     public CasesAPIPostCaseException(Throwable cause, ProblemResponseMapping<PostCasesErrorCode> mapping, Problem problem) {
         super(cause, mapping.getMessage(), problem);

--- a/src/main/java/uk/gov/hmcts/darts/common/client/exeption/cases/CasesAPIPostCaseException.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/exeption/cases/CasesAPIPostCaseException.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.darts.common.client.exeption.cases;
+
+
+import lombok.Getter;
+import uk.gov.hmcts.darts.common.client.exeption.ClientProblemException;
+import uk.gov.hmcts.darts.common.client.mapper.ProblemResponseMapping;
+import uk.gov.hmcts.darts.model.audio.Problem;
+import uk.gov.hmcts.darts.model.cases.PostCasesErrorCode;
+
+@Getter
+public class CasesAPIPostCaseException extends ClientProblemException {
+    private ProblemResponseMapping<PostCasesErrorCode> mapping;
+
+    public CasesAPIPostCaseException(Throwable cause, ProblemResponseMapping<PostCasesErrorCode> mapping, Problem problem) {
+        super(cause, mapping.getMessage(), problem);
+        this.mapping = mapping;
+    }
+
+    public CasesAPIPostCaseException(ProblemResponseMapping<PostCasesErrorCode> addCases, Problem problem) {
+        this(null, addCases, problem);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/common/client/exeption/dailylist/DailyListAPIAddException.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/exeption/dailylist/DailyListAPIAddException.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.common.client.exeption.dailylist;
 
-
 import lombok.Getter;
 import uk.gov.hmcts.darts.common.client.exeption.ClientProblemException;
 import uk.gov.hmcts.darts.common.client.mapper.ProblemResponseMapping;

--- a/src/main/java/uk/gov/hmcts/darts/common/client/exeption/dailylist/DailyListAPIAddException.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/exeption/dailylist/DailyListAPIAddException.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.darts.common.client.exeption.dailylist;
+
+
+import lombok.Getter;
+import uk.gov.hmcts.darts.common.client.exeption.ClientProblemException;
+import uk.gov.hmcts.darts.common.client.mapper.ProblemResponseMapping;
+import uk.gov.hmcts.darts.model.audio.Problem;
+import uk.gov.hmcts.darts.model.dailylist.PostDailyListErrorCode;
+
+@Getter
+public class DailyListAPIAddException extends ClientProblemException {
+    private ProblemResponseMapping<PostDailyListErrorCode> mapping;
+
+    public DailyListAPIAddException(Throwable cause, ProblemResponseMapping<PostDailyListErrorCode> mapping, Problem problem) {
+        super(cause, mapping.getMessage(), problem);
+        this.mapping = mapping;
+    }
+
+    public DailyListAPIAddException(ProblemResponseMapping<PostDailyListErrorCode> addDailyList, Problem problem) {
+        this(null, addDailyList, problem);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/common/client/exeption/dailylist/DailyListAPIAddException.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/exeption/dailylist/DailyListAPIAddException.java
@@ -7,8 +7,9 @@ import uk.gov.hmcts.darts.model.audio.Problem;
 import uk.gov.hmcts.darts.model.dailylist.PostDailyListErrorCode;
 
 @Getter
+@SuppressWarnings("java:S110")
 public class DailyListAPIAddException extends ClientProblemException {
-    private ProblemResponseMapping<PostDailyListErrorCode> mapping;
+    private final transient  ProblemResponseMapping<PostDailyListErrorCode> mapping;
 
     public DailyListAPIAddException(Throwable cause, ProblemResponseMapping<PostDailyListErrorCode> mapping, Problem problem) {
         super(cause, mapping.getMessage(), problem);

--- a/src/main/java/uk/gov/hmcts/darts/common/client/exeption/event/EventAPIGetCourtLogExeption.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/exeption/event/EventAPIGetCourtLogExeption.java
@@ -7,8 +7,9 @@ import uk.gov.hmcts.darts.model.audio.Problem;
 import uk.gov.hmcts.darts.model.event.GetCourtLogsErrorCode;
 
 @Getter
+@SuppressWarnings("java:S110")
 public class EventAPIGetCourtLogExeption extends ClientProblemException {
-    ProblemResponseMapping<GetCourtLogsErrorCode> mapping;
+    private final transient ProblemResponseMapping<GetCourtLogsErrorCode> mapping;
 
     public EventAPIGetCourtLogExeption(Throwable cause, ProblemResponseMapping<GetCourtLogsErrorCode> mapping, Problem problem) {
         super(cause, mapping.getMessage(), problem);

--- a/src/main/java/uk/gov/hmcts/darts/common/client/exeption/event/EventAPIGetCourtLogExeption.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/exeption/event/EventAPIGetCourtLogExeption.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.darts.common.client.exeption.event;
+
+import lombok.Getter;
+import uk.gov.hmcts.darts.common.client.exeption.ClientProblemException;
+import uk.gov.hmcts.darts.common.client.mapper.ProblemResponseMapping;
+import uk.gov.hmcts.darts.model.audio.Problem;
+import uk.gov.hmcts.darts.model.event.GetCourtLogsErrorCode;
+
+@Getter
+public class EventAPIGetCourtLogExeption extends ClientProblemException {
+    ProblemResponseMapping<GetCourtLogsErrorCode> mapping;
+
+    public EventAPIGetCourtLogExeption(Throwable cause, ProblemResponseMapping<GetCourtLogsErrorCode> mapping, Problem problem) {
+        super(cause, mapping.getMessage(), problem);
+
+        this.mapping = mapping;
+
+    }
+
+    public EventAPIGetCourtLogExeption(ProblemResponseMapping<GetCourtLogsErrorCode> mapping, Problem problem) {
+        this(null, mapping, problem);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/common/client/exeption/event/EventAPIPostCourtLogException.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/exeption/event/EventAPIPostCourtLogException.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.darts.common.client.exeption.event;
+
+import lombok.Getter;
+import uk.gov.hmcts.darts.common.client.exeption.ClientProblemException;
+import uk.gov.hmcts.darts.common.client.mapper.ProblemResponseMapping;
+import uk.gov.hmcts.darts.model.audio.Problem;
+import uk.gov.hmcts.darts.model.event.PostCourtLogsErrorCode;
+
+@Getter
+public class EventAPIPostCourtLogException extends ClientProblemException {
+    ProblemResponseMapping<PostCourtLogsErrorCode> mapping;
+
+    public EventAPIPostCourtLogException(Throwable cause, ProblemResponseMapping<PostCourtLogsErrorCode> mapping, Problem problem) {
+        super(cause, mapping.getMessage(), problem);
+        this.mapping = mapping;
+    }
+
+    public EventAPIPostCourtLogException(ProblemResponseMapping<PostCourtLogsErrorCode> mapping, Problem problem) {
+        this(null, mapping, problem);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/common/client/exeption/event/EventAPIPostCourtLogException.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/exeption/event/EventAPIPostCourtLogException.java
@@ -7,8 +7,9 @@ import uk.gov.hmcts.darts.model.audio.Problem;
 import uk.gov.hmcts.darts.model.event.PostCourtLogsErrorCode;
 
 @Getter
+@SuppressWarnings("java:S110")
 public class EventAPIPostCourtLogException extends ClientProblemException {
-    ProblemResponseMapping<PostCourtLogsErrorCode> mapping;
+    private final transient ProblemResponseMapping<PostCourtLogsErrorCode> mapping;
 
     public EventAPIPostCourtLogException(Throwable cause, ProblemResponseMapping<PostCourtLogsErrorCode> mapping, Problem problem) {
         super(cause, mapping.getMessage(), problem);

--- a/src/main/java/uk/gov/hmcts/darts/common/client/exeption/event/EventAPIPostEventException.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/exeption/event/EventAPIPostEventException.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.darts.common.client.exeption.event;
+
+import lombok.Getter;
+import uk.gov.hmcts.darts.common.client.exeption.ClientProblemException;
+import uk.gov.hmcts.darts.common.client.mapper.ProblemResponseMapping;
+import uk.gov.hmcts.darts.model.audio.Problem;
+import uk.gov.hmcts.darts.model.event.EventErrorCode;
+
+@Getter
+public class EventAPIPostEventException  extends ClientProblemException {
+    ProblemResponseMapping<EventErrorCode> mapping;
+
+    public EventAPIPostEventException(Throwable cause, ProblemResponseMapping<EventErrorCode> mapping, Problem problem) {
+        super(cause, mapping.getMessage(), problem);
+        this.mapping = mapping;
+    }
+
+    public EventAPIPostEventException(ProblemResponseMapping<EventErrorCode> mapping, Problem problem) {
+        this(null, mapping, problem);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/common/client/exeption/event/EventAPIPostEventException.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/exeption/event/EventAPIPostEventException.java
@@ -7,8 +7,9 @@ import uk.gov.hmcts.darts.model.audio.Problem;
 import uk.gov.hmcts.darts.model.event.EventErrorCode;
 
 @Getter
+@SuppressWarnings("java:S110")
 public class EventAPIPostEventException extends ClientProblemException {
-    ProblemResponseMapping<EventErrorCode> mapping;
+    private final transient ProblemResponseMapping<EventErrorCode> mapping;
 
     public EventAPIPostEventException(Throwable cause, ProblemResponseMapping<EventErrorCode> mapping, Problem problem) {
         super(cause, mapping.getMessage(), problem);

--- a/src/main/java/uk/gov/hmcts/darts/common/client/exeption/event/EventAPIPostEventException.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/exeption/event/EventAPIPostEventException.java
@@ -7,7 +7,7 @@ import uk.gov.hmcts.darts.model.audio.Problem;
 import uk.gov.hmcts.darts.model.event.EventErrorCode;
 
 @Getter
-public class EventAPIPostEventException  extends ClientProblemException {
+public class EventAPIPostEventException extends ClientProblemException {
     ProblemResponseMapping<EventErrorCode> mapping;
 
     public EventAPIPostEventException(Throwable cause, ProblemResponseMapping<EventErrorCode> mapping, Problem problem) {

--- a/src/main/java/uk/gov/hmcts/darts/common/client/mapper/APIProblemResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/mapper/APIProblemResponseMapper.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.darts.common.client.mapper;
+
+import uk.gov.hmcts.darts.common.client.exeption.ClientProblemException;
+import uk.gov.hmcts.darts.model.audio.Problem;
+import uk.gov.hmcts.darts.ws.CodeAndMessage;
+
+import java.util.Optional;
+
+public interface APIProblemResponseMapper {
+
+    <T> void addMapper(Class<T> operation, ProblemResponseMapping<T> mapping);
+
+    Optional<CodeAndMessage> getCodeAndMessage(Problem p);
+
+    Optional<ClientProblemException> getExceptionForProblem(Problem p);
+}

--- a/src/main/java/uk/gov/hmcts/darts/common/client/mapper/APIProblemResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/mapper/APIProblemResponseMapper.java
@@ -11,5 +11,5 @@ public interface APIProblemResponseMapper {
 
     Optional<ClientProblemException> getExceptionForProblem(Problem problem);
 
-    Optional<? extends ProblemResponseMapping<?>> getMapping(Problem problem);
+    Optional<ProblemResponseMapping<?>> getMapping(Problem problem);
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/client/mapper/APIProblemResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/mapper/APIProblemResponseMapper.java
@@ -10,7 +10,7 @@ public interface APIProblemResponseMapper {
 
     <T> void addMapper(Class<T> operation, ProblemResponseMapping<T> mapping);
 
-    Optional<CodeAndMessage> getCodeAndMessage(Problem p);
+    Optional<CodeAndMessage> getCodeAndMessage(Problem problem);
 
-    Optional<ClientProblemException> getExceptionForProblem(Problem p);
+    Optional<ClientProblemException> getExceptionForProblem(Problem problem);
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/client/mapper/APIProblemResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/mapper/APIProblemResponseMapper.java
@@ -2,15 +2,14 @@ package uk.gov.hmcts.darts.common.client.mapper;
 
 import uk.gov.hmcts.darts.common.client.exeption.ClientProblemException;
 import uk.gov.hmcts.darts.model.audio.Problem;
-import uk.gov.hmcts.darts.ws.CodeAndMessage;
 
 import java.util.Optional;
 
 public interface APIProblemResponseMapper {
 
-    <T> void addMapper(Class<T> operation, ProblemResponseMapping<T> mapping);
-
-    Optional<CodeAndMessage> getCodeAndMessage(Problem problem);
+    <T> void addOperationMappings(ProblemResponseMappingOperation<T> operation);
 
     Optional<ClientProblemException> getExceptionForProblem(Problem problem);
+
+    Optional<? extends ProblemResponseMapping<?>> getMapping(Problem problem);
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/client/mapper/AbstractAPIProblemResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/mapper/AbstractAPIProblemResponseMapper.java
@@ -18,6 +18,7 @@ public abstract class AbstractAPIProblemResponseMapper implements APIProblemResp
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Optional<ProblemResponseMapping<?>> getMapping(Problem problem) {
         for (ProblemResponseMappingOperation<?> operation : operationErrorResponseMappingList) {
             List<? extends ProblemResponseMapping<?>> mappingList = operation.getProblemResponseMappingList();

--- a/src/main/java/uk/gov/hmcts/darts/common/client/mapper/AbstractAPIProblemResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/mapper/AbstractAPIProblemResponseMapper.java
@@ -18,13 +18,13 @@ public abstract class AbstractAPIProblemResponseMapper implements APIProblemResp
     }
 
     @Override
-    public Optional<? extends ProblemResponseMapping<?>> getMapping(Problem problem) {
+    public Optional<ProblemResponseMapping<?>> getMapping(Problem problem) {
         for (ProblemResponseMappingOperation<?> operation : operationErrorResponseMappingList) {
             List<? extends ProblemResponseMapping<?>> mappingList = operation.getProblemResponseMappingList();
             Optional<? extends ProblemResponseMapping<?>> fnd = mappingList.stream().filter(m -> m.match(problem)).findFirst();
 
             if (fnd.isPresent()) {
-                return fnd;
+                return (Optional<ProblemResponseMapping<?>>)fnd;
             }
         }
 

--- a/src/main/java/uk/gov/hmcts/darts/common/client/mapper/AbstractAPIProblemResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/mapper/AbstractAPIProblemResponseMapper.java
@@ -1,0 +1,63 @@
+package uk.gov.hmcts.darts.common.client.mapper;
+
+import uk.gov.hmcts.darts.common.client.exeption.ClientProblemException;
+import uk.gov.hmcts.darts.model.audio.Problem;
+import uk.gov.hmcts.darts.ws.CodeAndMessage;
+
+import java.util.*;
+import java.util.function.Function;
+
+public abstract class AbstractAPIProblemResponseMapper implements APIProblemResponseMapper {
+    private final Map<Class<?>, List<ProblemResponseMapping<?>>> operationErrorResponseMappingList = new HashMap<>();
+
+    public <T> void addMapper(Class<T> operation, ProblemResponseMapping<T> mapping) {
+        if (!operationErrorResponseMappingList.containsKey(operation)) {
+            List<ProblemResponseMapping<?>> mappingsLst = new ArrayList<>();
+            operationErrorResponseMappingList.put(operation, mappingsLst);
+        }
+        operationErrorResponseMappingList.get(operation).add(mapping);
+    }
+
+    @Override
+    public Optional<CodeAndMessage> getCodeAndMessage(Problem p) {
+
+        for (Class<?> operation : operationErrorResponseMappingList.keySet()) {
+            Optional<ProblemResponseMapping<?>> mapping = operationErrorResponseMappingList.get(operation).stream().filter(
+                m -> m.match(
+                    p)).findFirst();
+
+            return mapping.isPresent() ? mapping.map(ProblemResponseMapping::getMessage) : Optional.empty();
+        }
+
+        return Optional.empty();
+    }
+
+    public Optional<ProblemResponseMapping<?>> getMapping(Problem p) {
+        for (Class<?> operation : operationErrorResponseMappingList.keySet()) {
+            List<ProblemResponseMapping<?>> mappingList = operationErrorResponseMappingList.get(operation);
+            return mappingList.stream().filter(m -> m.match(p)).findFirst();
+        }
+
+        return Optional.empty();
+    }
+
+    @SuppressWarnings("unchecked")
+    protected <T> Optional<ClientProblemException> getProblemValueForProblem(Class<T> operation, Problem p,
+                                                                             Function<ProblemResponseMapping<T>,
+                                                                                 ClientProblemException> exceptionSupplier) {
+        List<ProblemResponseMapping<?>> mappingList = operationErrorResponseMappingList.get(operation);
+
+        if (!mappingList.isEmpty()) {
+            Optional<ProblemResponseMapping<?>> mapping = mappingList.stream().filter(m -> m.match(p)).findFirst();
+
+            if (mapping.isPresent()) {
+                ProblemResponseMapping<T> errMapping = (ProblemResponseMapping<T>) mapping.get();
+
+                return Optional.of(exceptionSupplier.apply(errMapping));
+            }
+        }
+        ;
+
+        return Optional.empty();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/common/client/mapper/CaseAPIProblemResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/mapper/CaseAPIProblemResponseMapper.java
@@ -39,8 +39,7 @@ public class CaseAPIProblemResponseMapper extends AbstractAPIProblemResponseMapp
         addOperationMappings(getCaseOp);
     }
 
-    private CasesAPIPostCaseException createPostCaseException(ProblemAndMapping problemAndMapping)
-    {
+    private CasesAPIPostCaseException createPostCaseException(ProblemAndMapping problemAndMapping) {
         return new CasesAPIPostCaseException(
             (ProblemResponseMapping<PostCasesErrorCode>) problemAndMapping.getMapping(), problemAndMapping.getProblem());
     }

--- a/src/main/java/uk/gov/hmcts/darts/common/client/mapper/CaseAPIProblemResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/mapper/CaseAPIProblemResponseMapper.java
@@ -14,8 +14,7 @@ public class CaseAPIProblemResponseMapper extends AbstractAPIProblemResponseMapp
         var opmapping = new ProblemResponseMappingOperation
             .ProblemResponseMappingOperationBuilder<PostCasesErrorCode>()
             .operation(PostCasesErrorCode.class)
-            .exception((mapping) -> new CasesAPIPostCaseException(
-                (ProblemResponseMapping<PostCasesErrorCode>) mapping.getMapping(), mapping.getProblem())).build();
+            .exception(this::createPostCaseException).build();
 
         // create mappings
         opmapping.addMapping(opmapping.createProblemResponseMapping()
@@ -30,8 +29,7 @@ public class CaseAPIProblemResponseMapper extends AbstractAPIProblemResponseMapp
         var getCaseOp = new ProblemResponseMappingOperation
             .ProblemResponseMappingOperationBuilder<GetCasesErrorCode>()
             .operation(GetCasesErrorCode.class)
-            .exception((mapping) -> new CasesAPIGetCasesException(
-                (ProblemResponseMapping<GetCasesErrorCode>) mapping.getMapping(), mapping.getProblem())).build();
+            .exception(this::createAPIGetCasesException).build();
 
 
         getCaseOp.addMapping(getCaseOp.createProblemResponseMapping()
@@ -39,5 +37,16 @@ public class CaseAPIProblemResponseMapper extends AbstractAPIProblemResponseMapp
                                  .message(CodeAndMessage.NOT_FOUND_COURTHOUSE).build());
 
         addOperationMappings(getCaseOp);
+    }
+
+    private CasesAPIPostCaseException createPostCaseException(ProblemAndMapping problemAndMapping)
+    {
+        return new CasesAPIPostCaseException(
+            (ProblemResponseMapping<PostCasesErrorCode>) problemAndMapping.getMapping(), problemAndMapping.getProblem());
+    }
+
+    private CasesAPIGetCasesException createAPIGetCasesException(ProblemAndMapping problemAndMapping) {
+        return new CasesAPIGetCasesException(
+            (ProblemResponseMapping<GetCasesErrorCode>) problemAndMapping.getMapping(), problemAndMapping.getProblem());
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/client/mapper/CaseAPIProblemResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/mapper/CaseAPIProblemResponseMapper.java
@@ -1,8 +1,8 @@
 package uk.gov.hmcts.darts.common.client.mapper;
 
-import uk.gov.hmcts.darts.common.client.exeption.cases.CasesAPIPostCaseException;
-import uk.gov.hmcts.darts.common.client.exeption.cases.CasesAPIGetCasesException;
 import uk.gov.hmcts.darts.common.client.exeption.ClientProblemException;
+import uk.gov.hmcts.darts.common.client.exeption.cases.CasesAPIGetCasesException;
+import uk.gov.hmcts.darts.common.client.exeption.cases.CasesAPIPostCaseException;
 import uk.gov.hmcts.darts.model.audio.Problem;
 import uk.gov.hmcts.darts.model.cases.GetCasesErrorCode;
 import uk.gov.hmcts.darts.model.cases.PostCasesErrorCode;
@@ -13,31 +13,32 @@ import java.util.Optional;
 public class CaseAPIProblemResponseMapper extends AbstractAPIProblemResponseMapper {
 
     {
-        addMapper(PostCasesErrorCode.class, getBuilderAddCase().
-                      problem(PostCasesErrorCode.CASE_DOCUMENT_CANT_BE_PARSED).message(CodeAndMessage.INVALID_XML).build());
+        addMapper(PostCasesErrorCode.class, getBuilderAddCase()
+            .problem(PostCasesErrorCode.CASE_DOCUMENT_CANT_BE_PARSED).message(CodeAndMessage.INVALID_XML).build());
 
-        addMapper(PostCasesErrorCode.class, getBuilderAddCase().
-                      problem(PostCasesErrorCode.CASE_COURT_HOUSE_NOT_FOUND).message(CodeAndMessage.NOT_FOUND_COURTHOUSE).build());
+        addMapper(PostCasesErrorCode.class, getBuilderAddCase()
+            .problem(PostCasesErrorCode.CASE_COURT_HOUSE_NOT_FOUND).message(CodeAndMessage.NOT_FOUND_COURTHOUSE).build());
 
-        addMapper(GetCasesErrorCode.class, getBuilderGetCases().
-                      problem(GetCasesErrorCode.CASE_COURT_HOUSE_NOT_FOUND).message(CodeAndMessage.NOT_FOUND_COURTHOUSE).build());
+        addMapper(GetCasesErrorCode.class, getBuilderGetCases()
+            .problem(GetCasesErrorCode.CASE_COURT_HOUSE_NOT_FOUND).message(CodeAndMessage.NOT_FOUND_COURTHOUSE).build());
     }
 
-    private ProblemResponseMapping.ProblemResponseMappingBuilder<PostCasesErrorCode> getBuilderAddCase()
-    {
+    private ProblemResponseMapping.ProblemResponseMappingBuilder<PostCasesErrorCode> getBuilderAddCase() {
         return new ProblemResponseMapping.ProblemResponseMappingBuilder<>();
     }
 
-    private ProblemResponseMapping.ProblemResponseMappingBuilder<GetCasesErrorCode> getBuilderGetCases()
-    {
+    private ProblemResponseMapping.ProblemResponseMappingBuilder<GetCasesErrorCode> getBuilderGetCases() {
         return new ProblemResponseMapping.ProblemResponseMappingBuilder<>();
     }
 
     @Override
-    public Optional<ClientProblemException> getExceptionForProblem(Problem p) {
+    public Optional<ClientProblemException> getExceptionForProblem(Problem problem) {
 
-        return getProblemValueForProblem(PostCasesErrorCode.class, p,
-                                         (mapping) -> new CasesAPIPostCaseException(mapping, p))
-            .or(() -> getProblemValueForProblem(GetCasesErrorCode.class, p,
-                                         (mapping) -> new CasesAPIGetCasesException(mapping, p)));
-    }}
+        return getProblemValueForProblem(PostCasesErrorCode.class, problem,
+                                         (mapping) -> new CasesAPIPostCaseException(mapping, problem)
+        )
+            .or(() -> getProblemValueForProblem(GetCasesErrorCode.class, problem,
+                                                (mapping) -> new CasesAPIGetCasesException(mapping, problem)
+            ));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/common/client/mapper/CaseAPIProblemResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/mapper/CaseAPIProblemResponseMapper.java
@@ -1,0 +1,43 @@
+package uk.gov.hmcts.darts.common.client.mapper;
+
+import uk.gov.hmcts.darts.common.client.exeption.cases.CasesAPIPostCaseException;
+import uk.gov.hmcts.darts.common.client.exeption.cases.CasesAPIGetCasesException;
+import uk.gov.hmcts.darts.common.client.exeption.ClientProblemException;
+import uk.gov.hmcts.darts.model.audio.Problem;
+import uk.gov.hmcts.darts.model.cases.GetCasesErrorCode;
+import uk.gov.hmcts.darts.model.cases.PostCasesErrorCode;
+import uk.gov.hmcts.darts.ws.CodeAndMessage;
+
+import java.util.Optional;
+
+public class CaseAPIProblemResponseMapper extends AbstractAPIProblemResponseMapper {
+
+    {
+        addMapper(PostCasesErrorCode.class, getBuilderAddCase().
+                      problem(PostCasesErrorCode.CASE_DOCUMENT_CANT_BE_PARSED).message(CodeAndMessage.INVALID_XML).build());
+
+        addMapper(PostCasesErrorCode.class, getBuilderAddCase().
+                      problem(PostCasesErrorCode.CASE_COURT_HOUSE_NOT_FOUND).message(CodeAndMessage.NOT_FOUND_COURTHOUSE).build());
+
+        addMapper(GetCasesErrorCode.class, getBuilderGetCases().
+                      problem(GetCasesErrorCode.CASE_COURT_HOUSE_NOT_FOUND).message(CodeAndMessage.NOT_FOUND_COURTHOUSE).build());
+    }
+
+    private ProblemResponseMapping.ProblemResponseMappingBuilder<PostCasesErrorCode> getBuilderAddCase()
+    {
+        return new ProblemResponseMapping.ProblemResponseMappingBuilder<>();
+    }
+
+    private ProblemResponseMapping.ProblemResponseMappingBuilder<GetCasesErrorCode> getBuilderGetCases()
+    {
+        return new ProblemResponseMapping.ProblemResponseMappingBuilder<>();
+    }
+
+    @Override
+    public Optional<ClientProblemException> getExceptionForProblem(Problem p) {
+
+        return getProblemValueForProblem(PostCasesErrorCode.class, p,
+                                         (mapping) -> new CasesAPIPostCaseException(mapping, p))
+            .or(() -> getProblemValueForProblem(GetCasesErrorCode.class, p,
+                                         (mapping) -> new CasesAPIGetCasesException(mapping, p)));
+    }}

--- a/src/main/java/uk/gov/hmcts/darts/common/client/mapper/CaseAPIProblemResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/mapper/CaseAPIProblemResponseMapper.java
@@ -1,44 +1,43 @@
 package uk.gov.hmcts.darts.common.client.mapper;
 
-import uk.gov.hmcts.darts.common.client.exeption.ClientProblemException;
 import uk.gov.hmcts.darts.common.client.exeption.cases.CasesAPIGetCasesException;
 import uk.gov.hmcts.darts.common.client.exeption.cases.CasesAPIPostCaseException;
-import uk.gov.hmcts.darts.model.audio.Problem;
 import uk.gov.hmcts.darts.model.cases.GetCasesErrorCode;
 import uk.gov.hmcts.darts.model.cases.PostCasesErrorCode;
 import uk.gov.hmcts.darts.ws.CodeAndMessage;
 
-import java.util.Optional;
-
+@SuppressWarnings("unchecked")
 public class CaseAPIProblemResponseMapper extends AbstractAPIProblemResponseMapper {
 
     {
-        addMapper(PostCasesErrorCode.class, getBuilderAddCase()
-            .problem(PostCasesErrorCode.CASE_DOCUMENT_CANT_BE_PARSED).message(CodeAndMessage.INVALID_XML).build());
+        // create the operation and mappings for the post case
+        var opmapping = new ProblemResponseMappingOperation
+            .ProblemResponseMappingOperationBuilder<PostCasesErrorCode>()
+            .operation(PostCasesErrorCode.class)
+            .exception((mapping) -> new CasesAPIPostCaseException(
+                (ProblemResponseMapping<PostCasesErrorCode>) mapping.getMapping(), mapping.getProblem())).build();
 
-        addMapper(PostCasesErrorCode.class, getBuilderAddCase()
-            .problem(PostCasesErrorCode.CASE_COURT_HOUSE_NOT_FOUND).message(CodeAndMessage.NOT_FOUND_COURTHOUSE).build());
+        // create mappings
+        opmapping.addMapping(opmapping.createProblemResponseMapping()
+                                 .problem(PostCasesErrorCode.CASE_DOCUMENT_CANT_BE_PARSED)
+                                 .message(CodeAndMessage.INVALID_XML).build());
 
-        addMapper(GetCasesErrorCode.class, getBuilderGetCases()
-            .problem(GetCasesErrorCode.CASE_COURT_HOUSE_NOT_FOUND).message(CodeAndMessage.NOT_FOUND_COURTHOUSE).build());
-    }
+        opmapping.addMapping(opmapping.createProblemResponseMapping()
+                                 .problem(PostCasesErrorCode.CASE_COURT_HOUSE_NOT_FOUND)
+                                 .message(CodeAndMessage.NOT_FOUND_COURTHOUSE).build());
+        addOperationMappings(opmapping);
 
-    private ProblemResponseMapping.ProblemResponseMappingBuilder<PostCasesErrorCode> getBuilderAddCase() {
-        return new ProblemResponseMapping.ProblemResponseMappingBuilder<>();
-    }
+        var getCaseOp = new ProblemResponseMappingOperation
+            .ProblemResponseMappingOperationBuilder<GetCasesErrorCode>()
+            .operation(GetCasesErrorCode.class)
+            .exception((mapping) -> new CasesAPIGetCasesException(
+                (ProblemResponseMapping<GetCasesErrorCode>) mapping.getMapping(), mapping.getProblem())).build();
 
-    private ProblemResponseMapping.ProblemResponseMappingBuilder<GetCasesErrorCode> getBuilderGetCases() {
-        return new ProblemResponseMapping.ProblemResponseMappingBuilder<>();
-    }
 
-    @Override
-    public Optional<ClientProblemException> getExceptionForProblem(Problem problem) {
+        getCaseOp.addMapping(getCaseOp.createProblemResponseMapping()
+                                 .problem(GetCasesErrorCode.CASE_COURT_HOUSE_NOT_FOUND)
+                                 .message(CodeAndMessage.NOT_FOUND_COURTHOUSE).build());
 
-        return getProblemValueForProblem(PostCasesErrorCode.class, problem,
-                                         (mapping) -> new CasesAPIPostCaseException(mapping, problem)
-        )
-            .or(() -> getProblemValueForProblem(GetCasesErrorCode.class, problem,
-                                                (mapping) -> new CasesAPIGetCasesException(mapping, problem)
-            ));
+        addOperationMappings(getCaseOp);
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/client/mapper/DailyListAPIProblemResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/mapper/DailyListAPIProblemResponseMapper.java
@@ -1,34 +1,30 @@
 package uk.gov.hmcts.darts.common.client.mapper;
 
-import uk.gov.hmcts.darts.common.client.exeption.ClientProblemException;
 import uk.gov.hmcts.darts.common.client.exeption.dailylist.DailyListAPIAddException;
-import uk.gov.hmcts.darts.model.audio.Problem;
 import uk.gov.hmcts.darts.model.dailylist.PostDailyListErrorCode;
 import uk.gov.hmcts.darts.ws.CodeAndMessage;
 
-import java.util.Optional;
-
+@SuppressWarnings("unchecked")
 public class DailyListAPIProblemResponseMapper extends AbstractAPIProblemResponseMapper {
     {
-        addMapper(PostDailyListErrorCode.class, getBuilder().problem(
-                PostDailyListErrorCode.DAILYLIST_DOCUMENT_CANT_BE_PARSED)
-            .message(CodeAndMessage.INVALID_XML).build());
+        var opmapping = new ProblemResponseMappingOperation
+            . ProblemResponseMappingOperationBuilder<PostDailyListErrorCode>()
+            .operation(PostDailyListErrorCode.class)
+            .exception((mapping) -> new DailyListAPIAddException(
+                (ProblemResponseMapping<PostDailyListErrorCode>) mapping.getMapping(), mapping.getProblem())).build();
 
-        addMapper(PostDailyListErrorCode.class, getBuilder()
-            .problem(PostDailyListErrorCode.DAILYLIST_PROCESSOR_NOT_FOUND).message(CodeAndMessage.NOT_FOUND_HANLDER).build());
+        opmapping.addMapping(opmapping.createProblemResponseMapping()
+                       .problem(PostDailyListErrorCode.DAILYLIST_DOCUMENT_CANT_BE_PARSED)
+                       .message(CodeAndMessage.INVALID_XML).build());
 
-        addMapper(PostDailyListErrorCode.class, getBuilder()
-            .problem(PostDailyListErrorCode.DAILYLIST_COURT_HOUSE_NOT_FOUND).message(CodeAndMessage.NOT_FOUND_COURTHOUSE).build());
-    }
+        opmapping.addMapping(opmapping.createProblemResponseMapping()
+                                 .problem(PostDailyListErrorCode.DAILYLIST_PROCESSOR_NOT_FOUND)
+                                 .message(CodeAndMessage.NOT_FOUND_HANLDER).build());
 
-    private ProblemResponseMapping.ProblemResponseMappingBuilder<PostDailyListErrorCode> getBuilder() {
-        return new ProblemResponseMapping.ProblemResponseMappingBuilder<>();
-    }
+        opmapping.addMapping(opmapping.createProblemResponseMapping()
+                                 .problem(PostDailyListErrorCode.DAILYLIST_COURT_HOUSE_NOT_FOUND)
+                                 .message(CodeAndMessage.NOT_FOUND_COURTHOUSE).build());
 
-    @Override
-    public Optional<ClientProblemException> getExceptionForProblem(Problem problem) {
-        return getProblemValueForProblem(PostDailyListErrorCode.class, problem,
-                                         (mapping) -> new DailyListAPIAddException(mapping, problem)
-        );
+        addOperationMappings(opmapping);
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/client/mapper/DailyListAPIProblemResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/mapper/DailyListAPIProblemResponseMapper.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.darts.common.client.mapper;
 
+import uk.gov.hmcts.darts.common.client.exeption.cases.CasesAPIGetCasesException;
 import uk.gov.hmcts.darts.common.client.exeption.dailylist.DailyListAPIAddException;
+import uk.gov.hmcts.darts.model.cases.GetCasesErrorCode;
 import uk.gov.hmcts.darts.model.dailylist.PostDailyListErrorCode;
 import uk.gov.hmcts.darts.ws.CodeAndMessage;
 
@@ -10,8 +12,7 @@ public class DailyListAPIProblemResponseMapper extends AbstractAPIProblemRespons
         var opmapping = new ProblemResponseMappingOperation
             . ProblemResponseMappingOperationBuilder<PostDailyListErrorCode>()
             .operation(PostDailyListErrorCode.class)
-            .exception((mapping) -> new DailyListAPIAddException(
-                (ProblemResponseMapping<PostDailyListErrorCode>) mapping.getMapping(), mapping.getProblem())).build();
+            .exception(this::createPostDailyListException).build();
 
         opmapping.addMapping(opmapping.createProblemResponseMapping()
                        .problem(PostDailyListErrorCode.DAILYLIST_DOCUMENT_CANT_BE_PARSED)
@@ -26,5 +27,10 @@ public class DailyListAPIProblemResponseMapper extends AbstractAPIProblemRespons
                                  .message(CodeAndMessage.NOT_FOUND_COURTHOUSE).build());
 
         addOperationMappings(opmapping);
+    }
+
+    private DailyListAPIAddException createPostDailyListException(ProblemAndMapping problemAndMapping) {
+        return new DailyListAPIAddException(
+            (ProblemResponseMapping<PostDailyListErrorCode>) problemAndMapping.getMapping(), problemAndMapping.getProblem());
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/client/mapper/DailyListAPIProblemResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/mapper/DailyListAPIProblemResponseMapper.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.darts.common.client.mapper;
+
+import uk.gov.hmcts.darts.common.client.exeption.ClientProblemException;
+import uk.gov.hmcts.darts.common.client.exeption.dailylist.DailyListAPIAddException;
+import uk.gov.hmcts.darts.model.audio.Problem;
+import uk.gov.hmcts.darts.model.dailylist.PostDailyListErrorCode;
+import uk.gov.hmcts.darts.ws.CodeAndMessage;
+
+import java.util.Optional;
+
+public class DailyListAPIProblemResponseMapper extends AbstractAPIProblemResponseMapper {
+    {
+        addMapper(PostDailyListErrorCode.class, getBuilder().problem(
+                PostDailyListErrorCode.DAILYLIST_DOCUMENT_CANT_BE_PARSED)
+            .message(CodeAndMessage.INVALID_XML).build());
+
+        addMapper(PostDailyListErrorCode.class, getBuilder().
+            problem(PostDailyListErrorCode.DAILYLIST_PROCESSOR_NOT_FOUND).message(CodeAndMessage.NOT_FOUND_HANLDER).build());
+
+        addMapper(PostDailyListErrorCode.class, getBuilder().
+            problem(PostDailyListErrorCode.DAILYLIST_COURT_HOUSE_NOT_FOUND).message(CodeAndMessage.NOT_FOUND_COURTHOUSE).build());
+    }
+
+    private ProblemResponseMapping.ProblemResponseMappingBuilder<PostDailyListErrorCode> getBuilder() {
+        return new ProblemResponseMapping.ProblemResponseMappingBuilder<>();
+    }
+
+    @Override
+    public Optional<ClientProblemException> getExceptionForProblem(Problem p) {
+        return getProblemValueForProblem(PostDailyListErrorCode.class, p,
+                                         (mapping) -> new DailyListAPIAddException(mapping, p)
+        );
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/common/client/mapper/DailyListAPIProblemResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/mapper/DailyListAPIProblemResponseMapper.java
@@ -14,11 +14,11 @@ public class DailyListAPIProblemResponseMapper extends AbstractAPIProblemRespons
                 PostDailyListErrorCode.DAILYLIST_DOCUMENT_CANT_BE_PARSED)
             .message(CodeAndMessage.INVALID_XML).build());
 
-        addMapper(PostDailyListErrorCode.class, getBuilder().
-            problem(PostDailyListErrorCode.DAILYLIST_PROCESSOR_NOT_FOUND).message(CodeAndMessage.NOT_FOUND_HANLDER).build());
+        addMapper(PostDailyListErrorCode.class, getBuilder()
+            .problem(PostDailyListErrorCode.DAILYLIST_PROCESSOR_NOT_FOUND).message(CodeAndMessage.NOT_FOUND_HANLDER).build());
 
-        addMapper(PostDailyListErrorCode.class, getBuilder().
-            problem(PostDailyListErrorCode.DAILYLIST_COURT_HOUSE_NOT_FOUND).message(CodeAndMessage.NOT_FOUND_COURTHOUSE).build());
+        addMapper(PostDailyListErrorCode.class, getBuilder()
+            .problem(PostDailyListErrorCode.DAILYLIST_COURT_HOUSE_NOT_FOUND).message(CodeAndMessage.NOT_FOUND_COURTHOUSE).build());
     }
 
     private ProblemResponseMapping.ProblemResponseMappingBuilder<PostDailyListErrorCode> getBuilder() {
@@ -26,9 +26,9 @@ public class DailyListAPIProblemResponseMapper extends AbstractAPIProblemRespons
     }
 
     @Override
-    public Optional<ClientProblemException> getExceptionForProblem(Problem p) {
-        return getProblemValueForProblem(PostDailyListErrorCode.class, p,
-                                         (mapping) -> new DailyListAPIAddException(mapping, p)
+    public Optional<ClientProblemException> getExceptionForProblem(Problem problem) {
+        return getProblemValueForProblem(PostDailyListErrorCode.class, problem,
+                                         (mapping) -> new DailyListAPIAddException(mapping, problem)
         );
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/client/mapper/DailyListAPIProblemResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/mapper/DailyListAPIProblemResponseMapper.java
@@ -1,8 +1,6 @@
 package uk.gov.hmcts.darts.common.client.mapper;
 
-import uk.gov.hmcts.darts.common.client.exeption.cases.CasesAPIGetCasesException;
 import uk.gov.hmcts.darts.common.client.exeption.dailylist.DailyListAPIAddException;
-import uk.gov.hmcts.darts.model.cases.GetCasesErrorCode;
 import uk.gov.hmcts.darts.model.dailylist.PostDailyListErrorCode;
 import uk.gov.hmcts.darts.ws.CodeAndMessage;
 

--- a/src/main/java/uk/gov/hmcts/darts/common/client/mapper/EventAPIProblemResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/mapper/EventAPIProblemResponseMapper.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.darts.common.client.mapper;
 
-import uk.gov.hmcts.darts.common.client.exeption.*;
+import uk.gov.hmcts.darts.common.client.exeption.ClientProblemException;
 import uk.gov.hmcts.darts.common.client.exeption.event.EventAPIGetCourtLogExeption;
 import uk.gov.hmcts.darts.common.client.exeption.event.EventAPIPostCourtLogException;
 import uk.gov.hmcts.darts.common.client.exeption.event.EventAPIPostEventException;
@@ -17,49 +17,55 @@ public class EventAPIProblemResponseMapper extends AbstractAPIProblemResponseMap
 
     {
         addMapper(EventErrorCode.class, getSendErrorCodeBuilder().problem(EventErrorCode.EVENT_DOCUMENT_CANT_PARSED)
-                      .message(CodeAndMessage.INVALID_XML).build());
+            .message(CodeAndMessage.INVALID_XML).build());
 
-        addMapper(EventErrorCode.class, getSendErrorCodeBuilder().
-                      problem(EventErrorCode.PROCESSOR_NOT_FOUND).message(CodeAndMessage.NOT_FOUND_HANLDER).build());
+        addMapper(EventErrorCode.class, getSendErrorCodeBuilder()
+            .problem(EventErrorCode.PROCESSOR_NOT_FOUND).message(CodeAndMessage.NOT_FOUND_HANLDER).build());
 
-        addMapper(EventErrorCode.class, getSendErrorCodeBuilder().
-                      problem(EventErrorCode.EVENT_COURT_HOUSE_NOT_FOUND).message(CodeAndMessage.NOT_FOUND_COURTHOUSE).build());
+        addMapper(EventErrorCode.class, getSendErrorCodeBuilder()
+            .problem(EventErrorCode.EVENT_COURT_HOUSE_NOT_FOUND).message(CodeAndMessage.NOT_FOUND_COURTHOUSE).build());
 
-        addMapper(GetCourtLogsErrorCode.class, getCourtLogsBuilder().
-                      problem(GetCourtLogsErrorCode.COURTLOG_COURT_HOUSE_NOT_FOUND).message(CodeAndMessage.NOT_FOUND_COURTHOUSE).build());
+        addMapper(GetCourtLogsErrorCode.class, getCourtLogsBuilder()
+            .problem(GetCourtLogsErrorCode.COURTLOG_COURT_HOUSE_NOT_FOUND).message(CodeAndMessage.NOT_FOUND_COURTHOUSE).build());
 
-        addMapper(PostCourtLogsErrorCode.class, getPostCourtLogsBuilder().
-                      problem(PostCourtLogsErrorCode.COURTLOG_COURT_HOUSE_NOT_FOUND).message(CodeAndMessage.NOT_FOUND_COURTHOUSE).build());
+        addMapper(PostCourtLogsErrorCode.class, getPostCourtLogsBuilder()
+            .problem(PostCourtLogsErrorCode.COURTLOG_COURT_HOUSE_NOT_FOUND).message(CodeAndMessage.NOT_FOUND_COURTHOUSE).build());
 
-        addMapper(PostCourtLogsErrorCode.class, getPostCourtLogsBuilder().
-                      problem(PostCourtLogsErrorCode.COURTLOG_DOCUMENT_CANT_BE_PARSED).message(CodeAndMessage.INVALID_XML).build());
+        addMapper(PostCourtLogsErrorCode.class, getPostCourtLogsBuilder()
+            .problem(PostCourtLogsErrorCode.COURTLOG_DOCUMENT_CANT_BE_PARSED).message(CodeAndMessage.INVALID_XML).build());
     }
 
-    private ProblemResponseMapping.ProblemResponseMappingBuilder<EventErrorCode> getSendErrorCodeBuilder()
-    {
+    private ProblemResponseMapping.ProblemResponseMappingBuilder<EventErrorCode> getSendErrorCodeBuilder() {
         return new ProblemResponseMapping.ProblemResponseMappingBuilder<>();
     }
 
-    private ProblemResponseMapping.ProblemResponseMappingBuilder<GetCourtLogsErrorCode> getCourtLogsBuilder()
-    {
+    private ProblemResponseMapping.ProblemResponseMappingBuilder<GetCourtLogsErrorCode> getCourtLogsBuilder() {
         return new ProblemResponseMapping.ProblemResponseMappingBuilder<>();
     }
 
-    private ProblemResponseMapping.ProblemResponseMappingBuilder<PostCourtLogsErrorCode> getPostCourtLogsBuilder()
-    {
+    private ProblemResponseMapping.ProblemResponseMappingBuilder<PostCourtLogsErrorCode> getPostCourtLogsBuilder() {
         return new ProblemResponseMapping.ProblemResponseMappingBuilder<>();
     }
 
     @Override
-    public Optional<ClientProblemException> getExceptionForProblem(Problem p) {
+    public Optional<ClientProblemException> getExceptionForProblem(Problem problem) {
         Optional<ClientProblemException> exception;
 
         exception = getProblemValueForProblem(
             EventErrorCode.class,
-            p,
-            (mapping) -> new EventAPIPostEventException(mapping, p))
-            .or(()-> getProblemValueForProblem(GetCourtLogsErrorCode.class, p, (mapping) -> new EventAPIGetCourtLogExeption(mapping, p)))
-            .or(()-> getProblemValueForProblem(PostCourtLogsErrorCode.class, p, (mapping) -> new EventAPIPostCourtLogException(mapping, p)));
+            problem,
+            (mapping) -> new EventAPIPostEventException(mapping, problem)
+        )
+            .or(() -> getProblemValueForProblem(
+                GetCourtLogsErrorCode.class,
+                problem,
+                (mapping) -> new EventAPIGetCourtLogExeption(mapping, problem)
+            ))
+            .or(() -> getProblemValueForProblem(
+                PostCourtLogsErrorCode.class,
+                problem,
+                (mapping) -> new EventAPIPostCourtLogException(mapping, problem)
+            ));
 
         return exception;
     }

--- a/src/main/java/uk/gov/hmcts/darts/common/client/mapper/EventAPIProblemResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/mapper/EventAPIProblemResponseMapper.java
@@ -16,8 +16,7 @@ public class EventAPIProblemResponseMapper extends AbstractAPIProblemResponseMap
         var postEventOp = new ProblemResponseMappingOperation
                 .ProblemResponseMappingOperationBuilder<EventErrorCode>()
             .operation(EventErrorCode.class)
-            .exception((mapping) -> new EventAPIPostEventException(
-                (ProblemResponseMapping<EventErrorCode>) mapping.getMapping(), mapping.getProblem())).build();
+            .exception(this::createPostEventException).build();
 
         // create mappings
         postEventOp.addMapping(postEventOp.createProblemResponseMapping()
@@ -38,8 +37,7 @@ public class EventAPIProblemResponseMapper extends AbstractAPIProblemResponseMap
         var getCourtLog = new ProblemResponseMappingOperation
                 .ProblemResponseMappingOperationBuilder<GetCourtLogsErrorCode>()
             .operation(GetCourtLogsErrorCode.class)
-            .exception((mapping) -> new EventAPIGetCourtLogExeption(
-                (ProblemResponseMapping<GetCourtLogsErrorCode>) mapping.getMapping(), mapping.getProblem())).build();
+            .exception(this::createGetCourtLogs).build();
 
         getCourtLog.addMapping(getCourtLog.createProblemResponseMapping()
                                    .problem(GetCourtLogsErrorCode.COURTLOG_COURT_HOUSE_NOT_FOUND)
@@ -51,8 +49,7 @@ public class EventAPIProblemResponseMapper extends AbstractAPIProblemResponseMap
         var postCourtLog = new ProblemResponseMappingOperation
                 .ProblemResponseMappingOperationBuilder<PostCourtLogsErrorCode>()
             .operation(PostCourtLogsErrorCode.class)
-            .exception((mapping) -> new EventAPIPostCourtLogException(
-                (ProblemResponseMapping<PostCourtLogsErrorCode>) mapping.getMapping(), mapping.getProblem())).build();
+            .exception(this::createPostCourtLogs).build();
 
         postCourtLog.addMapping(postCourtLog.createProblemResponseMapping()
                                     .problem(PostCourtLogsErrorCode.COURTLOG_COURT_HOUSE_NOT_FOUND)
@@ -63,5 +60,20 @@ public class EventAPIProblemResponseMapper extends AbstractAPIProblemResponseMap
                                     .message(CodeAndMessage.INVALID_XML).build());
 
         addOperationMappings(postCourtLog);
+    }
+
+    private EventAPIPostEventException createPostEventException(ProblemAndMapping problemAndMapping) {
+        return new EventAPIPostEventException(
+            (ProblemResponseMapping<EventErrorCode>) problemAndMapping.getMapping(), problemAndMapping.getProblem());
+    }
+
+    private EventAPIGetCourtLogExeption createGetCourtLogs(ProblemAndMapping problemAndMapping) {
+        return new EventAPIGetCourtLogExeption(
+            (ProblemResponseMapping<GetCourtLogsErrorCode>) problemAndMapping.getMapping(), problemAndMapping.getProblem());
+    }
+
+    private EventAPIPostCourtLogException createPostCourtLogs(ProblemAndMapping problemAndMapping) {
+        return new EventAPIPostCourtLogException(
+            (ProblemResponseMapping<PostCourtLogsErrorCode>) problemAndMapping.getMapping(), problemAndMapping.getProblem());
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/client/mapper/EventAPIProblemResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/mapper/EventAPIProblemResponseMapper.java
@@ -1,0 +1,66 @@
+package uk.gov.hmcts.darts.common.client.mapper;
+
+import uk.gov.hmcts.darts.common.client.exeption.*;
+import uk.gov.hmcts.darts.common.client.exeption.event.EventAPIGetCourtLogExeption;
+import uk.gov.hmcts.darts.common.client.exeption.event.EventAPIPostCourtLogException;
+import uk.gov.hmcts.darts.common.client.exeption.event.EventAPIPostEventException;
+import uk.gov.hmcts.darts.model.audio.Problem;
+import uk.gov.hmcts.darts.model.event.EventErrorCode;
+import uk.gov.hmcts.darts.model.event.GetCourtLogsErrorCode;
+import uk.gov.hmcts.darts.model.event.PostCourtLogsErrorCode;
+import uk.gov.hmcts.darts.ws.CodeAndMessage;
+
+import java.util.Optional;
+
+
+public class EventAPIProblemResponseMapper extends AbstractAPIProblemResponseMapper {
+
+    {
+        addMapper(EventErrorCode.class, getSendErrorCodeBuilder().problem(EventErrorCode.EVENT_DOCUMENT_CANT_PARSED)
+                      .message(CodeAndMessage.INVALID_XML).build());
+
+        addMapper(EventErrorCode.class, getSendErrorCodeBuilder().
+                      problem(EventErrorCode.PROCESSOR_NOT_FOUND).message(CodeAndMessage.NOT_FOUND_HANLDER).build());
+
+        addMapper(EventErrorCode.class, getSendErrorCodeBuilder().
+                      problem(EventErrorCode.EVENT_COURT_HOUSE_NOT_FOUND).message(CodeAndMessage.NOT_FOUND_COURTHOUSE).build());
+
+        addMapper(GetCourtLogsErrorCode.class, getCourtLogsBuilder().
+                      problem(GetCourtLogsErrorCode.COURTLOG_COURT_HOUSE_NOT_FOUND).message(CodeAndMessage.NOT_FOUND_COURTHOUSE).build());
+
+        addMapper(PostCourtLogsErrorCode.class, getPostCourtLogsBuilder().
+                      problem(PostCourtLogsErrorCode.COURTLOG_COURT_HOUSE_NOT_FOUND).message(CodeAndMessage.NOT_FOUND_COURTHOUSE).build());
+
+        addMapper(PostCourtLogsErrorCode.class, getPostCourtLogsBuilder().
+                      problem(PostCourtLogsErrorCode.COURTLOG_DOCUMENT_CANT_BE_PARSED).message(CodeAndMessage.INVALID_XML).build());
+    }
+
+    private ProblemResponseMapping.ProblemResponseMappingBuilder<EventErrorCode> getSendErrorCodeBuilder()
+    {
+        return new ProblemResponseMapping.ProblemResponseMappingBuilder<>();
+    }
+
+    private ProblemResponseMapping.ProblemResponseMappingBuilder<GetCourtLogsErrorCode> getCourtLogsBuilder()
+    {
+        return new ProblemResponseMapping.ProblemResponseMappingBuilder<>();
+    }
+
+    private ProblemResponseMapping.ProblemResponseMappingBuilder<PostCourtLogsErrorCode> getPostCourtLogsBuilder()
+    {
+        return new ProblemResponseMapping.ProblemResponseMappingBuilder<>();
+    }
+
+    @Override
+    public Optional<ClientProblemException> getExceptionForProblem(Problem p) {
+        Optional<ClientProblemException> exception;
+
+        exception = getProblemValueForProblem(
+            EventErrorCode.class,
+            p,
+            (mapping) -> new EventAPIPostEventException(mapping, p))
+            .or(()-> getProblemValueForProblem(GetCourtLogsErrorCode.class, p, (mapping) -> new EventAPIGetCourtLogExeption(mapping, p)))
+            .or(()-> getProblemValueForProblem(PostCourtLogsErrorCode.class, p, (mapping) -> new EventAPIPostCourtLogException(mapping, p)));
+
+        return exception;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/common/client/mapper/ProblemAndMapping.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/mapper/ProblemAndMapping.java
@@ -1,0 +1,13 @@
+package uk.gov.hmcts.darts.common.client.mapper;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import uk.gov.hmcts.darts.model.audio.Problem;
+
+@Getter
+@RequiredArgsConstructor
+public class ProblemAndMapping {
+    private final Problem problem;
+
+    private final ProblemResponseMapping<?> mapping;
+}

--- a/src/main/java/uk/gov/hmcts/darts/common/client/mapper/ProblemResponseMapping.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/mapper/ProblemResponseMapping.java
@@ -10,11 +10,10 @@ import uk.gov.hmcts.darts.ws.CodeAndMessage;
 @Builder
 @Getter
 public class ProblemResponseMapping<T> {
-     T problem;
-     CodeAndMessage message;
+    T problem;
+    CodeAndMessage message;
 
-    public boolean match(Problem problemToMatch)
-    {
+    public boolean match(Problem problemToMatch) {
         return problemToMatch.getType().toString().equals(problem.toString());
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/client/mapper/ProblemResponseMapping.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/mapper/ProblemResponseMapping.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.darts.common.client.mapper;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Value;
+import uk.gov.hmcts.darts.model.audio.Problem;
+import uk.gov.hmcts.darts.ws.CodeAndMessage;
+
+@Value
+@Builder
+@Getter
+public class ProblemResponseMapping<T> {
+     T problem;
+     CodeAndMessage message;
+
+    public boolean match(Problem problemToMatch)
+    {
+        return problemToMatch.getType().toString().equals(problem.toString());
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/common/client/mapper/ProblemResponseMappingOperation.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/mapper/ProblemResponseMappingOperation.java
@@ -1,0 +1,31 @@
+package uk.gov.hmcts.darts.common.client.mapper;
+
+import lombok.Builder;
+import lombok.Getter;
+import uk.gov.hmcts.darts.common.client.exeption.ClientProblemException;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+@Builder
+@Getter
+public class ProblemResponseMappingOperation<T> {
+    @Builder.Default
+    private List<ProblemResponseMapping<T>> problemResponseMappingList = Collections.synchronizedList(
+        new ArrayList<>());
+
+    private Class<T> operation;
+    private Function<ProblemAndMapping, ClientProblemException> exception;
+    private ProblemResponseMapping.ProblemResponseMappingBuilder<T> builder;
+
+    public ProblemResponseMappingOperation<T> addMapping(ProblemResponseMapping<T> mapping) {
+        problemResponseMappingList.add(mapping);
+        return this;
+    }
+
+    public ProblemResponseMapping.ProblemResponseMappingBuilder<T>  createProblemResponseMapping() {
+        return new ProblemResponseMapping.ProblemResponseMappingBuilder<T>();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/common/client/mapper/ProblemResponseMappingOperation.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/mapper/ProblemResponseMappingOperation.java
@@ -26,6 +26,6 @@ public class ProblemResponseMappingOperation<T> {
     }
 
     public ProblemResponseMapping.ProblemResponseMappingBuilder<T>  createProblemResponseMapping() {
-        return new ProblemResponseMapping.ProblemResponseMappingBuilder<T>();
+        return new ProblemResponseMapping.ProblemResponseMappingBuilder<>();
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/config/EmptyObjectProvider.java
+++ b/src/main/java/uk/gov/hmcts/darts/config/EmptyObjectProvider.java
@@ -1,0 +1,33 @@
+package uk.gov.hmcts.darts.config;
+
+import org.springframework.beans.factory.ObjectProvider;
+
+import java.util.function.Consumer;
+
+class EmptyObjectProvider<T> implements ObjectProvider<T> {
+
+    @Override
+    public T getObject(Object... args)  {
+        return null;
+    }
+
+    @Override
+    public T getObject() {
+        return null;
+    }
+
+    @Override
+    public void forEach(Consumer action) {
+        // do nothing
+    }
+
+    @Override
+    public T getIfAvailable() {
+        return null;
+    }
+
+    @Override
+    public T getIfUnique() {
+        return null;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/config/OAuthTokenGenerator.java
+++ b/src/main/java/uk/gov/hmcts/darts/config/OAuthTokenGenerator.java
@@ -1,0 +1,47 @@
+package uk.gov.hmcts.darts.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class OAuthTokenGenerator {
+    @Value("${azure-ad-ropc.token-uri}")
+    private String tokenUri;
+    @Value("${azure-ad-ropc.scope}")
+    private String scope;
+    @Value("${azure-ad-ropc.username}")
+    private String username;
+    @Value("${azure-ad-ropc.password}")
+    private String password;
+    @Value("${azure-ad-ropc.client-id}")
+    private String clientId;
+
+    private final RestTemplate template;
+
+    public Map<?, ?> acquireNewToken() {
+        return template.exchange(tokenUri, HttpMethod.POST, buildTokenRequestEntity(), Map.class).getBody();
+    }
+
+    private HttpEntity<MultiValueMap<String, String>> buildTokenRequestEntity() {
+        MultiValueMap<String, String> formValues = new LinkedMultiValueMap<>();
+        formValues.add("grant_type", "password");
+        formValues.add("client_id", clientId);
+        formValues.add("scope", scope);
+        formValues.add("username", username);
+        formValues.add("password", password);
+
+        var headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        return new HttpEntity<>(formValues, headers);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/config/ServiceConfig.java
+++ b/src/main/java/uk/gov/hmcts/darts/config/ServiceConfig.java
@@ -8,6 +8,7 @@ import feign.Logger;
 import feign.RequestInterceptor;
 import feign.codec.Decoder;
 import feign.codec.Encoder;
+import feign.codec.ErrorDecoder;
 import feign.okhttp.OkHttpClient;
 import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.beans.factory.ObjectProvider;
@@ -29,16 +30,22 @@ import org.springframework.http.converter.json.MappingJackson2HttpMessageConvert
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
+import uk.gov.hmcts.darts.common.client.exeption.JacksonClientProblemDecoder;
+import uk.gov.hmcts.darts.common.client.mapper.CaseAPIProblemResponseMapper;
+import uk.gov.hmcts.darts.common.client.mapper.DailyListAPIProblemResponseMapper;
+import uk.gov.hmcts.darts.common.client.mapper.EventAPIProblemResponseMapper;
 import uk.gov.hmcts.darts.utilities.deserializer.LocalDateTimeTypeDeserializer;
 import uk.gov.hmcts.darts.utilities.deserializer.LocalDateTypeDeserializer;
 import uk.gov.hmcts.darts.utilities.deserializer.OffsetDateTimeTypeDeserializer;
 import uk.gov.hmcts.darts.utilities.serializer.LocalDateTimeTypeSerializer;
 import uk.gov.hmcts.darts.utilities.serializer.LocalDateTypeSerializer;
 import uk.gov.hmcts.darts.utilities.serializer.OffsetDateTimeTypeSerializer;
-
+import uk.gov.hmcts.darts.common.client.mapper.APIProblemResponseMapper;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -101,6 +108,18 @@ public class ServiceConfig {
         HttpMessageConverters httpMessageConverters = new HttpMessageConverters(jacksonConverter);
         ObjectFactory<HttpMessageConverters> objectFactory = () -> httpMessageConverters;
         return new ResponseEntityDecoder(new SpringDecoder(objectFactory, new EmptyObjectProvider<>()));
+    }
+
+    @Bean
+    public ErrorDecoder feignErrorDecoder (List<APIProblemResponseMapper> mappers) {
+        return new JacksonClientProblemDecoder(mappers);
+    }
+
+    @Bean
+    public List<APIProblemResponseMapper> getResponseMappers() {
+        return Arrays.asList(new APIProblemResponseMapper[] { new CaseAPIProblemResponseMapper(),
+        new DailyListAPIProblemResponseMapper(),
+        new EventAPIProblemResponseMapper()});
     }
 
     @Bean

--- a/src/main/java/uk/gov/hmcts/darts/config/ServiceConfig.java
+++ b/src/main/java/uk/gov/hmcts/darts/config/ServiceConfig.java
@@ -10,9 +10,9 @@ import feign.codec.Decoder;
 import feign.codec.Encoder;
 import feign.codec.ErrorDecoder;
 import feign.okhttp.OkHttpClient;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.http.HttpMessageConverters;
 import org.springframework.cloud.openfeign.support.ResponseEntityDecoder;
@@ -21,16 +21,11 @@ import org.springframework.cloud.openfeign.support.SpringEncoder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.hmcts.darts.common.client.exeption.JacksonClientProblemDecoder;
+import uk.gov.hmcts.darts.common.client.mapper.APIProblemResponseMapper;
 import uk.gov.hmcts.darts.common.client.mapper.CaseAPIProblemResponseMapper;
 import uk.gov.hmcts.darts.common.client.mapper.DailyListAPIProblemResponseMapper;
 import uk.gov.hmcts.darts.common.client.mapper.EventAPIProblemResponseMapper;
@@ -40,34 +35,22 @@ import uk.gov.hmcts.darts.utilities.deserializer.OffsetDateTimeTypeDeserializer;
 import uk.gov.hmcts.darts.utilities.serializer.LocalDateTimeTypeSerializer;
 import uk.gov.hmcts.darts.utilities.serializer.LocalDateTypeSerializer;
 import uk.gov.hmcts.darts.utilities.serializer.OffsetDateTimeTypeSerializer;
-import uk.gov.hmcts.darts.common.client.mapper.APIProblemResponseMapper;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 /**
  * DO NOT ANNOTATE THIS CLASS WITH @Configuration. This class works alongside the
- * {@link org.springframework.cloud.openfeign.FeignClient} annotation. In this way configurations can be specific API
- * feign interaction and not applied globally
+ * {@link org.springframework.cloud.openfeign.FeignClient} annotation. In this way configurations can be specific to a set of
+ * * feign interactions and not applied globally which may cause unintended sideeffects
  */
+@RequiredArgsConstructor
 @SuppressWarnings("PMD.ExcessiveImports")
 public class ServiceConfig {
-
-    @Value("${azure-ad-ropc.token-uri}")
-    private String tokenUri;
-    @Value("${azure-ad-ropc.scope}")
-    private String scope;
-    @Value("${azure-ad-ropc.username}")
-    private String username;
-    @Value("${azure-ad-ropc.password}")
-    private String password;
-    @Value("${azure-ad-ropc.client-id}")
-    private String clientId;
 
     @Bean
     public Logger.Level feignLoggerLevel() {
@@ -111,15 +94,16 @@ public class ServiceConfig {
     }
 
     @Bean
-    public ErrorDecoder feignErrorDecoder (List<APIProblemResponseMapper> mappers) {
+    public ErrorDecoder feignErrorDecoder(List<APIProblemResponseMapper> mappers) {
         return new JacksonClientProblemDecoder(mappers);
     }
 
     @Bean
     public List<APIProblemResponseMapper> getResponseMappers() {
-        return Arrays.asList(new APIProblemResponseMapper[] { new CaseAPIProblemResponseMapper(),
-        new DailyListAPIProblemResponseMapper(),
-        new EventAPIProblemResponseMapper()});
+        return Arrays.asList(new APIProblemResponseMapper[] {
+            new CaseAPIProblemResponseMapper(),
+            new DailyListAPIProblemResponseMapper(),
+            new EventAPIProblemResponseMapper()});
     }
 
     @Bean
@@ -133,70 +117,24 @@ public class ServiceConfig {
     }
 
     @Bean
+    public OAuthTokenGenerator getTokenGenerator() {
+        return new OAuthTokenGenerator(new RestTemplate());
+    }
+
+    @Bean
     @ConditionalOnMissingBean
     public HttpMessageConverters messageConverters(ObjectProvider<HttpMessageConverter<?>> converters) {
         return new HttpMessageConverters(converters.orderedStream().collect(Collectors.toList()));
     }
 
     // Temporary fix for service to service authentication.
-    @Bean
-    public RestTemplate restTemplate() {
-        return new RestTemplate();
-    }
-
-
-    // Temporary fix for service to service authentication.
+    //TODO: Needs to change when we the gateway is passed the token
     @Bean
     @Profile("!int-test")
-    public RequestInterceptor requestInterceptor(RestTemplate restTemplate) {
+    public RequestInterceptor requestInterceptor(OAuthTokenGenerator tokenGenerator) {
         return
             template -> {
-                var entity = buildTokenRequestEntity();
-                var tokenResponse = restTemplate.exchange(tokenUri, HttpMethod.POST, entity, Map.class).getBody();
-                template.header("Authorization", "Bearer " + tokenResponse.get("access_token"));
+                template.header("Authorization", "Bearer " + tokenGenerator.acquireNewToken().get("access_token"));
             };
-    }
-
-    // Temporary fix for service to service authentication.
-    private HttpEntity<MultiValueMap<String, String>> buildTokenRequestEntity() {
-        MultiValueMap<String, String> formValues = new LinkedMultiValueMap<>();
-        formValues.add("grant_type", "password");
-        formValues.add("client_id", clientId);
-        formValues.add("scope", scope);
-        formValues.add("username", username);
-        formValues.add("password", password);
-
-        var headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-
-        return new HttpEntity<>(formValues, headers);
-    }
-
-    class EmptyObjectProvider<T> implements ObjectProvider<T> {
-
-        @Override
-        public T getObject(Object... args)  {
-            return null;
-        }
-
-        @Override
-        public T getObject() {
-            return null;
-        }
-
-        @Override
-        public void forEach(Consumer action) {
-            // do nothing
-        }
-
-        @Override
-        public T getIfAvailable() {
-            return null;
-        }
-
-        @Override
-        public T getIfUnique() {
-            return null;
-        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/courtlogs/AddCourtLogsRoute.java
+++ b/src/main/java/uk/gov/hmcts/darts/courtlogs/AddCourtLogsRoute.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.darts.courtlogs;
 
-import com.service.mojdarts.synapps.com.AddLogEntryResponse;
+import com.synapps.moj.dfs.response.DARTSResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -22,7 +22,7 @@ public class AddCourtLogsRoute {
     private final AddCourtLogsMapper mapper;
     private final CourtLogsClient courtLogsClient;
 
-    public AddLogEntryResponse route(String document) {
+    public DARTSResponse route(String document) {
 
         ResponseEntity<EventsResponse> response;
 

--- a/src/main/java/uk/gov/hmcts/darts/courtlogs/GetCourtLogRoute.java
+++ b/src/main/java/uk/gov/hmcts/darts/courtlogs/GetCourtLogRoute.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.darts.courtlogs;
 
 import com.service.mojdarts.synapps.com.GetCourtLog;
-import com.service.mojdarts.synapps.com.GetCourtLogResponse;
+import com.synapps.moj.dfs.response.GetCourtLogResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.common.client.CourtLogsClient;

--- a/src/main/java/uk/gov/hmcts/darts/courtlogs/GetCourtLogsMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/courtlogs/GetCourtLogsMapper.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.darts.courtlogs;
 
-import com.service.mojdarts.synapps.com.GetCourtLogResponse;
+import com.synapps.moj.dfs.response.GetCourtLogResponse;
 import com.synapps.moj.dfs.response.CourtLogEntry;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -31,10 +31,7 @@ public class GetCourtLogsMapper {
         innerResponse.setCode(String.valueOf(HttpStatus.OK.value()));
         innerResponse.setMessage(HttpStatus.OK.name());
 
-        var outerResponse = new GetCourtLogResponse();
-        outerResponse.setReturn(innerResponse);
-
-        return outerResponse;
+        return innerResponse;
     }
 
     private CourtLogEntry toLegacyApi(CourtLog courtLog) {
@@ -57,9 +54,8 @@ public class GetCourtLogsMapper {
     private GetCourtLogResponse emptyResponse() {
         var innerResponse = createInnerResponse();
         var outerResponse = new GetCourtLogResponse();
-        outerResponse.setReturn(innerResponse);
 
-        return outerResponse;
+        return innerResponse;
     }
 
     private com.synapps.moj.dfs.response.CourtLog createLegacyCourtLog() {

--- a/src/main/java/uk/gov/hmcts/darts/courtlogs/GetCourtLogsMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/courtlogs/GetCourtLogsMapper.java
@@ -1,7 +1,8 @@
 package uk.gov.hmcts.darts.courtlogs;
 
-import com.synapps.moj.dfs.response.GetCourtLogResponse;
+
 import com.synapps.moj.dfs.response.CourtLogEntry;
+import com.synapps.moj.dfs.response.GetCourtLogResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -35,10 +36,9 @@ public class GetCourtLogsMapper {
     }
 
     private CourtLogEntry toLegacyApi(CourtLog courtLog) {
+        var legacyCourtLogEntry = new CourtLogEntry();
         var logDateTime =
             dateConverters.offsetDateTimeToLegacyDateTime(courtLog.getTimestamp());
-
-        var legacyCourtLogEntry = new CourtLogEntry();
 
         legacyCourtLogEntry.setY(String.valueOf(logDateTime.getYear()));
         legacyCourtLogEntry.setM(String.valueOf(logDateTime.getMonthValue()));
@@ -52,17 +52,14 @@ public class GetCourtLogsMapper {
     }
 
     private GetCourtLogResponse emptyResponse() {
-        var innerResponse = createInnerResponse();
-        var outerResponse = new GetCourtLogResponse();
-
-        return innerResponse;
+        return createInnerResponse();
     }
 
     private com.synapps.moj.dfs.response.CourtLog createLegacyCourtLog() {
         return new com.synapps.moj.dfs.response.CourtLog();
     }
 
-    private com.synapps.moj.dfs.response.GetCourtLogResponse createInnerResponse() {
-        return new com.synapps.moj.dfs.response.GetCourtLogResponse();
+    private GetCourtLogResponse createInnerResponse() {
+        return new GetCourtLogResponse();
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/dailylist/DailyListRoute.java
+++ b/src/main/java/uk/gov/hmcts/darts/dailylist/DailyListRoute.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.dailylist;
 
-import com.service.mojdarts.synapps.com.AddDocumentResponse;
 import com.synapps.moj.dfs.response.DARTSResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/uk/gov/hmcts/darts/dailylist/DailyListRoute.java
+++ b/src/main/java/uk/gov/hmcts/darts/dailylist/DailyListRoute.java
@@ -39,7 +39,7 @@ public class DailyListRoute {
     @Value("${darts-gateway.daily-list.validate}")
     private boolean validate;
 
-    public AddDocumentResponse handle(String document, String type) {
+    public DARTSResponse handle(String document, String type) {
         Optional<SystemType> systemType = SystemType.getByType(type);
         if (systemType.isEmpty()) {
             throw new DartsValidationException("SystemType is not valid " + type);
@@ -98,12 +98,10 @@ public class DailyListRoute {
         return successResponse();
     }
 
-    private AddDocumentResponse successResponse() {
+    private DARTSResponse successResponse() {
         DARTSResponse dartsResponse = new DARTSResponse();
         dartsResponse.setCode("200");
         dartsResponse.setMessage("OK");
-        AddDocumentResponse response = new AddDocumentResponse();
-        response.setReturn(dartsResponse);
-        return response;
+        return dartsResponse;
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventRequestMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventRequestMapper.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.event.service.impl;
 
-import com.service.mojdarts.synapps.com.AddDocumentResponse;
 import com.synapps.moj.dfs.response.DARTSResponse;
 import org.springframework.stereotype.Service;
 import uk.gov.courtservice.events.DartsEvent;
@@ -39,14 +38,11 @@ public class EventRequestMapper {
             dartsEvent.getS().intValue()), ZoneOffset.UTC);
     }
 
-    public AddDocumentResponse toLegacyAddDocumentResponse(EventsResponse eventResponse) {
+    public DARTSResponse toLegacyAddDocumentResponse(EventsResponse eventResponse) {
         var dartsResponse = new DARTSResponse();
         dartsResponse.setMessage(eventResponse.getMessage());
         dartsResponse.setCode(eventResponse.getCode());
 
-        var addDocumentResponse = new AddDocumentResponse();
-        addDocumentResponse.setReturn(dartsResponse);
-
-        return addDocumentResponse;
+        return dartsResponse;
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventRoute.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventRoute.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.darts.event.service.impl;
 
 import com.service.mojdarts.synapps.com.AddDocumentResponse;
+import com.synapps.moj.dfs.response.DARTSResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
@@ -25,7 +26,7 @@ public class EventRoute {
     private final EventRequestMapper dartsXmlMapper;
 
     @SuppressWarnings("PMD.UseObjectForClearerAPI")
-    public AddDocumentResponse handle(String document, String messageId, String type, String subType) {
+    public DARTSResponse handle(String document, String messageId, String type, String subType) {
         if (validateEvent) {
             xmlValidator.validate(document, schemaPath);
         }

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventRoute.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventRoute.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.event.service.impl;
 
-import com.service.mojdarts.synapps.com.AddDocumentResponse;
 import com.synapps.moj.dfs.response.DARTSResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/uk/gov/hmcts/darts/routing/EventRoutingService.java
+++ b/src/main/java/uk/gov/hmcts/darts/routing/EventRoutingService.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.routing;
 
 import com.service.mojdarts.synapps.com.AddDocument;
-import com.service.mojdarts.synapps.com.AddDocumentResponse;
 import com.synapps.moj.dfs.response.DARTSResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/uk/gov/hmcts/darts/routing/EventRoutingService.java
+++ b/src/main/java/uk/gov/hmcts/darts/routing/EventRoutingService.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.darts.routing;
 
 import com.service.mojdarts.synapps.com.AddDocument;
 import com.service.mojdarts.synapps.com.AddDocumentResponse;
+import com.synapps.moj.dfs.response.DARTSResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.dailylist.DailyListRoute;
@@ -21,7 +22,7 @@ public class EventRoutingService {
     private final DailyListRoute dailyListRoute;
     private final EventRoute eventRoute;
 
-    public AddDocumentResponse route(AddDocument request) {
+    public DARTSResponse route(AddDocument request) {
         if (DAILY_LIST_TYPES.contains(request.getType())) {
             return dailyListRoute.handle(request.getDocument(), request.getType());
         } else {

--- a/src/main/java/uk/gov/hmcts/darts/utilities/MapperUtility.java
+++ b/src/main/java/uk/gov/hmcts/darts/utilities/MapperUtility.java
@@ -35,15 +35,12 @@ public class MapperUtility {
 
     }
 
-    public static AddLogEntryResponse mapResponse(EventsResponse eventResponse) {
+    public static DARTSResponse mapResponse(EventsResponse eventResponse) {
         var dartsResponse = new DARTSResponse();
         dartsResponse.setMessage(eventResponse.getMessage());
         dartsResponse.setCode(eventResponse.getCode());
 
-        var addLogEntryResponse = new AddLogEntryResponse();
-        addLogEntryResponse.setReturn(dartsResponse);
-
-        return addLogEntryResponse;
+        return dartsResponse;
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/utilities/MapperUtility.java
+++ b/src/main/java/uk/gov/hmcts/darts/utilities/MapperUtility.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.utilities;
 
-import com.service.mojdarts.synapps.com.AddLogEntryResponse;
 import com.synapps.moj.dfs.response.DARTSResponse;
 import lombok.experimental.UtilityClass;
 import uk.gov.hmcts.darts.addlogentry.LogEntry;

--- a/src/main/java/uk/gov/hmcts/darts/ws/CodeAndMessage.java
+++ b/src/main/java/uk/gov/hmcts/darts/ws/CodeAndMessage.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.darts.ws;
 
+import com.synapps.moj.dfs.response.DARTSResponse;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -17,4 +18,21 @@ public enum CodeAndMessage {
     private final String code;
     private final String message;
 
+    public DARTSResponse getResponse() {
+        return getResponse(code, message);
+    }
+
+    public static DARTSResponse getResponse(String code, String message) {
+        DARTSResponse response = new DARTSResponse();
+        response.setCode(code);
+        response.setMessage(message);
+        return response;
+    }
+
+    public static DARTSResponse getResponse(CodeAndMessage codeAndMessage) {
+        DARTSResponse response = new DARTSResponse();
+        response.setCode(codeAndMessage.getCode());
+        response.setMessage(codeAndMessage.getMessage());
+        return response;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/darts/ws/DartsEndpoint.java
+++ b/src/main/java/uk/gov/hmcts/darts/ws/DartsEndpoint.java
@@ -60,7 +60,7 @@ public class DartsEndpoint {
     public JAXBElement<AddCaseResponse> addCase(@RequestPayload JAXBElement<AddCase> addCase) {
         AddCaseResponse addCaseResponse = ResponseFactory.getAddCaseResponse();
 
-        addCaseResponse.setReturn(endpointHandler.makeAPICall("getCases", () -> casesRoute.route(addCase.getValue()),
+        addCaseResponse.setReturn(endpointHandler.makeAPICall("addCases", () -> casesRoute.route(addCase.getValue()),
                                                             addCaseResponse::getReturn));
 
         return new ObjectFactory().createAddCaseResponse(addCaseResponse);
@@ -72,7 +72,7 @@ public class DartsEndpoint {
 
         GetCourtLogResponse addCaseResponseLog = ResponseFactory.getCourtLogResponse();
 
-        addCaseResponseLog.setReturn(endpointHandler.makeAPICall("getCases", () -> getCourtLogRoute.route(getCourtLog.getValue()),
+        addCaseResponseLog.setReturn(endpointHandler.makeAPICall("getCourtLogResponse", () -> getCourtLogRoute.route(getCourtLog.getValue()),
                                     addCaseResponseLog::getReturn));
 
         return new ObjectFactory().createGetCourtLogResponse(addCaseResponseLog);
@@ -84,7 +84,7 @@ public class DartsEndpoint {
 
         AddLogEntryResponse addLogEntryResponse = ResponseFactory.getAddLogEntryResponse();
 
-        addLogEntryResponse.setReturn(endpointHandler.makeAPICall("getCases", () -> addCourtLogsRoute.route(addLogEntry.getValue().getDocument()),
+        addLogEntryResponse.setReturn(endpointHandler.makeAPICall("addLogEntry", () -> addCourtLogsRoute.route(addLogEntry.getValue().getDocument()),
                                    addLogEntryResponse::getReturn));
 
         return new ObjectFactory().createAddLogEntryResponse(addLogEntryResponse);

--- a/src/main/java/uk/gov/hmcts/darts/ws/DartsEndpoint.java
+++ b/src/main/java/uk/gov/hmcts/darts/ws/DartsEndpoint.java
@@ -1,7 +1,16 @@
 package uk.gov.hmcts.darts.ws;
 
-
-import com.service.mojdarts.synapps.com.*;
+import com.service.mojdarts.synapps.com.AddCase;
+import com.service.mojdarts.synapps.com.AddCaseResponse;
+import com.service.mojdarts.synapps.com.AddDocument;
+import com.service.mojdarts.synapps.com.AddDocumentResponse;
+import com.service.mojdarts.synapps.com.AddLogEntry;
+import com.service.mojdarts.synapps.com.AddLogEntryResponse;
+import com.service.mojdarts.synapps.com.GetCases;
+import com.service.mojdarts.synapps.com.GetCasesResponse;
+import com.service.mojdarts.synapps.com.GetCourtLog;
+import com.service.mojdarts.synapps.com.GetCourtLogResponse;
+import com.service.mojdarts.synapps.com.ObjectFactory;
 import jakarta.xml.bind.JAXBElement;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,21 +27,18 @@ import uk.gov.hmcts.darts.routing.EventRoutingService;
 @RequiredArgsConstructor
 @Slf4j
 public class DartsEndpoint {
-
     private final EventRoutingService eventRoutingService;
     private final CasesRoute casesRoute;
     private final GetCourtLogRoute getCourtLogRoute;
     private final AddCourtLogsRoute addCourtLogsRoute;
-    private final DartsResponseUtils utils;
     private final DartsEndpointHandler endpointHandler;
-
 
     @PayloadRoot(namespace = "http://com.synapps.mojdarts.service.com", localPart = "addDocument")
     @ResponsePayload
     public JAXBElement<AddDocumentResponse> addDocument(@RequestPayload JAXBElement<AddDocument> addDocument) {
         AddDocumentResponse documentResponse = ResponseFactory.getAddDocumentResponse();
 
-        documentResponse.setReturn(endpointHandler.makeAPICall("addDocument", ()-> eventRoutingService.route( addDocument.getValue()),
+        documentResponse.setReturn(endpointHandler.makeAPICall("addDocument", () -> eventRoutingService.route(addDocument.getValue()),
                                            documentResponse::getReturn));
 
         return new ObjectFactory().createAddDocumentResponse(documentResponse);
@@ -43,7 +49,7 @@ public class DartsEndpoint {
     public JAXBElement<GetCasesResponse> getCases(@RequestPayload JAXBElement<GetCases> getCases) {
         GetCasesResponse casesResponse =  ResponseFactory.getCasesResponse();
 
-        casesResponse.setReturn(endpointHandler.makeAPICall("getCases", ()-> casesRoute.route(getCases.getValue()),
+        casesResponse.setReturn(endpointHandler.makeAPICall("getCases", () -> casesRoute.route(getCases.getValue()),
                                                             casesResponse::getReturn));
 
         return new ObjectFactory().createGetCasesResponse(casesResponse);
@@ -54,7 +60,7 @@ public class DartsEndpoint {
     public JAXBElement<AddCaseResponse> addCase(@RequestPayload JAXBElement<AddCase> addCase) {
         AddCaseResponse addCaseResponse = ResponseFactory.getAddCaseResponse();
 
-        addCaseResponse.setReturn(endpointHandler.makeAPICall("getCases", ()-> casesRoute.route(addCase.getValue()),
+        addCaseResponse.setReturn(endpointHandler.makeAPICall("getCases", () -> casesRoute.route(addCase.getValue()),
                                                             addCaseResponse::getReturn));
 
         return new ObjectFactory().createAddCaseResponse(addCaseResponse);
@@ -66,7 +72,7 @@ public class DartsEndpoint {
 
         GetCourtLogResponse addCaseResponseLog = ResponseFactory.getCourtLogResponse();
 
-        addCaseResponseLog.setReturn(endpointHandler.makeAPICall("getCases", ()-> getCourtLogRoute.route(getCourtLog.getValue()),
+        addCaseResponseLog.setReturn(endpointHandler.makeAPICall("getCases", () -> getCourtLogRoute.route(getCourtLog.getValue()),
                                     addCaseResponseLog::getReturn));
 
         return new ObjectFactory().createGetCourtLogResponse(addCaseResponseLog);
@@ -78,7 +84,7 @@ public class DartsEndpoint {
 
         AddLogEntryResponse addLogEntryResponse = ResponseFactory.getAddLogEntryResponse();
 
-        addLogEntryResponse.setReturn(endpointHandler.makeAPICall("getCases", ()->addCourtLogsRoute.route(addLogEntry.getValue().getDocument()),
+        addLogEntryResponse.setReturn(endpointHandler.makeAPICall("getCases", () -> addCourtLogsRoute.route(addLogEntry.getValue().getDocument()),
                                    addLogEntryResponse::getReturn));
 
         return new ObjectFactory().createAddLogEntryResponse(addLogEntryResponse);

--- a/src/main/java/uk/gov/hmcts/darts/ws/DartsEndpoint.java
+++ b/src/main/java/uk/gov/hmcts/darts/ws/DartsEndpoint.java
@@ -1,18 +1,7 @@
 package uk.gov.hmcts.darts.ws;
 
 
-import com.service.mojdarts.synapps.com.AddCase;
-import com.service.mojdarts.synapps.com.AddCaseResponse;
-import com.service.mojdarts.synapps.com.AddDocument;
-import com.service.mojdarts.synapps.com.AddDocumentResponse;
-import com.service.mojdarts.synapps.com.AddLogEntry;
-import com.service.mojdarts.synapps.com.AddLogEntryResponse;
-import com.service.mojdarts.synapps.com.GetCases;
-import com.service.mojdarts.synapps.com.GetCasesResponse;
-import com.service.mojdarts.synapps.com.GetCourtLog;
-import com.service.mojdarts.synapps.com.GetCourtLogResponse;
-import com.service.mojdarts.synapps.com.ObjectFactory;
-import feign.FeignException;
+import com.service.mojdarts.synapps.com.*;
 import jakarta.xml.bind.JAXBElement;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,82 +24,63 @@ public class DartsEndpoint {
     private final GetCourtLogRoute getCourtLogRoute;
     private final AddCourtLogsRoute addCourtLogsRoute;
     private final DartsResponseUtils utils;
+    private final DartsEndpointHandler endpointHandler;
+
 
     @PayloadRoot(namespace = "http://com.synapps.mojdarts.service.com", localPart = "addDocument")
     @ResponsePayload
     public JAXBElement<AddDocumentResponse> addDocument(@RequestPayload JAXBElement<AddDocument> addDocument) {
-        ObjectFactory factory = new ObjectFactory();
-        var addDocumentResponse = new AddDocumentResponse();
-        try {
-            addDocumentResponse = eventRoutingService.route(addDocument.getValue());
-        } catch (FeignException e) {
-            log.error("Error sending addDocument. {}", e.contentUTF8(), e);
-            addDocumentResponse.setReturn(utils.createDartsResponseMessage(e));
-        } catch (DartsException de) {
-            log.error("Error sending addDocument. {}", de);
-            addDocumentResponse.setReturn(utils.createDartsResponseMessage(de.getCodeAndMessage()));
-        }
+        AddDocumentResponse documentResponse = ResponseFactory.getAddDocumentResponse();
 
-        return factory.createAddDocumentResponse(addDocumentResponse);
+        documentResponse.setReturn(endpointHandler.makeAPICall("addDocument", ()-> eventRoutingService.route( addDocument.getValue()),
+                                           documentResponse::getReturn));
+
+        return new ObjectFactory().createAddDocumentResponse(documentResponse);
     }
 
     @PayloadRoot(namespace = "http://com.synapps.mojdarts.service.com", localPart = "getCases")
     @ResponsePayload
     public JAXBElement<GetCasesResponse> getCases(@RequestPayload JAXBElement<GetCases> getCases) {
+        GetCasesResponse casesResponse =  ResponseFactory.getCasesResponse();
 
-        ObjectFactory factory = new ObjectFactory();
+        casesResponse.setReturn(endpointHandler.makeAPICall("getCases", ()-> casesRoute.route(getCases.getValue()),
+                                                            casesResponse::getReturn));
 
-        return factory.createGetCasesResponse(casesRoute.route(getCases.getValue()));
+        return new ObjectFactory().createGetCasesResponse(casesResponse);
     }
 
     @PayloadRoot(namespace = "http://com.synapps.mojdarts.service.com", localPart = "addCase")
     @ResponsePayload
     public JAXBElement<AddCaseResponse> addCase(@RequestPayload JAXBElement<AddCase> addCase) {
-        ObjectFactory factory = new ObjectFactory();
+        AddCaseResponse addCaseResponse = ResponseFactory.getAddCaseResponse();
 
-        try {
-            casesRoute.route(addCase.getValue());
+        addCaseResponse.setReturn(endpointHandler.makeAPICall("getCases", ()-> casesRoute.route(addCase.getValue()),
+                                                            addCaseResponse::getReturn));
 
-            return factory.createAddCaseResponse(utils.createSuccessfulAddCaseResponse());
-        } catch (DartsException e) {
-            return factory.createAddCaseResponse(utils.createErrorAddCaseResponse(e));
-        }
+        return new ObjectFactory().createAddCaseResponse(addCaseResponse);
     }
 
     @PayloadRoot(namespace = "http://com.synapps.mojdarts.service.com", localPart = "getCourtLog")
     @ResponsePayload
     public JAXBElement<GetCourtLogResponse> getCourtLogResponse(@RequestPayload JAXBElement<GetCourtLog> getCourtLog) {
-        var getCourtLogResponse = new GetCourtLogResponse();
-        ObjectFactory factory = new ObjectFactory();
 
-        try {
-            getCourtLogResponse = getCourtLogRoute.route(getCourtLog.getValue());
+        GetCourtLogResponse addCaseResponseLog = ResponseFactory.getCourtLogResponse();
 
-        } catch (DartsException e) {
-            getCourtLogResponse.setReturn(utils.createCourtLogResponse(e));
-            return factory.createGetCourtLogResponse(getCourtLogResponse);
-        }
+        addCaseResponseLog.setReturn(endpointHandler.makeAPICall("getCases", ()-> getCourtLogRoute.route(getCourtLog.getValue()),
+                                    addCaseResponseLog::getReturn));
 
-        return factory.createGetCourtLogResponse(getCourtLogResponse);
+        return new ObjectFactory().createGetCourtLogResponse(addCaseResponseLog);
     }
 
     @PayloadRoot(namespace = "http://com.synapps.mojdarts.service.com", localPart = "addLogEntry")
     @ResponsePayload
     public JAXBElement<AddLogEntryResponse> addLogEntry(@RequestPayload JAXBElement<AddLogEntry> addLogEntry) {
-        var addLogEntryResponse = new AddLogEntryResponse();
-        ObjectFactory factory = new ObjectFactory();
 
-        try {
-            addLogEntryResponse = addCourtLogsRoute.route(addLogEntry.getValue().getDocument());
+        AddLogEntryResponse addLogEntryResponse = ResponseFactory.getAddLogEntryResponse();
 
-        } catch (DartsException e) {
-            log.error(e.getMessage());
-            addLogEntryResponse.setReturn(utils.createCourtLogResponse(e));
-            return factory.createAddLogEntryResponse(addLogEntryResponse);
-        }
+        addLogEntryResponse.setReturn(endpointHandler.makeAPICall("getCases", ()->addCourtLogsRoute.route(addLogEntry.getValue().getDocument()),
+                                   addLogEntryResponse::getReturn));
 
-        return factory.createAddLogEntryResponse(addLogEntryResponse);
+        return new ObjectFactory().createAddLogEntryResponse(addLogEntryResponse);
     }
-
-
 }

--- a/src/main/java/uk/gov/hmcts/darts/ws/DartsEndpointHandler.java
+++ b/src/main/java/uk/gov/hmcts/darts/ws/DartsEndpointHandler.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.darts.ws;
+
+import com.synapps.moj.dfs.response.DARTSResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import java.util.function.Supplier;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DartsEndpointHandler {
+
+    public <T extends DARTSResponse> T makeAPICall(String taskName, Supplier<T> execute, Supplier<T> createResponse) {
+        try {
+            return execute.get();
+        }  catch (DartsException de) {
+            log.error("Error sending " + taskName + "{}", de);
+            T response = createResponse.get();
+            response.setCode(de.getCodeAndMessage().getCode());
+            response.setMessage(de.getCodeAndMessage().getMessage());
+
+            return response;
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/ws/DartsEndpointHandler.java
+++ b/src/main/java/uk/gov/hmcts/darts/ws/DartsEndpointHandler.java
@@ -4,6 +4,7 @@ import com.synapps.moj.dfs.response.DARTSResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+
 import java.util.function.Supplier;
 
 @Slf4j
@@ -14,7 +15,7 @@ public class DartsEndpointHandler {
     public <T extends DARTSResponse> T makeAPICall(String taskName, Supplier<T> execute, Supplier<T> createResponse) {
         try {
             return execute.get();
-        }  catch (DartsException de) {
+        } catch (DartsException de) {
             log.error("Error sending " + taskName + "{}", de);
             T response = createResponse.get();
             response.setCode(de.getCodeAndMessage().getCode());

--- a/src/main/java/uk/gov/hmcts/darts/ws/ResponseFactory.java
+++ b/src/main/java/uk/gov/hmcts/darts/ws/ResponseFactory.java
@@ -1,9 +1,17 @@
 package uk.gov.hmcts.darts.ws;
 
-import com.service.mojdarts.synapps.com.*;
+import com.service.mojdarts.synapps.com.AddCaseResponse;
+import com.service.mojdarts.synapps.com.AddDocumentResponse;
+import com.service.mojdarts.synapps.com.AddLogEntryResponse;
+import com.service.mojdarts.synapps.com.GetCasesResponse;
+import com.service.mojdarts.synapps.com.GetCourtLogResponse;
+import com.service.mojdarts.synapps.com.ObjectFactory;
 import com.synapps.moj.dfs.response.DARTSResponse;
 
-public class ResponseFactory {
+public final class ResponseFactory {
+
+    private ResponseFactory() {
+    }
 
     public static AddDocumentResponse getAddDocumentResponse() {
         AddDocumentResponse documentResponse = new ObjectFactory().createAddDocumentResponse();
@@ -34,10 +42,8 @@ public class ResponseFactory {
 
     public static AddLogEntryResponse getAddLogEntryResponse() {
         AddLogEntryResponse addLogEntryResponse = new ObjectFactory().createAddLogEntryResponse();
-        addLogEntryResponse.setReturn(new com.synapps.moj.dfs.response.DARTSResponse());
+        addLogEntryResponse.setReturn(new DARTSResponse());
 
         return addLogEntryResponse;
     }
-
-
 }

--- a/src/main/java/uk/gov/hmcts/darts/ws/ResponseFactory.java
+++ b/src/main/java/uk/gov/hmcts/darts/ws/ResponseFactory.java
@@ -1,0 +1,43 @@
+package uk.gov.hmcts.darts.ws;
+
+import com.service.mojdarts.synapps.com.*;
+import com.synapps.moj.dfs.response.DARTSResponse;
+
+public class ResponseFactory {
+
+    public static AddDocumentResponse getAddDocumentResponse() {
+        AddDocumentResponse documentResponse = new ObjectFactory().createAddDocumentResponse();
+        documentResponse.setReturn(new DARTSResponse());
+        return documentResponse;
+    }
+
+
+    public static GetCasesResponse getCasesResponse() {
+        GetCasesResponse casesResponse = new ObjectFactory().createGetCasesResponse();
+        casesResponse.setReturn(new com.synapps.moj.dfs.response.GetCasesResponse());
+        return casesResponse;
+    }
+
+
+    public static AddCaseResponse getAddCaseResponse() {
+        AddCaseResponse addCaseResponse = new ObjectFactory().createAddCaseResponse();
+        addCaseResponse.setReturn(new com.synapps.moj.dfs.response.GetCasesResponse());
+        return addCaseResponse;
+    }
+
+    public static GetCourtLogResponse getCourtLogResponse() {
+        GetCourtLogResponse addCaseResponseLog = new ObjectFactory().createGetCourtLogResponse();
+        addCaseResponseLog.setReturn(new com.synapps.moj.dfs.response.GetCourtLogResponse());
+        return addCaseResponseLog;
+    }
+
+
+    public static AddLogEntryResponse getAddLogEntryResponse() {
+        AddLogEntryResponse addLogEntryResponse = new ObjectFactory().createAddLogEntryResponse();
+        addLogEntryResponse.setReturn(new com.synapps.moj.dfs.response.DARTSResponse());
+
+        return addLogEntryResponse;
+    }
+
+
+}

--- a/src/test/java/uk/gov/hmcts/darts/cases/mapper/GetCasesMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cases/mapper/GetCasesMapperTest.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.service.mojdarts.synapps.com.GetCases;
-import com.service.mojdarts.synapps.com.GetCasesResponse;
+import com.synapps.moj.dfs.response.GetCasesResponse;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -50,7 +50,7 @@ class GetCasesMapperTest {
             .registerModule(module);
         List<ScheduledCase> modernisedDartsResponse = mapper.readValue(dartsApiResponseStr, new TypeReference<ArrayList<ScheduledCase>>() {});
 
-        GetCasesResponse getCasesResponse = GetCasesMapper.mapToMojDartsResponse(
+        GetCasesResponse getCasesResponse = GetCasesMapper.mapToDfsResponse(
             getCasesRequest,
             modernisedDartsResponse
         );

--- a/src/test/java/uk/gov/hmcts/darts/common/client/mapper/APIResponseMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/client/mapper/APIResponseMapperTest.java
@@ -1,0 +1,64 @@
+package uk.gov.hmcts.darts.common.client.mapper;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.darts.common.client.exeption.ClientProblemException;
+
+import uk.gov.hmcts.darts.model.audio.Problem;
+import uk.gov.hmcts.darts.model.dailylist.PostDailyListErrorCode;
+import uk.gov.hmcts.darts.ws.CodeAndMessage;
+
+import java.net.URI;
+import java.util.Optional;
+
+public class APIResponseMapperTest {
+
+    @Test
+    public void testProblemNoCourtHouse() {
+        Problem problem = new Problem();
+        problem.setType(URI.create(PostDailyListErrorCode.DAILYLIST_COURT_HOUSE_NOT_FOUND.getValue()));
+        Optional<CodeAndMessage> message = new DummyAPIResponseMapper().getCodeAndMessage(problem);
+        Assertions.assertTrue(message.isPresent());
+        Assertions.assertEquals(CodeAndMessage.NOT_FOUND_COURTHOUSE, message.get());
+    }
+
+    @Test
+    public void testNoProblemFound() {
+        Problem problem = new Problem();
+        problem.setType(URI.create(PostDailyListErrorCode.DAILYLIST_DOCUMENT_CANT_BE_PARSED.getValue()));
+        Optional<CodeAndMessage> message = new DummyAPIResponseMapper().getCodeAndMessage(problem);
+        Assertions.assertTrue(message.isEmpty());
+    }
+
+    @Test
+    public void testProblemNoCourtHouseException() {
+        Problem problem = new Problem();
+        problem.setType(URI.create(PostDailyListErrorCode.DAILYLIST_COURT_HOUSE_NOT_FOUND.getValue()));
+        Optional<ClientProblemException> exception = new DummyAPIResponseMapper().getExceptionForProblem(problem);
+        Assertions.assertTrue(exception.isPresent());
+        Assertions.assertEquals(CodeAndMessage.NOT_FOUND_COURTHOUSE, exception.get().getCodeAndMessage());
+        Assertions.assertEquals(problem, exception.get().getProblem());
+    }
+
+    class DummyAPIResponseMapper extends AbstractAPIProblemResponseMapper {
+        {
+            addMapper(PostDailyListErrorCode.class,
+                      getBuilder().problem(PostDailyListErrorCode.DAILYLIST_COURT_HOUSE_NOT_FOUND).message(
+                          CodeAndMessage.NOT_FOUND_COURTHOUSE).build()
+            );
+        }
+
+        private ProblemResponseMapping.ProblemResponseMappingBuilder<PostDailyListErrorCode> getBuilder() {
+            return new ProblemResponseMapping.ProblemResponseMappingBuilder<>();
+        }
+
+        @Override
+        public Optional<ClientProblemException> getExceptionForProblem(Problem p) {
+            return getProblemValueForProblem(
+                PostDailyListErrorCode.class,
+                p,
+                (mapping) -> new ClientProblemException(mapping.getMessage(), p)
+            );
+        }
+    }
+}

--- a/src/test/java/uk/gov/hmcts/darts/common/client/mapper/APIResponseMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/client/mapper/APIResponseMapperTest.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.darts.common.client.mapper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.darts.common.client.exeption.ClientProblemException;
-
 import uk.gov.hmcts.darts.model.audio.Problem;
 import uk.gov.hmcts.darts.model.dailylist.PostDailyListErrorCode;
 import uk.gov.hmcts.darts.ws.CodeAndMessage;
@@ -11,29 +10,35 @@ import uk.gov.hmcts.darts.ws.CodeAndMessage;
 import java.net.URI;
 import java.util.Optional;
 
-public class APIResponseMapperTest {
+class APIResponseMapperTest {
 
     @Test
-    public void testProblemNoCourtHouse() {
+    void testProblemNoCourtHouse() {
         Problem problem = new Problem();
-        problem.setType(URI.create(PostDailyListErrorCode.DAILYLIST_COURT_HOUSE_NOT_FOUND.getValue()));
+        PostDailyListErrorCode problemCode = PostDailyListErrorCode.DAILYLIST_COURT_HOUSE_NOT_FOUND;
+        URI uriType = URI.create(problemCode.getValue());
+        problem.setType(uriType);
         Optional<CodeAndMessage> message = new DummyAPIResponseMapper().getCodeAndMessage(problem);
         Assertions.assertTrue(message.isPresent());
         Assertions.assertEquals(CodeAndMessage.NOT_FOUND_COURTHOUSE, message.get());
     }
 
     @Test
-    public void testNoProblemFound() {
+    void testNoProblemFound() {
         Problem problem = new Problem();
-        problem.setType(URI.create(PostDailyListErrorCode.DAILYLIST_DOCUMENT_CANT_BE_PARSED.getValue()));
+        PostDailyListErrorCode problemCode = PostDailyListErrorCode.DAILYLIST_DOCUMENT_CANT_BE_PARSED;
+        URI uriType = URI.create(problemCode.getValue());
+        problem.setType(uriType);
         Optional<CodeAndMessage> message = new DummyAPIResponseMapper().getCodeAndMessage(problem);
         Assertions.assertTrue(message.isEmpty());
     }
 
     @Test
-    public void testProblemNoCourtHouseException() {
+    void testProblemNoCourtHouseException() {
         Problem problem = new Problem();
-        problem.setType(URI.create(PostDailyListErrorCode.DAILYLIST_COURT_HOUSE_NOT_FOUND.getValue()));
+        PostDailyListErrorCode problemCode = PostDailyListErrorCode.DAILYLIST_COURT_HOUSE_NOT_FOUND;
+        URI uriType = URI.create(problemCode.getValue());
+        problem.setType(uriType);
         Optional<ClientProblemException> exception = new DummyAPIResponseMapper().getExceptionForProblem(problem);
         Assertions.assertTrue(exception.isPresent());
         Assertions.assertEquals(CodeAndMessage.NOT_FOUND_COURTHOUSE, exception.get().getCodeAndMessage());
@@ -42,9 +47,10 @@ public class APIResponseMapperTest {
 
     class DummyAPIResponseMapper extends AbstractAPIProblemResponseMapper {
         {
-            addMapper(PostDailyListErrorCode.class,
-                      getBuilder().problem(PostDailyListErrorCode.DAILYLIST_COURT_HOUSE_NOT_FOUND).message(
-                          CodeAndMessage.NOT_FOUND_COURTHOUSE).build()
+            addMapper(
+                PostDailyListErrorCode.class,
+                getBuilder().problem(PostDailyListErrorCode.DAILYLIST_COURT_HOUSE_NOT_FOUND).message(
+                    CodeAndMessage.NOT_FOUND_COURTHOUSE).build()
             );
         }
 
@@ -53,11 +59,11 @@ public class APIResponseMapperTest {
         }
 
         @Override
-        public Optional<ClientProblemException> getExceptionForProblem(Problem p) {
+        public Optional<ClientProblemException> getExceptionForProblem(Problem problem) {
             return getProblemValueForProblem(
                 PostDailyListErrorCode.class,
-                p,
-                (mapping) -> new ClientProblemException(mapping.getMessage(), p)
+                problem,
+                (mapping) -> new ClientProblemException(mapping.getMessage(), problem)
             );
         }
     }

--- a/src/test/java/uk/gov/hmcts/darts/common/client/mapper/CaseAPIErrorResponseMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/client/mapper/CaseAPIErrorResponseMapperTest.java
@@ -3,69 +3,90 @@ package uk.gov.hmcts.darts.common.client.mapper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.darts.common.client.exeption.ClientProblemException;
 import uk.gov.hmcts.darts.common.client.exeption.cases.CasesAPIGetCasesException;
 import uk.gov.hmcts.darts.common.client.exeption.cases.CasesAPIPostCaseException;
-import uk.gov.hmcts.darts.common.client.exeption.ClientProblemException;
 import uk.gov.hmcts.darts.model.audio.Problem;
-import uk.gov.hmcts.darts.model.cases.PostCasesErrorCode;
 import uk.gov.hmcts.darts.model.cases.GetCasesErrorCode;
+import uk.gov.hmcts.darts.model.cases.PostCasesErrorCode;
 import uk.gov.hmcts.darts.model.dailylist.PostDailyListErrorCode;
 import uk.gov.hmcts.darts.ws.CodeAndMessage;
 
 import java.net.URI;
 import java.util.Optional;
 
-public class CaseAPIErrorResponseMapperTest {
+class CaseAPIErrorResponseMapperTest {
 
     private CaseAPIProblemResponseMapper responseMapper;
 
     private Problem problem;
 
     @BeforeEach
-    public void before()
-    {
+    void before() {
         responseMapper = new CaseAPIProblemResponseMapper();
         problem = new Problem();
     }
 
     @Test
-    public void testNoExceptionForProblem(){
-        Problem problem = new Problem();
-        problem.setType(URI.create(PostDailyListErrorCode.DAILYLIST_COURT_HOUSE_NOT_FOUND.getValue()));
+    void testNoExceptionForProblem() {
+        PostDailyListErrorCode problemCode = PostDailyListErrorCode.DAILYLIST_COURT_HOUSE_NOT_FOUND;
+        URI uriType = URI.create(problemCode.getValue());
+        problem.setType(uriType);
         Optional<ClientProblemException> exception = responseMapper.getExceptionForProblem(problem);
         Assertions.assertTrue(exception.isEmpty());
     }
 
     @Test
-    public void testExceptionForAddCaseProblemNoParse(){
-        Problem problem = new Problem();
-        problem.setType(URI.create(PostCasesErrorCode.CASE_DOCUMENT_CANT_BE_PARSED.getValue()));
+    void testExceptionForAddCaseProblemNoParse() {
+        PostCasesErrorCode problemCode = PostCasesErrorCode.CASE_DOCUMENT_CANT_BE_PARSED;
+        URI uriType = URI.create(problemCode.getValue());
+        problem.setType(uriType);
         Optional<ClientProblemException> exception = responseMapper.getExceptionForProblem(problem);
         Assertions.assertTrue(exception.isPresent());
-        Assertions.assertEquals(problem, ((CasesAPIPostCaseException)exception.get()).getProblem());
-        Assertions.assertEquals(CodeAndMessage.INVALID_XML, ((CasesAPIPostCaseException)exception.get()).getMapping().getMessage());
-        Assertions.assertEquals(PostCasesErrorCode.CASE_DOCUMENT_CANT_BE_PARSED, ((CasesAPIPostCaseException)exception.get()).getMapping().getProblem());
+        Assertions.assertEquals(problem, ((CasesAPIPostCaseException) exception.get()).getProblem());
+        Assertions.assertEquals(
+            CodeAndMessage.INVALID_XML,
+            ((CasesAPIPostCaseException) exception.get()).getMapping().getMessage()
+        );
+        Assertions.assertEquals(
+            PostCasesErrorCode.CASE_DOCUMENT_CANT_BE_PARSED,
+            ((CasesAPIPostCaseException) exception.get()).getMapping().getProblem()
+        );
     }
 
     @Test
-    public void testExceptionForAddCaseProblemNoCourtHouse(){
-        Problem problem = new Problem();
-        problem.setType(URI.create(PostCasesErrorCode.CASE_COURT_HOUSE_NOT_FOUND.getValue()));
+    void testExceptionForAddCaseProblemNoCourtHouse() {
+        PostCasesErrorCode problemCode = PostCasesErrorCode.CASE_COURT_HOUSE_NOT_FOUND;
+        URI uriType = URI.create(problemCode.getValue());
+        problem.setType(uriType);
         Optional<ClientProblemException> exception = responseMapper.getExceptionForProblem(problem);
         Assertions.assertTrue(exception.isPresent());
-        Assertions.assertEquals(problem, ((CasesAPIPostCaseException)exception.get()).getProblem());
-        Assertions.assertEquals(CodeAndMessage.NOT_FOUND_COURTHOUSE, ((CasesAPIPostCaseException)exception.get()).getMapping().getMessage());
-        Assertions.assertEquals(PostCasesErrorCode.CASE_COURT_HOUSE_NOT_FOUND, ((CasesAPIPostCaseException)exception.get()).getMapping().getProblem());
+        Assertions.assertEquals(problem, ((CasesAPIPostCaseException) exception.get()).getProblem());
+        Assertions.assertEquals(
+            CodeAndMessage.NOT_FOUND_COURTHOUSE,
+            ((CasesAPIPostCaseException) exception.get()).getMapping().getMessage()
+        );
+        Assertions.assertEquals(
+            PostCasesErrorCode.CASE_COURT_HOUSE_NOT_FOUND,
+            ((CasesAPIPostCaseException) exception.get()).getMapping().getProblem()
+        );
     }
 
     @Test
-    public void testExceptionForGetCaseProblemNoParse(){
-        Problem problem = new Problem();
-        problem.setType(URI.create(GetCasesErrorCode.CASE_COURT_HOUSE_NOT_FOUND.getValue()));
+    void testExceptionForGetCaseProblemNoParse() {
+        GetCasesErrorCode problemCode = GetCasesErrorCode.CASE_COURT_HOUSE_NOT_FOUND;
+        URI uriType = URI.create(problemCode.getValue());
+        problem.setType(uriType);
         Optional<ClientProblemException> exception = responseMapper.getExceptionForProblem(problem);
         Assertions.assertTrue(exception.isPresent());
         Assertions.assertEquals(problem, exception.get().getProblem());
-        Assertions.assertEquals(CodeAndMessage.NOT_FOUND_COURTHOUSE, ((CasesAPIGetCasesException)exception.get()).getMapping().getMessage());
-        Assertions.assertEquals(GetCasesErrorCode.CASE_COURT_HOUSE_NOT_FOUND, ((CasesAPIGetCasesException)exception.get()).getMapping().getProblem());
+        Assertions.assertEquals(
+            CodeAndMessage.NOT_FOUND_COURTHOUSE,
+            ((CasesAPIGetCasesException) exception.get()).getMapping().getMessage()
+        );
+        Assertions.assertEquals(
+            GetCasesErrorCode.CASE_COURT_HOUSE_NOT_FOUND,
+            ((CasesAPIGetCasesException) exception.get()).getMapping().getProblem()
+        );
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/common/client/mapper/CaseAPIErrorResponseMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/client/mapper/CaseAPIErrorResponseMapperTest.java
@@ -1,0 +1,71 @@
+package uk.gov.hmcts.darts.common.client.mapper;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.darts.common.client.exeption.cases.CasesAPIGetCasesException;
+import uk.gov.hmcts.darts.common.client.exeption.cases.CasesAPIPostCaseException;
+import uk.gov.hmcts.darts.common.client.exeption.ClientProblemException;
+import uk.gov.hmcts.darts.model.audio.Problem;
+import uk.gov.hmcts.darts.model.cases.PostCasesErrorCode;
+import uk.gov.hmcts.darts.model.cases.GetCasesErrorCode;
+import uk.gov.hmcts.darts.model.dailylist.PostDailyListErrorCode;
+import uk.gov.hmcts.darts.ws.CodeAndMessage;
+
+import java.net.URI;
+import java.util.Optional;
+
+public class CaseAPIErrorResponseMapperTest {
+
+    private CaseAPIProblemResponseMapper responseMapper;
+
+    private Problem problem;
+
+    @BeforeEach
+    public void before()
+    {
+        responseMapper = new CaseAPIProblemResponseMapper();
+        problem = new Problem();
+    }
+
+    @Test
+    public void testNoExceptionForProblem(){
+        Problem problem = new Problem();
+        problem.setType(URI.create(PostDailyListErrorCode.DAILYLIST_COURT_HOUSE_NOT_FOUND.getValue()));
+        Optional<ClientProblemException> exception = responseMapper.getExceptionForProblem(problem);
+        Assertions.assertTrue(exception.isEmpty());
+    }
+
+    @Test
+    public void testExceptionForAddCaseProblemNoParse(){
+        Problem problem = new Problem();
+        problem.setType(URI.create(PostCasesErrorCode.CASE_DOCUMENT_CANT_BE_PARSED.getValue()));
+        Optional<ClientProblemException> exception = responseMapper.getExceptionForProblem(problem);
+        Assertions.assertTrue(exception.isPresent());
+        Assertions.assertEquals(problem, ((CasesAPIPostCaseException)exception.get()).getProblem());
+        Assertions.assertEquals(CodeAndMessage.INVALID_XML, ((CasesAPIPostCaseException)exception.get()).getMapping().getMessage());
+        Assertions.assertEquals(PostCasesErrorCode.CASE_DOCUMENT_CANT_BE_PARSED, ((CasesAPIPostCaseException)exception.get()).getMapping().getProblem());
+    }
+
+    @Test
+    public void testExceptionForAddCaseProblemNoCourtHouse(){
+        Problem problem = new Problem();
+        problem.setType(URI.create(PostCasesErrorCode.CASE_COURT_HOUSE_NOT_FOUND.getValue()));
+        Optional<ClientProblemException> exception = responseMapper.getExceptionForProblem(problem);
+        Assertions.assertTrue(exception.isPresent());
+        Assertions.assertEquals(problem, ((CasesAPIPostCaseException)exception.get()).getProblem());
+        Assertions.assertEquals(CodeAndMessage.NOT_FOUND_COURTHOUSE, ((CasesAPIPostCaseException)exception.get()).getMapping().getMessage());
+        Assertions.assertEquals(PostCasesErrorCode.CASE_COURT_HOUSE_NOT_FOUND, ((CasesAPIPostCaseException)exception.get()).getMapping().getProblem());
+    }
+
+    @Test
+    public void testExceptionForGetCaseProblemNoParse(){
+        Problem problem = new Problem();
+        problem.setType(URI.create(GetCasesErrorCode.CASE_COURT_HOUSE_NOT_FOUND.getValue()));
+        Optional<ClientProblemException> exception = responseMapper.getExceptionForProblem(problem);
+        Assertions.assertTrue(exception.isPresent());
+        Assertions.assertEquals(problem, exception.get().getProblem());
+        Assertions.assertEquals(CodeAndMessage.NOT_FOUND_COURTHOUSE, ((CasesAPIGetCasesException)exception.get()).getMapping().getMessage());
+        Assertions.assertEquals(GetCasesErrorCode.CASE_COURT_HOUSE_NOT_FOUND, ((CasesAPIGetCasesException)exception.get()).getMapping().getProblem());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/darts/common/client/mapper/DailyListAPIErrorResponseMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/client/mapper/DailyListAPIErrorResponseMapperTest.java
@@ -12,48 +12,68 @@ import uk.gov.hmcts.darts.ws.CodeAndMessage;
 import java.net.URI;
 import java.util.Optional;
 
-public class DailyListAPIErrorResponseMapperTest {
+class DailyListAPIErrorResponseMapperTest {
     private DailyListAPIProblemResponseMapper responseMapper;
 
     private Problem problem;
 
     @BeforeEach
-    public void before()
-    {
+    public void before() {
         responseMapper = new DailyListAPIProblemResponseMapper();
         problem = new Problem();
     }
 
     @Test
-    public void testDocumentParseExceptionForAddDailyList(){
-        Problem problem = new Problem();
-        problem.setType(URI.create(PostDailyListErrorCode.DAILYLIST_DOCUMENT_CANT_BE_PARSED.getValue()));
+    void testDocumentParseExceptionForAddDailyList() {
+        PostDailyListErrorCode problemCode = PostDailyListErrorCode.DAILYLIST_DOCUMENT_CANT_BE_PARSED;
+        URI uriType = URI.create(problemCode.getValue());
+        problem.setType(uriType);
         Optional<ClientProblemException> exception = responseMapper.getExceptionForProblem(problem);
         Assertions.assertTrue(exception.isPresent());
-        Assertions.assertEquals(problem, ((DailyListAPIAddException)exception.get()).getProblem());
-        Assertions.assertEquals(CodeAndMessage.INVALID_XML, ((DailyListAPIAddException)exception.get()).getMapping().getMessage());
-        Assertions.assertEquals(PostDailyListErrorCode.DAILYLIST_DOCUMENT_CANT_BE_PARSED, ((DailyListAPIAddException)exception.get()).getMapping().getProblem());
+        Assertions.assertEquals(problem, ((DailyListAPIAddException) exception.get()).getProblem());
+        Assertions.assertEquals(
+            CodeAndMessage.INVALID_XML,
+            ((DailyListAPIAddException) exception.get()).getMapping().getMessage()
+        );
+        Assertions.assertEquals(
+            PostDailyListErrorCode.DAILYLIST_DOCUMENT_CANT_BE_PARSED,
+            ((DailyListAPIAddException) exception.get()).getMapping().getProblem()
+        );
     }
 
     @Test
-    public void testCourtNotFoundForAddDailyList(){
-        Problem problem = new Problem();
-        problem.setType(URI.create(PostDailyListErrorCode.DAILYLIST_COURT_HOUSE_NOT_FOUND.getValue()));
+    void testCourtNotFoundForAddDailyList() {
+        PostDailyListErrorCode problemCode = PostDailyListErrorCode.DAILYLIST_COURT_HOUSE_NOT_FOUND;
+        URI uriType = URI.create(problemCode.getValue());
+        problem.setType(uriType);
         Optional<ClientProblemException> exception = responseMapper.getExceptionForProblem(problem);
         Assertions.assertTrue(exception.isPresent());
-        Assertions.assertEquals(problem, ((DailyListAPIAddException)exception.get()).getProblem());
-        Assertions.assertEquals(CodeAndMessage.NOT_FOUND_COURTHOUSE, ((DailyListAPIAddException)exception.get()).getMapping().getMessage());
-        Assertions.assertEquals(PostDailyListErrorCode.DAILYLIST_COURT_HOUSE_NOT_FOUND, ((DailyListAPIAddException)exception.get()).getMapping().getProblem());
+        Assertions.assertEquals(problem, ((DailyListAPIAddException) exception.get()).getProblem());
+        Assertions.assertEquals(
+            CodeAndMessage.NOT_FOUND_COURTHOUSE,
+            ((DailyListAPIAddException) exception.get()).getMapping().getMessage()
+        );
+        Assertions.assertEquals(
+            PostDailyListErrorCode.DAILYLIST_COURT_HOUSE_NOT_FOUND,
+            ((DailyListAPIAddException) exception.get()).getMapping().getProblem()
+        );
     }
 
     @Test
-    public void testCourtHandlerNotFoundForAddDailyList(){
-        Problem problem = new Problem();
-        problem.setType(URI.create(PostDailyListErrorCode.DAILYLIST_PROCESSOR_NOT_FOUND.getValue()));
+    void testCourtHandlerNotFoundForAddDailyList() {
+        PostDailyListErrorCode problemCode = PostDailyListErrorCode.DAILYLIST_PROCESSOR_NOT_FOUND;
+        URI uriType = URI.create(problemCode.getValue());
+        problem.setType(uriType);
         Optional<ClientProblemException> exception = responseMapper.getExceptionForProblem(problem);
         Assertions.assertTrue(exception.isPresent());
-        Assertions.assertEquals(problem, ((DailyListAPIAddException)exception.get()).getProblem());
-        Assertions.assertEquals(CodeAndMessage.NOT_FOUND_HANLDER, ((DailyListAPIAddException)exception.get()).getMapping().getMessage());
-        Assertions.assertEquals(PostDailyListErrorCode.DAILYLIST_PROCESSOR_NOT_FOUND, ((DailyListAPIAddException)exception.get()).getMapping().getProblem());
+        Assertions.assertEquals(problem, ((DailyListAPIAddException) exception.get()).getProblem());
+        Assertions.assertEquals(
+            CodeAndMessage.NOT_FOUND_HANLDER,
+            ((DailyListAPIAddException) exception.get()).getMapping().getMessage()
+        );
+        Assertions.assertEquals(
+            PostDailyListErrorCode.DAILYLIST_PROCESSOR_NOT_FOUND,
+            ((DailyListAPIAddException) exception.get()).getMapping().getProblem()
+        );
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/common/client/mapper/DailyListAPIErrorResponseMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/client/mapper/DailyListAPIErrorResponseMapperTest.java
@@ -1,0 +1,59 @@
+package uk.gov.hmcts.darts.common.client.mapper;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.darts.common.client.exeption.ClientProblemException;
+import uk.gov.hmcts.darts.common.client.exeption.dailylist.DailyListAPIAddException;
+import uk.gov.hmcts.darts.model.audio.Problem;
+import uk.gov.hmcts.darts.model.dailylist.PostDailyListErrorCode;
+import uk.gov.hmcts.darts.ws.CodeAndMessage;
+
+import java.net.URI;
+import java.util.Optional;
+
+public class DailyListAPIErrorResponseMapperTest {
+    private DailyListAPIProblemResponseMapper responseMapper;
+
+    private Problem problem;
+
+    @BeforeEach
+    public void before()
+    {
+        responseMapper = new DailyListAPIProblemResponseMapper();
+        problem = new Problem();
+    }
+
+    @Test
+    public void testDocumentParseExceptionForAddDailyList(){
+        Problem problem = new Problem();
+        problem.setType(URI.create(PostDailyListErrorCode.DAILYLIST_DOCUMENT_CANT_BE_PARSED.getValue()));
+        Optional<ClientProblemException> exception = responseMapper.getExceptionForProblem(problem);
+        Assertions.assertTrue(exception.isPresent());
+        Assertions.assertEquals(problem, ((DailyListAPIAddException)exception.get()).getProblem());
+        Assertions.assertEquals(CodeAndMessage.INVALID_XML, ((DailyListAPIAddException)exception.get()).getMapping().getMessage());
+        Assertions.assertEquals(PostDailyListErrorCode.DAILYLIST_DOCUMENT_CANT_BE_PARSED, ((DailyListAPIAddException)exception.get()).getMapping().getProblem());
+    }
+
+    @Test
+    public void testCourtNotFoundForAddDailyList(){
+        Problem problem = new Problem();
+        problem.setType(URI.create(PostDailyListErrorCode.DAILYLIST_COURT_HOUSE_NOT_FOUND.getValue()));
+        Optional<ClientProblemException> exception = responseMapper.getExceptionForProblem(problem);
+        Assertions.assertTrue(exception.isPresent());
+        Assertions.assertEquals(problem, ((DailyListAPIAddException)exception.get()).getProblem());
+        Assertions.assertEquals(CodeAndMessage.NOT_FOUND_COURTHOUSE, ((DailyListAPIAddException)exception.get()).getMapping().getMessage());
+        Assertions.assertEquals(PostDailyListErrorCode.DAILYLIST_COURT_HOUSE_NOT_FOUND, ((DailyListAPIAddException)exception.get()).getMapping().getProblem());
+    }
+
+    @Test
+    public void testCourtHandlerNotFoundForAddDailyList(){
+        Problem problem = new Problem();
+        problem.setType(URI.create(PostDailyListErrorCode.DAILYLIST_PROCESSOR_NOT_FOUND.getValue()));
+        Optional<ClientProblemException> exception = responseMapper.getExceptionForProblem(problem);
+        Assertions.assertTrue(exception.isPresent());
+        Assertions.assertEquals(problem, ((DailyListAPIAddException)exception.get()).getProblem());
+        Assertions.assertEquals(CodeAndMessage.NOT_FOUND_HANLDER, ((DailyListAPIAddException)exception.get()).getMapping().getMessage());
+        Assertions.assertEquals(PostDailyListErrorCode.DAILYLIST_PROCESSOR_NOT_FOUND, ((DailyListAPIAddException)exception.get()).getMapping().getProblem());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/darts/common/client/mapper/EventAPIErrorResponseMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/client/mapper/EventAPIErrorResponseMapperTest.java
@@ -3,7 +3,7 @@ package uk.gov.hmcts.darts.common.client.mapper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import uk.gov.hmcts.darts.common.client.exeption.*;
+import uk.gov.hmcts.darts.common.client.exeption.ClientProblemException;
 import uk.gov.hmcts.darts.common.client.exeption.event.EventAPIGetCourtLogExeption;
 import uk.gov.hmcts.darts.common.client.exeption.event.EventAPIPostCourtLogException;
 import uk.gov.hmcts.darts.common.client.exeption.event.EventAPIPostEventException;
@@ -16,7 +16,7 @@ import uk.gov.hmcts.darts.ws.CodeAndMessage;
 import java.net.URI;
 import java.util.Optional;
 
-public class EventAPIErrorResponseMapperTest {
+class EventAPIErrorResponseMapperTest {
 
     private EventAPIProblemResponseMapper responseMapper;
 
@@ -29,9 +29,10 @@ public class EventAPIErrorResponseMapperTest {
     }
 
     @Test
-    public void testProcessorNotFoundForNewEvent() {
-        Problem problem = new Problem();
-        problem.setType(URI.create(EventErrorCode.PROCESSOR_NOT_FOUND.getValue()));
+    void testProcessorNotFoundForNewEvent() {
+        EventErrorCode problemCode = EventErrorCode.PROCESSOR_NOT_FOUND;
+        URI uriType = URI.create(problemCode.getValue());
+        problem.setType(uriType);
         Optional<ClientProblemException> exception = responseMapper.getExceptionForProblem(problem);
         Assertions.assertTrue(exception.isPresent());
         Assertions.assertTrue(exception.get() instanceof EventAPIPostEventException);
@@ -47,9 +48,10 @@ public class EventAPIErrorResponseMapperTest {
     }
 
     @Test
-    public void testCourtNotFoundForNewEvent() {
-        Problem problem = new Problem();
-        problem.setType(URI.create(EventErrorCode.EVENT_COURT_HOUSE_NOT_FOUND.getValue()));
+    void testCourtNotFoundForNewEvent() {
+        EventErrorCode problemCode = EventErrorCode.EVENT_COURT_HOUSE_NOT_FOUND;
+        URI uriType = URI.create(problemCode.getValue());
+        problem.setType(uriType);
         Optional<ClientProblemException> exception = responseMapper.getExceptionForProblem(problem);
         Assertions.assertTrue(exception.isPresent());
         Assertions.assertTrue(exception.get() instanceof EventAPIPostEventException);
@@ -65,9 +67,10 @@ public class EventAPIErrorResponseMapperTest {
     }
 
     @Test
-    public void testCourtDocumentCantBeParsedForNewEvent() {
-        Problem problem = new Problem();
-        problem.setType(URI.create(EventErrorCode.EVENT_DOCUMENT_CANT_PARSED.getValue()));
+    void testCourtDocumentCantBeParsedForNewEvent() {
+        EventErrorCode problemCode = EventErrorCode.EVENT_DOCUMENT_CANT_PARSED;
+        URI uriType = URI.create(problemCode.getValue());
+        problem.setType(uriType);
         Optional<ClientProblemException> exception = responseMapper.getExceptionForProblem(problem);
         Assertions.assertTrue(exception.isPresent());
         Assertions.assertTrue(exception.get() instanceof EventAPIPostEventException);
@@ -83,9 +86,10 @@ public class EventAPIErrorResponseMapperTest {
     }
 
     @Test
-    public void testGetCourtLogs() {
-        Problem problem = new Problem();
-        problem.setType(URI.create(GetCourtLogsErrorCode.COURTLOG_COURT_HOUSE_NOT_FOUND.getValue()));
+    void testGetCourtLogs() {
+        GetCourtLogsErrorCode problemCode = GetCourtLogsErrorCode.COURTLOG_COURT_HOUSE_NOT_FOUND;
+        URI uriType = URI.create(problemCode.getValue());
+        problem.setType(uriType);
         Optional<ClientProblemException> exception = responseMapper.getExceptionForProblem(problem);
         Assertions.assertTrue(exception.isPresent());
         Assertions.assertTrue(exception.get() instanceof EventAPIGetCourtLogExeption);
@@ -101,12 +105,13 @@ public class EventAPIErrorResponseMapperTest {
     }
 
     @Test
-    public void testDocumentCantBeParsedWhenAddingCourtLogs() {
-        Problem problem = new Problem();
-        problem.setType(URI.create(PostCourtLogsErrorCode.COURTLOG_DOCUMENT_CANT_BE_PARSED.getValue()));
+    void testDocumentCantBeParsedWhenAddingCourtLogs() {
+        PostCourtLogsErrorCode problemCode = PostCourtLogsErrorCode.COURTLOG_DOCUMENT_CANT_BE_PARSED;
+        URI uriType = URI.create(problemCode.getValue());
+        problem.setType(uriType);
         Optional<ClientProblemException> exception = responseMapper.getExceptionForProblem(problem);
         Assertions.assertTrue(exception.isPresent());
-        Assertions.assertTrue(exception.get() instanceof EventAPIGetCourtLogExeption);
+        Assertions.assertTrue(exception.get() instanceof EventAPIPostCourtLogException);
         Assertions.assertEquals(problem, ((EventAPIPostCourtLogException) exception.get()).getProblem());
         Assertions.assertEquals(
             CodeAndMessage.INVALID_XML,
@@ -119,12 +124,13 @@ public class EventAPIErrorResponseMapperTest {
     }
 
     @Test
-    public void testCourtHouseNotFoundWhenAddingCourtLogs() {
-        Problem problem = new Problem();
-        problem.setType(URI.create(PostCourtLogsErrorCode.COURTLOG_COURT_HOUSE_NOT_FOUND.getValue()));
+    void testCourtHouseNotFoundWhenAddingCourtLogs() {
+        PostCourtLogsErrorCode problemCode = PostCourtLogsErrorCode.COURTLOG_COURT_HOUSE_NOT_FOUND;
+        URI uriType = URI.create(problemCode.getValue());
+        problem.setType(uriType);
         Optional<ClientProblemException> exception = responseMapper.getExceptionForProblem(problem);
         Assertions.assertTrue(exception.isPresent());
-        Assertions.assertTrue(exception.get() instanceof EventAPIGetCourtLogExeption);
+        Assertions.assertTrue(exception.get() instanceof EventAPIPostCourtLogException);
         Assertions.assertEquals(problem, ((EventAPIPostCourtLogException) exception.get()).getProblem());
         Assertions.assertEquals(
             CodeAndMessage.NOT_FOUND_COURTHOUSE,

--- a/src/test/java/uk/gov/hmcts/darts/common/client/mapper/EventAPIErrorResponseMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/client/mapper/EventAPIErrorResponseMapperTest.java
@@ -1,0 +1,138 @@
+package uk.gov.hmcts.darts.common.client.mapper;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.darts.common.client.exeption.*;
+import uk.gov.hmcts.darts.common.client.exeption.event.EventAPIGetCourtLogExeption;
+import uk.gov.hmcts.darts.common.client.exeption.event.EventAPIPostCourtLogException;
+import uk.gov.hmcts.darts.common.client.exeption.event.EventAPIPostEventException;
+import uk.gov.hmcts.darts.model.audio.Problem;
+import uk.gov.hmcts.darts.model.event.EventErrorCode;
+import uk.gov.hmcts.darts.model.event.GetCourtLogsErrorCode;
+import uk.gov.hmcts.darts.model.event.PostCourtLogsErrorCode;
+import uk.gov.hmcts.darts.ws.CodeAndMessage;
+
+import java.net.URI;
+import java.util.Optional;
+
+public class EventAPIErrorResponseMapperTest {
+
+    private EventAPIProblemResponseMapper responseMapper;
+
+    private Problem problem;
+
+    @BeforeEach
+    public void before() {
+        responseMapper = new EventAPIProblemResponseMapper();
+        problem = new Problem();
+    }
+
+    @Test
+    public void testProcessorNotFoundForNewEvent() {
+        Problem problem = new Problem();
+        problem.setType(URI.create(EventErrorCode.PROCESSOR_NOT_FOUND.getValue()));
+        Optional<ClientProblemException> exception = responseMapper.getExceptionForProblem(problem);
+        Assertions.assertTrue(exception.isPresent());
+        Assertions.assertTrue(exception.get() instanceof EventAPIPostEventException);
+        Assertions.assertEquals(problem, ((EventAPIPostEventException) exception.get()).getProblem());
+        Assertions.assertEquals(
+            CodeAndMessage.NOT_FOUND_HANLDER,
+            ((EventAPIPostEventException) exception.get()).getMapping().getMessage()
+        );
+        Assertions.assertEquals(
+            EventErrorCode.PROCESSOR_NOT_FOUND,
+            ((EventAPIPostEventException) exception.get()).getMapping().getProblem()
+        );
+    }
+
+    @Test
+    public void testCourtNotFoundForNewEvent() {
+        Problem problem = new Problem();
+        problem.setType(URI.create(EventErrorCode.EVENT_COURT_HOUSE_NOT_FOUND.getValue()));
+        Optional<ClientProblemException> exception = responseMapper.getExceptionForProblem(problem);
+        Assertions.assertTrue(exception.isPresent());
+        Assertions.assertTrue(exception.get() instanceof EventAPIPostEventException);
+        Assertions.assertEquals(problem, ((EventAPIPostEventException) exception.get()).getProblem());
+        Assertions.assertEquals(
+            CodeAndMessage.NOT_FOUND_COURTHOUSE,
+            ((EventAPIPostEventException) exception.get()).getMapping().getMessage()
+        );
+        Assertions.assertEquals(
+            EventErrorCode.EVENT_COURT_HOUSE_NOT_FOUND,
+            ((EventAPIPostEventException) exception.get()).getMapping().getProblem()
+        );
+    }
+
+    @Test
+    public void testCourtDocumentCantBeParsedForNewEvent() {
+        Problem problem = new Problem();
+        problem.setType(URI.create(EventErrorCode.EVENT_DOCUMENT_CANT_PARSED.getValue()));
+        Optional<ClientProblemException> exception = responseMapper.getExceptionForProblem(problem);
+        Assertions.assertTrue(exception.isPresent());
+        Assertions.assertTrue(exception.get() instanceof EventAPIPostEventException);
+        Assertions.assertEquals(problem, ((EventAPIPostEventException) exception.get()).getProblem());
+        Assertions.assertEquals(
+            CodeAndMessage.INVALID_XML,
+            ((EventAPIPostEventException) exception.get()).getMapping().getMessage()
+        );
+        Assertions.assertEquals(
+            EventErrorCode.EVENT_DOCUMENT_CANT_PARSED,
+            ((EventAPIPostEventException) exception.get()).getMapping().getProblem()
+        );
+    }
+
+    @Test
+    public void testGetCourtLogs() {
+        Problem problem = new Problem();
+        problem.setType(URI.create(GetCourtLogsErrorCode.COURTLOG_COURT_HOUSE_NOT_FOUND.getValue()));
+        Optional<ClientProblemException> exception = responseMapper.getExceptionForProblem(problem);
+        Assertions.assertTrue(exception.isPresent());
+        Assertions.assertTrue(exception.get() instanceof EventAPIGetCourtLogExeption);
+        Assertions.assertEquals(problem, ((EventAPIGetCourtLogExeption) exception.get()).getProblem());
+        Assertions.assertEquals(
+            CodeAndMessage.NOT_FOUND_COURTHOUSE,
+            ((EventAPIGetCourtLogExeption) exception.get()).getMapping().getMessage()
+        );
+        Assertions.assertEquals(
+            GetCourtLogsErrorCode.COURTLOG_COURT_HOUSE_NOT_FOUND,
+            ((EventAPIGetCourtLogExeption) exception.get()).getMapping().getProblem()
+        );
+    }
+
+    @Test
+    public void testDocumentCantBeParsedWhenAddingCourtLogs() {
+        Problem problem = new Problem();
+        problem.setType(URI.create(PostCourtLogsErrorCode.COURTLOG_DOCUMENT_CANT_BE_PARSED.getValue()));
+        Optional<ClientProblemException> exception = responseMapper.getExceptionForProblem(problem);
+        Assertions.assertTrue(exception.isPresent());
+        Assertions.assertTrue(exception.get() instanceof EventAPIGetCourtLogExeption);
+        Assertions.assertEquals(problem, ((EventAPIPostCourtLogException) exception.get()).getProblem());
+        Assertions.assertEquals(
+            CodeAndMessage.INVALID_XML,
+            ((EventAPIPostCourtLogException) exception.get()).getMapping().getMessage()
+        );
+        Assertions.assertEquals(
+            PostCourtLogsErrorCode.COURTLOG_DOCUMENT_CANT_BE_PARSED,
+            ((EventAPIPostCourtLogException) exception.get()).getMapping().getProblem()
+        );
+    }
+
+    @Test
+    public void testCourtHouseNotFoundWhenAddingCourtLogs() {
+        Problem problem = new Problem();
+        problem.setType(URI.create(PostCourtLogsErrorCode.COURTLOG_COURT_HOUSE_NOT_FOUND.getValue()));
+        Optional<ClientProblemException> exception = responseMapper.getExceptionForProblem(problem);
+        Assertions.assertTrue(exception.isPresent());
+        Assertions.assertTrue(exception.get() instanceof EventAPIGetCourtLogExeption);
+        Assertions.assertEquals(problem, ((EventAPIPostCourtLogException) exception.get()).getProblem());
+        Assertions.assertEquals(
+            CodeAndMessage.NOT_FOUND_COURTHOUSE,
+            ((EventAPIPostCourtLogException) exception.get()).getMapping().getMessage()
+        );
+        Assertions.assertEquals(
+            PostCourtLogsErrorCode.COURTLOG_COURT_HOUSE_NOT_FOUND,
+            ((EventAPIPostCourtLogException) exception.get()).getMapping().getProblem()
+        );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/darts/common/exception/ClientProblemDecoderTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/exception/ClientProblemDecoderTest.java
@@ -1,0 +1,93 @@
+package uk.gov.hmcts.darts.common.exception;
+
+import feign.Response;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import uk.gov.hmcts.darts.common.client.exeption.ClientProblemException;
+import uk.gov.hmcts.darts.common.client.exeption.JacksonClientProblemDecoder;
+import uk.gov.hmcts.darts.common.client.mapper.APIProblemResponseMapper;
+import uk.gov.hmcts.darts.model.audio.Problem;
+import uk.gov.hmcts.darts.utilities.TestUtils;
+import uk.gov.hmcts.darts.ws.CodeAndMessage;
+import uk.gov.hmcts.darts.ws.DartsException;
+
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class ClientProblemDecoderTest {
+
+    private Response response;
+
+
+    private void setupSuccessResponse() throws Exception {
+        response = Mockito.mock(Response.class);
+        Response.Body body = Mockito.mock(Response.Body.class);
+
+        Mockito.when(response.body()).thenReturn(body);
+
+        String dartsApiResponseStr = TestUtils.getContentsFromFile(
+                "tests/client/error/problemResponse.json");
+
+        Mockito.when(body.asInputStream()).thenReturn(new ByteArrayInputStream(dartsApiResponseStr.getBytes()));
+    }
+
+    @Test
+    public void testDecoderNoProblemMapperFound() throws Exception {
+        setupSuccessResponse();
+
+        APIProblemResponseMapper mapper = Mockito.mock(APIProblemResponseMapper.class);
+        Mockito.when(mapper.getExceptionForProblem(Mockito.any(Problem.class))).thenReturn(Optional.empty());
+
+        List<APIProblemResponseMapper> responseMappers = new ArrayList<>();
+        responseMappers.add(mapper);
+
+        Exception exception = new JacksonClientProblemDecoder(responseMappers).decode("", response);
+
+        Assertions.assertTrue(ClientProblemException.class.isAssignableFrom(exception.getClass()));
+        Assertions.assertNotNull(((ClientProblemException) exception).getProblem());
+        Assertions.assertEquals(CodeAndMessage.ERROR, ((ClientProblemException) exception).getCodeAndMessage());
+    }
+
+    @Test
+    public void testDecoderErrorsException() throws Exception {
+        setupSuccessResponse();
+
+        ClientProblemException exceptionToReturn = new ClientProblemException(null);
+        APIProblemResponseMapper mapper = Mockito.mock(APIProblemResponseMapper.class);
+        Mockito.when(mapper.getExceptionForProblem(Mockito.any(Problem.class))).thenReturn(Optional.of(exceptionToReturn));
+
+        List<APIProblemResponseMapper> responseMappers = new ArrayList<>();
+        responseMappers.add(mapper);
+
+        Exception exception = new JacksonClientProblemDecoder(responseMappers).decode("", response);
+        Assertions.assertTrue(ClientProblemException.class.isAssignableFrom(exception.getClass()));
+        Assertions.assertSame(exception, exceptionToReturn);
+    }
+
+    @Test
+    public void testDecoderProblemParsingException() throws Exception {
+        response = Mockito.mock(Response.class);
+        Response.Body body = Mockito.mock(Response.Body.class);
+
+        Mockito.when(response.body()).thenReturn(body);
+
+        String dartsApiResponseStr = TestUtils.getContentsFromFile(
+                "tests/client/error/invalidProblemResponse.json");
+
+        Mockito.when(body.asInputStream()).thenReturn(new ByteArrayInputStream(dartsApiResponseStr.getBytes()));
+
+        ClientProblemException exceptionToReturn = new ClientProblemException(null);
+        APIProblemResponseMapper mapper = Mockito.mock(APIProblemResponseMapper.class);
+        Mockito.when(mapper.getExceptionForProblem(Mockito.any(Problem.class))).thenReturn(Optional.of(exceptionToReturn));
+
+        List<APIProblemResponseMapper> responseMappers = new ArrayList<>();
+        responseMappers.add(mapper);
+
+        Exception exception = new JacksonClientProblemDecoder(responseMappers).decode("", response);
+        Assertions.assertTrue(exception.getClass().equals(DartsException.class));
+        Assertions.assertEquals(CodeAndMessage.ERROR, ((DartsException) exception).getCodeAndMessage());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/darts/common/exception/ClientProblemDecoderTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/exception/ClientProblemDecoderTest.java
@@ -17,7 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-public class ClientProblemDecoderTest {
+class ClientProblemDecoderTest {
 
     private Response response;
 
@@ -35,7 +35,7 @@ public class ClientProblemDecoderTest {
     }
 
     @Test
-    public void testDecoderNoProblemMapperFound() throws Exception {
+    void testDecoderNoProblemMapperFound() throws Exception {
         setupSuccessResponse();
 
         APIProblemResponseMapper mapper = Mockito.mock(APIProblemResponseMapper.class);
@@ -52,7 +52,7 @@ public class ClientProblemDecoderTest {
     }
 
     @Test
-    public void testDecoderErrorsException() throws Exception {
+    void testDecoderErrorsException() throws Exception {
         setupSuccessResponse();
 
         ClientProblemException exceptionToReturn = new ClientProblemException(null);
@@ -68,7 +68,7 @@ public class ClientProblemDecoderTest {
     }
 
     @Test
-    public void testDecoderProblemParsingException() throws Exception {
+    void testDecoderProblemParsingException() throws Exception {
         response = Mockito.mock(Response.class);
         Response.Body body = Mockito.mock(Response.Body.class);
 
@@ -87,7 +87,7 @@ public class ClientProblemDecoderTest {
         responseMappers.add(mapper);
 
         Exception exception = new JacksonClientProblemDecoder(responseMappers).decode("", response);
-        Assertions.assertTrue(exception.getClass().equals(DartsException.class));
+        Assertions.assertEquals(DartsException.class, exception.getClass());
         Assertions.assertEquals(CodeAndMessage.ERROR, ((DartsException) exception).getCodeAndMessage());
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/courtlogs/GetCourtLogsMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/courtlogs/GetCourtLogsMapperTest.java
@@ -27,14 +27,14 @@ class GetCourtLogsMapperTest {
         var legacyCourtLog = courtLogsMapper.toLegacyApi(emptyCourtLogs);
 
         assertThat(legacyCourtLog).isInstanceOf(GetCourtLogResponse.class);
-        assertThat(legacyCourtLog.getReturn().getCourtLog()).isNull();
+        assertThat(legacyCourtLog.getCourtLog()).isNull();
     }
 
     @Test
     void mapsToLegacyApi() {
         var dartsApiCourtLogs = someCourtLogs(2);
 
-        var legacyCourtLog = courtLogsMapper.toLegacyApi(dartsApiCourtLogs).getReturn().getCourtLog();
+        var legacyCourtLog = courtLogsMapper.toLegacyApi(dartsApiCourtLogs).getCourtLog();
 
         verifyThat(legacyCourtLog).isCorrectlyMappedFrom(dartsApiCourtLogs);
     }

--- a/src/test/java/uk/gov/hmcts/darts/courtlogs/GetCourtLogsMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/courtlogs/GetCourtLogsMapperTest.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.darts.courtlogs;
 
-import com.service.mojdarts.synapps.com.GetCourtLogResponse;
+import com.synapps.moj.dfs.response.GetCourtLogResponse;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.darts.common.util.DateConverters;
 import uk.gov.hmcts.darts.model.event.CourtLog;

--- a/src/test/java/uk/gov/hmcts/darts/ws/DartsEndpointHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/ws/DartsEndpointHandlerTest.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.darts.ws;
+
+import com.synapps.moj.dfs.response.DARTSResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class DartsEndpointHandlerTest {
+
+    private CodeAndMessage assertMessage = CodeAndMessage.NOT_FOUND_COURTHOUSE;
+
+    @Test
+    public void testEndpointExecution() {
+        DARTSResponse response = new DartsEndpointHandler().makeAPICall(
+            "",
+            this::executeWithCourtHouseError,
+            () -> new DARTSResponse()
+        );
+
+        Assertions.assertEquals(assertMessage.getCode(), response.getCode());
+        Assertions.assertEquals(assertMessage.getMessage(), response.getMessage());
+    }
+
+    private DARTSResponse executeWithCourtHouseError() {
+        throw new DartsException(null, assertMessage);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/darts/ws/DartsEndpointHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/ws/DartsEndpointHandlerTest.java
@@ -4,12 +4,12 @@ import com.synapps.moj.dfs.response.DARTSResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class DartsEndpointHandlerTest {
+class DartsEndpointHandlerTest {
 
-    private CodeAndMessage assertMessage = CodeAndMessage.NOT_FOUND_COURTHOUSE;
+    private final CodeAndMessage assertMessage = CodeAndMessage.NOT_FOUND_COURTHOUSE;
 
     @Test
-    public void testEndpointExecution() {
+    void testEndpointExecution() {
         DARTSResponse response = new DartsEndpointHandler().makeAPICall(
             "",
             this::executeWithCourtHouseError,

--- a/src/test/resources/tests/cases/GetCasesMapperTest/mapOk/expectedResponse.json
+++ b/src/test/resources/tests/cases/GetCasesMapperTest/mapOk/expectedResponse.json
@@ -1,229 +1,227 @@
 {
-  "return": {
-    "cases": {
-      "case": [
-        {
-          "caseNumber": "Case0000001",
-          "scheduledStart": "09:00",
-          "defendants": {
-            "defendant": [
-              "Mr Defendant0000001 Bloggs1",
-              "Mr Defendant0000001 Bloggs2"
-            ]
-          },
-          "judges": {
-            "judge": [
-              "Judge1"
-            ]
-          },
-          "prosecutors": {
-            "prosecutor": [
-              "Prosecutor00000011",
-              "Prosecutor00000012"
-            ]
-          },
-          "defenders": {
-            "defender": [
-              "Defence00000011",
-              "Defence00000012"
-            ]
-          }
+  "cases": {
+    "case": [
+      {
+        "caseNumber": "Case0000001",
+        "scheduledStart": "09:00",
+        "defendants": {
+          "defendant": [
+            "Mr Defendant0000001 Bloggs1",
+            "Mr Defendant0000001 Bloggs2"
+          ]
         },
-        {
-          "caseNumber": "Case0000002",
-          "scheduledStart": "10:00",
-          "defendants": {
-            "defendant": [
-              "Mr Defendant0000002 Bloggs1",
-              "Mr Defendant0000002 Bloggs2"
-            ]
-          },
-          "judges": {
-            "judge": [
-              "Judge1"
-            ]
-          },
-          "prosecutors": {
-            "prosecutor": [
-              "Prosecutor00000021",
-              "Prosecutor00000022"
-            ]
-          },
-          "defenders": {
-            "defender": [
-              "Defence00000021",
-              "Defence00000022"
-            ]
-          }
+        "judges": {
+          "judge": [
+            "Judge1"
+          ]
         },
-        {
-          "caseNumber": "Case0000003",
-          "scheduledStart": "11:00",
-          "defendants": {
-            "defendant": [
-              "Mr Defendant0000003 Bloggs1",
-              "Mr Defendant0000003 Bloggs2"
-            ]
-          },
-          "judges": {
-            "judge": [
-              "Judge1"
-            ]
-          },
-          "prosecutors": {
-            "prosecutor": [
-              "Prosecutor00000031",
-              "Prosecutor00000032"
-            ]
-          },
-          "defenders": {
-            "defender": [
-              "Defence00000031",
-              "Defence00000032"
-            ]
-          }
+        "prosecutors": {
+          "prosecutor": [
+            "Prosecutor00000011",
+            "Prosecutor00000012"
+          ]
         },
-        {
-          "caseNumber": "Case0000004",
-          "scheduledStart": "12:00",
-          "defendants": {
-            "defendant": [
-              "Mr Defendant0000004 Bloggs1",
-              "Mr Defendant0000004 Bloggs2"
-            ]
-          },
-          "judges": {
-            "judge": [
-              "Judge1"
-            ]
-          },
-          "prosecutors": {
-            "prosecutor": [
-              "Prosecutor00000041",
-              "Prosecutor00000042"
-            ]
-          },
-          "defenders": {
-            "defender": [
-              "Defence00000041",
-              "Defence00000042"
-            ]
-          }
-        },
-        {
-          "caseNumber": "Case0000005",
-          "scheduledStart": "13:00",
-          "defendants": {
-            "defendant": [
-              "Mr Defendant0000005 Bloggs1",
-              "Mr Defendant0000005 Bloggs2"
-            ]
-          },
-          "judges": {
-            "judge": [
-              "Judge1"
-            ]
-          },
-          "prosecutors": {
-            "prosecutor": [
-              "Prosecutor00000051",
-              "Prosecutor00000052"
-            ]
-          },
-          "defenders": {
-            "defender": [
-              "Defence00000051",
-              "Defence00000052"
-            ]
-          }
-        },
-        {
-          "caseNumber": "Case0000006",
-          "scheduledStart": "14:00",
-          "defendants": {
-            "defendant": [
-              "Mr Defendant0000006 Bloggs1",
-              "Mr Defendant0000006 Bloggs2"
-            ]
-          },
-          "judges": {
-            "judge": [
-              "Judge1"
-            ]
-          },
-          "prosecutors": {
-            "prosecutor": [
-              "Prosecutor00000061",
-              "Prosecutor00000062"
-            ]
-          },
-          "defenders": {
-            "defender": [
-              "Defence00000061",
-              "Defence00000062"
-            ]
-          }
-        },
-        {
-          "caseNumber": "Case0000007",
-          "scheduledStart": "15:00",
-          "defendants": {
-            "defendant": [
-              "Mr Defendant0000007 Bloggs1",
-              "Mr Defendant0000007 Bloggs2"
-            ]
-          },
-          "judges": {
-            "judge": [
-              "Judge1"
-            ]
-          },
-          "prosecutors": {
-            "prosecutor": [
-              "Prosecutor00000071",
-              "Prosecutor00000072"
-            ]
-          },
-          "defenders": {
-            "defender": [
-              "Defence00000071",
-              "Defence00000072"
-            ]
-          }
-        },
-        {
-          "caseNumber": "Case0000008",
-          "scheduledStart": "16:00",
-          "defendants": {
-            "defendant": [
-              "Mr Defendant0000008 Bloggs1",
-              "Mr Defendant0000008 Bloggs2"
-            ]
-          },
-          "judges": {
-            "judge": [
-              "Judge1"
-            ]
-          },
-          "prosecutors": {
-            "prosecutor": [
-              "Prosecutor00000081",
-              "Prosecutor00000082"
-            ]
-          },
-          "defenders": {
-            "defender": [
-              "Defence00000081",
-              "Defence00000082"
-            ]
-          }
+        "defenders": {
+          "defender": [
+            "Defence00000011",
+            "Defence00000012"
+          ]
         }
-      ],
-      "courthouse": "Swansea",
-      "courtroom": "1",
-      "y": "2023",
-      "m": "6",
-      "d": "20"
-    }
+      },
+      {
+        "caseNumber": "Case0000002",
+        "scheduledStart": "10:00",
+        "defendants": {
+          "defendant": [
+            "Mr Defendant0000002 Bloggs1",
+            "Mr Defendant0000002 Bloggs2"
+          ]
+        },
+        "judges": {
+          "judge": [
+            "Judge1"
+          ]
+        },
+        "prosecutors": {
+          "prosecutor": [
+            "Prosecutor00000021",
+            "Prosecutor00000022"
+          ]
+        },
+        "defenders": {
+          "defender": [
+            "Defence00000021",
+            "Defence00000022"
+          ]
+        }
+      },
+      {
+        "caseNumber": "Case0000003",
+        "scheduledStart": "11:00",
+        "defendants": {
+          "defendant": [
+            "Mr Defendant0000003 Bloggs1",
+            "Mr Defendant0000003 Bloggs2"
+          ]
+        },
+        "judges": {
+          "judge": [
+            "Judge1"
+          ]
+        },
+        "prosecutors": {
+          "prosecutor": [
+            "Prosecutor00000031",
+            "Prosecutor00000032"
+          ]
+        },
+        "defenders": {
+          "defender": [
+            "Defence00000031",
+            "Defence00000032"
+          ]
+        }
+      },
+      {
+        "caseNumber": "Case0000004",
+        "scheduledStart": "12:00",
+        "defendants": {
+          "defendant": [
+            "Mr Defendant0000004 Bloggs1",
+            "Mr Defendant0000004 Bloggs2"
+          ]
+        },
+        "judges": {
+          "judge": [
+            "Judge1"
+          ]
+        },
+        "prosecutors": {
+          "prosecutor": [
+            "Prosecutor00000041",
+            "Prosecutor00000042"
+          ]
+        },
+        "defenders": {
+          "defender": [
+            "Defence00000041",
+            "Defence00000042"
+          ]
+        }
+      },
+      {
+        "caseNumber": "Case0000005",
+        "scheduledStart": "13:00",
+        "defendants": {
+          "defendant": [
+            "Mr Defendant0000005 Bloggs1",
+            "Mr Defendant0000005 Bloggs2"
+          ]
+        },
+        "judges": {
+          "judge": [
+            "Judge1"
+          ]
+        },
+        "prosecutors": {
+          "prosecutor": [
+            "Prosecutor00000051",
+            "Prosecutor00000052"
+          ]
+        },
+        "defenders": {
+          "defender": [
+            "Defence00000051",
+            "Defence00000052"
+          ]
+        }
+      },
+      {
+        "caseNumber": "Case0000006",
+        "scheduledStart": "14:00",
+        "defendants": {
+          "defendant": [
+            "Mr Defendant0000006 Bloggs1",
+            "Mr Defendant0000006 Bloggs2"
+          ]
+        },
+        "judges": {
+          "judge": [
+            "Judge1"
+          ]
+        },
+        "prosecutors": {
+          "prosecutor": [
+            "Prosecutor00000061",
+            "Prosecutor00000062"
+          ]
+        },
+        "defenders": {
+          "defender": [
+            "Defence00000061",
+            "Defence00000062"
+          ]
+        }
+      },
+      {
+        "caseNumber": "Case0000007",
+        "scheduledStart": "15:00",
+        "defendants": {
+          "defendant": [
+            "Mr Defendant0000007 Bloggs1",
+            "Mr Defendant0000007 Bloggs2"
+          ]
+        },
+        "judges": {
+          "judge": [
+            "Judge1"
+          ]
+        },
+        "prosecutors": {
+          "prosecutor": [
+            "Prosecutor00000071",
+            "Prosecutor00000072"
+          ]
+        },
+        "defenders": {
+          "defender": [
+            "Defence00000071",
+            "Defence00000072"
+          ]
+        }
+      },
+      {
+        "caseNumber": "Case0000008",
+        "scheduledStart": "16:00",
+        "defendants": {
+          "defendant": [
+            "Mr Defendant0000008 Bloggs1",
+            "Mr Defendant0000008 Bloggs2"
+          ]
+        },
+        "judges": {
+          "judge": [
+            "Judge1"
+          ]
+        },
+        "prosecutors": {
+          "prosecutor": [
+            "Prosecutor00000081",
+            "Prosecutor00000082"
+          ]
+        },
+        "defenders": {
+          "defender": [
+            "Defence00000081",
+            "Defence00000082"
+          ]
+        }
+      }
+    ],
+    "courthouse": "Swansea",
+    "courtroom": "1",
+    "y": "2023",
+    "m": "6",
+    "d": "20"
   }
 }

--- a/src/test/resources/tests/client/error/invalidProblemResponse.json
+++ b/src/test/resources/tests/client/error/invalidProblemResponse.json
@@ -1,0 +1,6 @@
+{
+  "type"
+  "title": "",
+  "status": 434,
+  "detail" : ""
+}

--- a/src/test/resources/tests/client/error/problemResponse.json
+++ b/src/test/resources/tests/client/error/problemResponse.json
@@ -1,0 +1,6 @@
+{
+  "type": "TEST_TYPE",
+  "title": "",
+  "status": 434,
+  "detail" : ""
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-499

### Change description ###

This PR adds an exception translation layer to translate the Restful request to the SOAP responses in line with the associated confluence page analysis (See confluence linked off the JIRA board)

This PR is the second of two:-

1) A PR related to adding a darts api enumeration to represent the Restful error codes (needed for legacy support) that are to be returned from the darts api (see PR https://github.com/hmcts/darts-api/pull/452)
2) A PR relating to adapting the darts apis error coeds to the correct SOAP responses (this PR)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No - Should not break anything as the nature of this ticket is to maintain consistency
```
