### PR TITLE
DMP-398: Fixing connectivity to darts stub

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -276,6 +276,11 @@ sourceSets {
 }
 
 dependencies {
+  implementation 'org.apache.tomcat.embed:tomcat-embed-core:10.1.15'
+  implementation 'org.apache.tomcat.embed:tomcat-embed-websocket:10.1.15'
+  implementation 'org.apache.tomcat.embed:tomcat-embed-el:10.1.15'
+  implementation 'org.apache.santuario:xmlsec:3.0.3'
+
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-aop'

--- a/charts/darts-gateway/Chart.yaml
+++ b/charts/darts-gateway/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for darts-gateway App
 name: darts-gateway
 home: https://github.com/hmcts/darts-gateway
-version: 0.0.15
+version: 0.0.16
 maintainers:
   - name: HMCTS darts team
 dependencies:

--- a/charts/darts-gateway/values.dev.template.yaml
+++ b/charts/darts-gateway/values.dev.template.yaml
@@ -15,5 +15,4 @@ java:
           alias: FUNC_TEST_ROPC_PASSWORD
   environment:
     DARTS_API_URL: https://darts-api.staging.platform.hmcts.net
-    DAR_NOTIFY_DEFAULT_URL: https://darts-stub-services.staging.platform.hmcts.net/VIQDARNotifyEvent/DARNotifyEvent.asmx
 

--- a/charts/darts-gateway/values.dev.template.yaml
+++ b/charts/darts-gateway/values.dev.template.yaml
@@ -15,3 +15,5 @@ java:
           alias: FUNC_TEST_ROPC_PASSWORD
   environment:
     DARTS_API_URL: https://darts-api.staging.platform.hmcts.net
+    DAR_NOTIFY_DEFAULT_URL: https://darts-stub-services.staging.platform.hmcts.net/VIQDARNotifyEvent/DARNotifyEvent.asmx
+

--- a/charts/darts-gateway/values.stg.template.yaml
+++ b/charts/darts-gateway/values.stg.template.yaml
@@ -4,3 +4,4 @@ java:
   ingressHost: ${SERVICE_FQDN}
   environment:
     DARTS_API_URL: https://darts-api.staging.platform.hmcts.net
+    DAR_NOTIFY_DEFAULT_URL: https://darts-stub-services.staging.platform.hmcts.net/VIQDARNotifyEvent/DARNotifyEvent.asmx

--- a/charts/darts-gateway/values.stg.template.yaml
+++ b/charts/darts-gateway/values.stg.template.yaml
@@ -4,4 +4,3 @@ java:
   ingressHost: ${SERVICE_FQDN}
   environment:
     DARTS_API_URL: https://darts-api.staging.platform.hmcts.net
-    DAR_NOTIFY_DEFAULT_URL: https://darts-stub-services.staging.platform.hmcts.net/VIQDARNotifyEvent/DARNotifyEvent.asmx

--- a/charts/darts-gateway/values.yaml
+++ b/charts/darts-gateway/values.yaml
@@ -19,5 +19,5 @@ java:
         - name: AppInsightsInstrumentationKey
           alias: azure.application-insights.instrumentation-key
   environment:
-    DAR_NOTIFY_DEFAULT_URL: http://localhost:8080/VIQDARNotifyEvent/DARNotifyEvent.asmx
+    DAR_NOTIFY_DEFAULT_URL: https://darts-stub-services.staging.platform.hmcts.net/VIQDARNotifyEvent/DARNotifyEvent.asmx
     DARTS_API_URL: https://darts-api.{{ .Values.global.environment }}.platform.hmcts.net


### PR DESCRIPTION
This will be temporary as the long term plan is to pass the url for the DAR node through from the darts api.

Regarding the new dependencies.  These are existing transitive dependencies and have been added to bump the versions due to vulnerabilities.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
