### PR TITLE
DMP-2115: Add functionality to support a stored jwt token for downstream commun…

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/AddAudioWebServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/AddAudioWebServiceTest.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.darts.ws;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.matching.RegexPattern;
 import com.service.mojdarts.synapps.com.AddAudioResponse;
-import com.service.mojdarts.synapps.com.GetCasesResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -29,15 +28,12 @@ import uk.gov.hmcts.darts.workflow.command.AddAudioMidTierCommand;
 import java.util.Optional;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -183,10 +179,10 @@ class AddAudioWebServiceTest extends IntegrationBase {
                                      Mockito.eq("downstreamtoken"))).thenReturn(true);
 
         when(mockOauthTokenGenerator.acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD))
-            .thenReturn( "downstreamtoken", "test", "downstreamrefresh", "downstreamrefreshoutsidecache");
+            .thenReturn("downstreamtoken", "test", "downstreamrefresh", "downstreamrefreshoutsidecache");
 
         authenticationStub.assertWithTokenHeader(client, () -> {
-            String soapRequestStr = TestUtils.getContentsFromFile(
+            final String soapRequestStr = TestUtils.getContentsFromFile(
                 "payloads/addAudio/register/soapRequest.xml");
 
             String dartsApiResponseStr = TestUtils.getContentsFromFile(

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/CasesWebServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/CasesWebServiceTest.java
@@ -23,14 +23,12 @@ import uk.gov.hmcts.darts.utils.TestUtils;
 import uk.gov.hmcts.darts.utils.client.SoapAssertionUtil;
 import uk.gov.hmcts.darts.utils.client.darts.DartsClientProvider;
 import uk.gov.hmcts.darts.utils.client.darts.DartsGatewayClient;
-import uk.gov.hmcts.darts.utils.matcher.MultipartDartsProxyContentPattern;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.mockito.Mockito.times;
@@ -146,11 +144,10 @@ class CasesWebServiceTest extends IntegrationBase {
 
         // setup the tokens so that we refresh the backend token before making the restful darts calls
         when(mockOauthTokenGenerator.acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD))
-            .thenReturn( "downstreamtoken", "test", "downstreamrefresh", "downstreamrefreshoutsidecache");
+            .thenReturn("downstreamtoken", "test", "downstreamrefresh", "downstreamrefreshoutsidecache");
 
         authenticationStub.assertWithTokenHeader(client, () -> {
-            String soapRequestStr = TestUtils.getContentsFromFile(
-                "payloads/getCases/soapRequest.xml");
+            String soapRequestStr = TestUtils.getContentsFromFile("payloads/getCases/soapRequest.xml");
 
             String dartsApiResponseStr = TestUtils.getContentsFromFile(
                 "payloads/getCases/dartsApiResponse.json");

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/ContextRegistryDocumentumToJwtServiceSharedTokenTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/ContextRegistryDocumentumToJwtServiceSharedTokenTest.java
@@ -15,8 +15,6 @@ import uk.gov.hmcts.darts.utils.CacheUtil;
 import uk.gov.hmcts.darts.utils.client.ctxt.ContextRegistryClient;
 import uk.gov.hmcts.darts.utils.client.ctxt.ContextRegistryClientProvider;
 
-import java.net.URL;
-
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/ContextRegistryDocumentumToJwtServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/ContextRegistryDocumentumToJwtServiceTest.java
@@ -1,7 +1,5 @@
 package uk.gov.hmcts.darts.ws;
 
-import documentum.contextreg.LookupResponse;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
@@ -12,12 +10,8 @@ import org.springframework.test.context.ActiveProfiles;
 import uk.gov.hmcts.darts.cache.token.component.TokenGenerator;
 import uk.gov.hmcts.darts.cache.token.component.TokenValidator;
 import uk.gov.hmcts.darts.cache.token.config.CacheProperties;
-import uk.gov.hmcts.darts.utils.TestUtils;
-import uk.gov.hmcts.darts.utils.client.SoapAssertionUtil;
 import uk.gov.hmcts.darts.utils.client.ctxt.ContextRegistryClient;
 import uk.gov.hmcts.darts.utils.client.ctxt.ContextRegistryClientProvider;
-
-import java.net.URL;
 
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/ContextRegistryJwtServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/ContextRegistryJwtServiceTest.java
@@ -46,16 +46,20 @@ class ContextRegistryJwtServiceTest extends ContextRegistryParent {
         when(generator.acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD))
             .thenReturn("test");
 
-        when(tokenValidator.validate(Mockito.eq("test"))).thenReturn(true);
+        when(tokenValidator.validate(Mockito.eq(true), Mockito.eq("test"))).thenReturn(true);
+        when(tokenValidator.validate(Mockito.eq(false), Mockito.eq("test"))).thenReturn(true);
 
         when(generator.acquireNewToken(SERVICE_CONTEXT_USER, SERVICE_CONTEXT_PASSWORD))
             .thenReturn(CONTEXT_REGISTRY_TOKEN);
 
-        when(tokenValidator.validate(Mockito.eq(CONTEXT_REGISTRY_TOKEN))).thenReturn(true);
+        when(tokenValidator.validate(Mockito.eq(true), Mockito.eq(CONTEXT_REGISTRY_TOKEN))).thenReturn(true);
+        when(tokenValidator.validate(Mockito.eq(false), Mockito.eq(CONTEXT_REGISTRY_TOKEN))).thenReturn(true);
 
         for (int i = 0; i < REGISTERED_USER_COUNT; i++) {
 
-            when(tokenValidator.validate(Mockito.eq("test2"))).thenReturn(true);
+            when(tokenValidator.validate(Mockito.eq(true), Mockito.eq("test2"))).thenReturn(true);
+            when(tokenValidator.validate(Mockito.eq(false), Mockito.eq("test2"))).thenReturn(true);
+
             when(generator.acquireNewToken(Mockito.eq("user" + i), Mockito.eq("pass"))).thenReturn("test2");
         }
     }
@@ -181,7 +185,7 @@ class ContextRegistryJwtServiceTest extends ContextRegistryParent {
     @ParameterizedTest
     @ArgumentsSource(ContextRegistryClientProvider.class)
     void testHandleLookupTokenExpired(ContextRegistryClient client) throws Exception {
-        when(tokenValidator.validate(Mockito.eq(CONTEXT_REGISTRY_TOKEN))).thenReturn(true, false, false);
+        when(tokenValidator.validate(Mockito.anyBoolean(), Mockito.eq(CONTEXT_REGISTRY_TOKEN))).thenReturn(true, false, false);
 
         authenticationStub.assertWithUserNameAndPasswordHeader(client, () -> {
 
@@ -193,7 +197,7 @@ class ContextRegistryJwtServiceTest extends ContextRegistryParent {
 
             SoapAssertionUtil<LookupResponse> response = client.lookup(new URL(getGatewayUri() + "ContextRegistryService?wsdl"), soapRequestStr);
             Assertions.assertNull(response.getResponse().getValue().getReturn());
-            verify(tokenValidator, times(2)).validate(CONTEXT_REGISTRY_TOKEN);
+            verify(tokenValidator, times(2)).validate(Mockito.anyBoolean(), Mockito.eq(CONTEXT_REGISTRY_TOKEN));
         }, DEFAULT_USERNAME, DEFAULT_PASSWORD);
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/ContextRegistryParent.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/ContextRegistryParent.java
@@ -41,7 +41,7 @@ public class ContextRegistryParent extends IntegrationBase {
         Assertions.assertNotNull(response.body());
     }
 
-    void executeHandleRegister(ContextRegistryClient client) throws Exception {
+    String executeHandleRegister(ContextRegistryClient client) throws Exception {
         String soapRequestStr = TestUtils.getContentsFromFile(
                 "payloads/ctxtRegistry/register/soapRequest.xml");
 
@@ -50,6 +50,8 @@ public class ContextRegistryParent extends IntegrationBase {
 
         SoapAssertionUtil<RegisterResponse> response = client.register(new URL(getGatewayUri() + "ContextRegistryService?wsdl"), soapRequestStr);
         Assertions.assertNotNull(response.getResponse().getValue());
+
+        return response.getResponse().getValue().getReturn();
     }
 
     void executeHandleRegisterWithSharing(ContextRegistryClient client) throws Exception {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/CourtLogsWebServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/CourtLogsWebServiceTest.java
@@ -29,7 +29,6 @@ import java.util.stream.IntStream;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static java.util.stream.Collectors.toList;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -163,7 +162,7 @@ class CourtLogsWebServiceTest extends IntegrationBase {
                                 Mockito.eq("downstreamtoken"))).thenReturn(true);
 
         when(mockOauthTokenGenerator.acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD))
-            .thenReturn( "downstreamtoken", "test", "downstreamrefresh", "downstreamrefreshoutsidecache");
+            .thenReturn("downstreamtoken", "test", "downstreamrefresh", "downstreamrefreshoutsidecache");
 
 
         authenticationStub.assertWithTokenHeader(client, () -> {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/CourtLogsWebServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/CourtLogsWebServiceTest.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.darts.ws;
 
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.matching.RegexPattern;
 import com.service.mojdarts.synapps.com.AddLogEntryResponse;
 import com.service.mojdarts.synapps.com.GetCourtLogResponse;
 import org.junit.jupiter.api.Assertions;
@@ -25,13 +27,16 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.stream.IntStream;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static java.util.stream.Collectors.toList;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-@ActiveProfiles("int-test-jwt-token")
+@ActiveProfiles("int-test-jwt-token-shared")
 class CourtLogsWebServiceTest extends IntegrationBase {
 
     private static final String VALID_GET_COURTLOGS_XML = "classpath:payloads/courtlogs/valid-get-courtlogs.xml";
@@ -54,8 +59,8 @@ class CourtLogsWebServiceTest extends IntegrationBase {
 
     @BeforeEach
     public void before() {
-        when(tokenValidator.validate(Mockito.eq("test"))).thenReturn(true);
-
+        when(tokenValidator.validate(Mockito.eq(true), Mockito.eq("test"))).thenReturn(true);
+        when(tokenValidator.validate(Mockito.eq(false), Mockito.eq("test"))).thenReturn(true);
         when(mockOauthTokenGenerator.acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD))
             .thenReturn("test");
     }
@@ -152,6 +157,50 @@ class CourtLogsWebServiceTest extends IntegrationBase {
 
     @ParameterizedTest
     @ArgumentsSource(DartsClientProvider.class)
+    void testRoutesGetCourtLogRequestWithAuthenticationTokenRefresh(DartsGatewayClient client) throws Exception {
+
+        when(tokenValidator.validate(Mockito.anyBoolean(),
+                                Mockito.eq("downstreamtoken"))).thenReturn(true);
+
+        when(mockOauthTokenGenerator.acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD))
+            .thenReturn( "downstreamtoken", "test", "downstreamrefresh", "downstreamrefreshoutsidecache");
+
+
+        authenticationStub.assertWithTokenHeader(client, () -> {
+            var dartsApiCourtLogsResponse = someListOfCourtLog(3);
+            courtLogsApi.returnsCourtLogs(dartsApiCourtLogsResponse);
+
+            when(tokenValidator.validate(Mockito.anyBoolean(),
+                                         Mockito.eq("downstreamtoken"))).thenReturn(false);
+
+            SoapAssertionUtil<GetCourtLogResponse> response = client.getCourtLogs(
+                getGatewayUri(),
+                getCourtLogs.getContentAsString(
+                    Charset.defaultCharset())
+            );
+
+            com.synapps.moj.dfs.response.GetCourtLogResponse actualResponse = response.getResponse().getValue().getReturn();
+
+            Assertions.assertEquals("200", actualResponse.getCode());
+            Assertions.assertEquals("OK", actualResponse.getMessage());
+            Assertions.assertEquals(SOME_COURTHOUSE, actualResponse.getCourtLog().getCourthouse());
+            Assertions.assertEquals(SOME_CASE_NUMBER, actualResponse.getCourtLog().getCaseNumber());
+            Assertions.assertEquals("some-log-text-1", actualResponse.getCourtLog().getEntry().get(0).getValue());
+            Assertions.assertEquals("some-log-text-2", actualResponse.getCourtLog().getEntry().get(1).getValue());
+            Assertions.assertEquals("some-log-text-3", actualResponse.getCourtLog().getEntry().get(2).getValue());
+        }, getContextClient(), getGatewayUri(), DEFAULT_USERNAME, DEFAULT_PASSWORD);
+
+        courtLogsApi.verifyReceivedGetCourtLogsRequestFor(SOME_COURTHOUSE, "some-case");
+
+        WireMock.verify(getRequestedFor(urlMatching("/courtlogs.*"))
+                            .withHeader("Authorization", new RegexPattern("Bearer downstreamrefreshoutsidecache")));
+
+        verify(mockOauthTokenGenerator, times(4)).acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD);
+        verifyNoMoreInteractions(mockOauthTokenGenerator);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(DartsClientProvider.class)
     void testRoutesGetCourtLogRequest(DartsGatewayClient client) throws Exception {
         authenticationStub.assertWithUserNameAndPasswordHeader(client, () -> {
             var dartsApiCourtLogsResponse = someListOfCourtLog(3);
@@ -175,7 +224,10 @@ class CourtLogsWebServiceTest extends IntegrationBase {
         }, DEFAULT_USERNAME, DEFAULT_PASSWORD);
         courtLogsApi.verifyReceivedGetCourtLogsRequestFor(SOME_COURTHOUSE, "some-case");
 
-        verify(mockOauthTokenGenerator, times(1)).acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD);
+        WireMock.verify(getRequestedFor(urlMatching("/courtlogs.*"))
+                            .withHeader("Authorization", new RegexPattern("Bearer test")));
+
+        verify(mockOauthTokenGenerator, times(2)).acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD);
         verifyNoMoreInteractions(mockOauthTokenGenerator);
     }
 
@@ -195,7 +247,7 @@ class CourtLogsWebServiceTest extends IntegrationBase {
         }, DEFAULT_USERNAME, DEFAULT_PASSWORD);
         courtLogsApi.verifyDoesntReceiveRequest();
 
-        verify(mockOauthTokenGenerator).acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD);
+        verify(mockOauthTokenGenerator, times(2)).acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD);
         verifyNoMoreInteractions(mockOauthTokenGenerator);
     }
 
@@ -209,7 +261,7 @@ class CourtLogsWebServiceTest extends IntegrationBase {
             postCourtLogsApi.verifyReceivedPostCourtLogsRequestForCaseNumber("CASE000001");
         }, DEFAULT_USERNAME, DEFAULT_PASSWORD);
 
-        verify(mockOauthTokenGenerator).acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD);
+        verify(mockOauthTokenGenerator, times(2)).acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD);
         verifyNoMoreInteractions(mockOauthTokenGenerator);
     }
 
@@ -229,7 +281,7 @@ class CourtLogsWebServiceTest extends IntegrationBase {
         }, DEFAULT_USERNAME, DEFAULT_PASSWORD);
         postCourtLogsApi.verifyReceivedPostCourtLogsRequestForCaseNumber("CASE000001");
 
-        verify(mockOauthTokenGenerator).acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD);
+        verify(mockOauthTokenGenerator, times(2)).acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD);
         verifyNoMoreInteractions(mockOauthTokenGenerator);
     }
 
@@ -249,7 +301,7 @@ class CourtLogsWebServiceTest extends IntegrationBase {
         }, DEFAULT_USERNAME, DEFAULT_PASSWORD);
 
         postCourtLogsApi.verifyDoesntReceiveRequest();
-        verify(mockOauthTokenGenerator).acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD);
+        verify(mockOauthTokenGenerator, times(2)).acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD);
         verifyNoMoreInteractions(mockOauthTokenGenerator);
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/EventWebServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/EventWebServiceTest.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.darts.ws;
 
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.matching.RegexPattern;
 import com.service.mojdarts.synapps.com.AddDocumentResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,12 +25,15 @@ import uk.gov.hmcts.darts.utils.client.darts.DartsGatewayClient;
 
 import java.nio.charset.Charset;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-@ActiveProfiles("int-test-jwt-token")
+@ActiveProfiles("int-test-jwt-token-shared")
 class EventWebServiceTest extends IntegrationBase {
 
     private @Value("classpath:payloads/events/valid-event.xml") Resource validEvent;
@@ -53,10 +58,13 @@ class EventWebServiceTest extends IntegrationBase {
 
     @BeforeEach
     public void before() {
-
-        when(tokenValidator.validate(Mockito.eq("test"))).thenReturn(true);
+        when(tokenValidator.validate(Mockito.eq(true), Mockito.eq("test"))).thenReturn(true);
+        when(tokenValidator.validate(Mockito.eq(false), Mockito.eq("test"))).thenReturn(true);
 
         when(mockOauthTokenGenerator.acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD))
+            .thenReturn("test");
+
+        when(mockOauthTokenGenerator.acquireNewToken(ContextRegistryParent.SERVICE_CONTEXT_USER, ContextRegistryParent.SERVICE_CONTEXT_USER))
             .thenReturn("test");
     }
 
@@ -135,6 +143,8 @@ class EventWebServiceTest extends IntegrationBase {
         DartsGatewayClient client
     ) throws Exception {
 
+        when(tokenValidator.validate(Mockito.eq(false), Mockito.eq("test"))).thenReturn(true);
+
         authenticationStub.assertWithTokenHeader(client, () -> {
             theEventApi.willRespondSuccessfully();
 
@@ -152,6 +162,45 @@ class EventWebServiceTest extends IntegrationBase {
         theEventApi.verifyReceivedEventWithMessageId("12345");
 
         verify(mockOauthTokenGenerator, times(2)).acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD);
+        verifyNoMoreInteractions(mockOauthTokenGenerator);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(DartsClientProvider.class)
+    void testRoutesValidEventPayloadWithAuthenticationTokenRefresh(
+        DartsGatewayClient client
+    ) throws Exception {
+
+        when(tokenValidator.validate(Mockito.anyBoolean(),
+                                     Mockito.eq("downstreamtoken"))).thenReturn(true);
+
+        when(mockOauthTokenGenerator.acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD))
+            .thenReturn( "downstreamtoken", "test", "downstreamrefresh", "downstreamrefreshoutsidecache");
+
+        authenticationStub.assertWithTokenHeader(client, () -> {
+            theEventApi.willRespondSuccessfully();
+
+            when(tokenValidator.validate(Mockito.anyBoolean(),
+                                         Mockito.eq("downstreamtoken"))).thenReturn(false);
+
+            SoapAssertionUtil<AddDocumentResponse> response = client.addDocument(
+                getGatewayUri(),
+                validEvent.getContentAsString(
+                    Charset.defaultCharset())
+            );
+
+            response.assertIdenticalResponse(client.convertData(
+                validEventResponse.getContentAsString(Charset.defaultCharset()),
+                AddDocumentResponse.class
+            ).getValue());
+        }, getContextClient(), getGatewayUri(), DEFAULT_USERNAME, DEFAULT_PASSWORD);
+
+        theEventApi.verifyReceivedEventWithMessageId("12345");
+
+        WireMock.verify(postRequestedFor(urlPathEqualTo("/events"))
+                            .withHeader("Authorization", new RegexPattern("Bearer downstreamrefreshoutsidecache")));
+
+        verify(mockOauthTokenGenerator, times(4)).acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD);
         verifyNoMoreInteractions(mockOauthTokenGenerator);
     }
 
@@ -175,7 +224,10 @@ class EventWebServiceTest extends IntegrationBase {
             ).getValue());
         }, DEFAULT_USERNAME, DEFAULT_PASSWORD);
 
-        verify(mockOauthTokenGenerator).acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD);
+        WireMock.verify(postRequestedFor(urlPathEqualTo("/events"))
+                            .withHeader("Authorization", new RegexPattern("Bearer test")));
+
+        verify(mockOauthTokenGenerator, times(2)).acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD);
         verifyNoMoreInteractions(mockOauthTokenGenerator);
     }
 
@@ -192,7 +244,7 @@ class EventWebServiceTest extends IntegrationBase {
             theEventApi.verifyDoesntReceiveEvent();
         }, DEFAULT_USERNAME, DEFAULT_PASSWORD);
 
-        verify(mockOauthTokenGenerator).acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD);
+        verify(mockOauthTokenGenerator, times(2)).acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD);
         verifyNoMoreInteractions(mockOauthTokenGenerator);
     }
 
@@ -220,7 +272,7 @@ class EventWebServiceTest extends IntegrationBase {
         dailyListApiStub.verifyPostRequest();
         dailyListApiStub.verifyPatchRequest();
 
-        verify(mockOauthTokenGenerator).acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD);
+        verify(mockOauthTokenGenerator, times(2)).acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD);
         verifyNoMoreInteractions(mockOauthTokenGenerator);
     }
 
@@ -238,7 +290,7 @@ class EventWebServiceTest extends IntegrationBase {
             });
         }, DEFAULT_USERNAME, DEFAULT_PASSWORD);
 
-        verify(mockOauthTokenGenerator).acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD);
+        verify(mockOauthTokenGenerator, times(2)).acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD);
         verifyNoMoreInteractions(mockOauthTokenGenerator);
     }
 
@@ -262,7 +314,7 @@ class EventWebServiceTest extends IntegrationBase {
 
         }, DEFAULT_USERNAME, DEFAULT_PASSWORD);
 
-        verify(mockOauthTokenGenerator).acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD);
+        verify(mockOauthTokenGenerator, times(2)).acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD);
         verifyNoMoreInteractions(mockOauthTokenGenerator);
     }
 
@@ -281,7 +333,7 @@ class EventWebServiceTest extends IntegrationBase {
             SoapAssertionUtil.assertErrorResponse(String.valueOf(500), response.getResponse().getValue().getReturn());
         }, DEFAULT_USERNAME, DEFAULT_PASSWORD);
 
-        verify(mockOauthTokenGenerator).acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD);
+        verify(mockOauthTokenGenerator, times(2)).acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD);
         verifyNoMoreInteractions(mockOauthTokenGenerator);
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/EventWebServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/EventWebServiceTest.java
@@ -25,7 +25,6 @@ import uk.gov.hmcts.darts.utils.client.darts.DartsGatewayClient;
 
 import java.nio.charset.Charset;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.mockito.Mockito.times;
@@ -175,7 +174,7 @@ class EventWebServiceTest extends IntegrationBase {
                                      Mockito.eq("downstreamtoken"))).thenReturn(true);
 
         when(mockOauthTokenGenerator.acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD))
-            .thenReturn( "downstreamtoken", "test", "downstreamrefresh", "downstreamrefreshoutsidecache");
+            .thenReturn("downstreamtoken", "test", "downstreamrefresh", "downstreamrefreshoutsidecache");
 
         authenticationStub.assertWithTokenHeader(client, () -> {
             theEventApi.willRespondSuccessfully();

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/RegisterNodeWebServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/RegisterNodeWebServiceTest.java
@@ -168,7 +168,7 @@ class RegisterNodeWebServiceTest extends IntegrationBase {
                                      Mockito.eq("downstreamtoken"))).thenReturn(true);
 
         when(mockOauthTokenGenerator.acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD))
-            .thenReturn( "downstreamtoken", "test", "downstreamrefresh", "downstreamrefreshoutsidecache");
+            .thenReturn("downstreamtoken", "test", "downstreamrefresh", "downstreamrefreshoutsidecache");
 
         authenticationStub.assertWithTokenHeader(client, () -> {
             String soapRequestStr = TestUtils.getContentsFromFile(

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/RegisterNodeWebServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/RegisterNodeWebServiceTest.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.darts.ws;
 
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.matching.RegexPattern;
 import com.service.mojdarts.synapps.com.RegisterNodeResponse;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,6 +21,7 @@ import uk.gov.hmcts.darts.utils.client.darts.DartsGatewayClient;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.mockito.Mockito.times;
@@ -26,7 +29,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-@ActiveProfiles("int-test-jwt-token")
+@ActiveProfiles("int-test-jwt-token-shared")
 class RegisterNodeWebServiceTest extends IntegrationBase {
 
     @MockBean
@@ -37,9 +40,13 @@ class RegisterNodeWebServiceTest extends IntegrationBase {
 
     @BeforeEach
     public void before() {
-        when(tokenValidator.validate(Mockito.eq("test"))).thenReturn(true);
+        when(tokenValidator.validate(Mockito.eq(true), Mockito.eq("test"))).thenReturn(true);
+        when(tokenValidator.validate(Mockito.eq(false), Mockito.eq("test"))).thenReturn(true);
 
         when(mockOauthTokenGenerator.acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD))
+            .thenReturn("test");
+
+        when(mockOauthTokenGenerator.acquireNewToken(ContextRegistryParent.SERVICE_CONTEXT_USER, ContextRegistryParent.SERVICE_CONTEXT_USER))
             .thenReturn("test");
     }
 
@@ -130,6 +137,7 @@ class RegisterNodeWebServiceTest extends IntegrationBase {
     @ArgumentsSource(DartsClientProvider.class)
     void handlesRegisterNodeWithAuthenticationToken(DartsGatewayClient client) throws Exception {
 
+        when(tokenValidator.validate(Mockito.eq(false), Mockito.eq("test"))).thenReturn(true);
         authenticationStub.assertWithTokenHeader(client, () -> {
             String soapRequestStr = TestUtils.getContentsFromFile(
                 "payloads/registernode/soapRequest.xml");
@@ -154,6 +162,43 @@ class RegisterNodeWebServiceTest extends IntegrationBase {
 
     @ParameterizedTest
     @ArgumentsSource(DartsClientProvider.class)
+    void handlesRegisterNodeWithAuthenticationTokenRefresh(DartsGatewayClient client) throws Exception {
+
+        when(tokenValidator.validate(Mockito.anyBoolean(),
+                                     Mockito.eq("downstreamtoken"))).thenReturn(true);
+
+        when(mockOauthTokenGenerator.acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD))
+            .thenReturn( "downstreamtoken", "test", "downstreamrefresh", "downstreamrefreshoutsidecache");
+
+        authenticationStub.assertWithTokenHeader(client, () -> {
+            String soapRequestStr = TestUtils.getContentsFromFile(
+                "payloads/registernode/soapRequest.xml");
+
+            String dartsApiResponseStr = TestUtils.getContentsFromFile(
+                "payloads/registernode/dartsApiResponse.json");
+
+            stubFor(post(urlPathEqualTo("/register-devices"))
+                        .willReturn(ok(dartsApiResponseStr).withHeader("Content-Type", "application/json")));
+
+            String expectedResponseStr = TestUtils.getContentsFromFile(
+                "payloads/registernode/expectedResponse.xml");
+
+            when(tokenValidator.validate(Mockito.anyBoolean(),
+                                         Mockito.eq("downstreamtoken"))).thenReturn(false);
+
+            SoapAssertionUtil<RegisterNodeResponse> response = client.registerNode(getGatewayUri(), soapRequestStr);
+            response.assertIdenticalResponse(client.convertData(expectedResponseStr, RegisterNodeResponse.class).getValue());
+        },  getContextClient(), getGatewayUri(), DEFAULT_USERNAME, DEFAULT_PASSWORD);
+
+        WireMock.verify(postRequestedFor(urlPathEqualTo("/register-devices"))
+                            .withHeader("Authorization", new RegexPattern("Bearer downstreamrefreshoutsidecache")));
+        verify(mockOauthTokenGenerator, times(4)).acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD);
+        verifyNoMoreInteractions(mockOauthTokenGenerator);
+    }
+
+
+    @ParameterizedTest
+    @ArgumentsSource(DartsClientProvider.class)
     void testHandlesRegisterNode(DartsGatewayClient client) throws Exception {
 
         authenticationStub.assertWithUserNameAndPasswordHeader(client, () -> {
@@ -174,7 +219,9 @@ class RegisterNodeWebServiceTest extends IntegrationBase {
             response.assertIdenticalResponse(client.convertData(expectedResponseStr, RegisterNodeResponse.class).getValue());
         }, DEFAULT_USERNAME, DEFAULT_PASSWORD);
 
-        verify(mockOauthTokenGenerator).acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD);
+        WireMock.verify(postRequestedFor(urlPathEqualTo("/register-devices"))
+                            .withHeader("Authorization", new RegexPattern("Bearer test")));
+        verify(mockOauthTokenGenerator, times(2)).acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD);
         verifyNoMoreInteractions(mockOauthTokenGenerator);
     }
 
@@ -198,7 +245,7 @@ class RegisterNodeWebServiceTest extends IntegrationBase {
             });
         }, DEFAULT_USERNAME, DEFAULT_PASSWORD);
 
-        verify(mockOauthTokenGenerator).acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD);
+        verify(mockOauthTokenGenerator, times(2)).acquireNewToken(DEFAULT_USERNAME, DEFAULT_PASSWORD);
         verifyNoMoreInteractions(mockOauthTokenGenerator);
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/authentication/component/SecurityRequestAttributesWrapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/component/SecurityRequestAttributesWrapper.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.authentication.component;
 
 import org.springframework.web.context.request.RequestAttributes;
 import uk.gov.hmcts.darts.cache.token.service.value.DownstreamTokenisableValue;
-import uk.gov.hmcts.darts.cache.token.service.value.impl.RefeshableTokenCacheValue;
 import uk.gov.hmcts.darts.common.exceptions.DartsValidationException;
 import uk.gov.hmcts.darts.ws.CodeAndMessage;
 
@@ -28,12 +27,10 @@ public class SecurityRequestAttributesWrapper {
             if (tokenCacheValue.refresh()) {
                 tokenCacheValue.performRefresh();
                 tokenToReturn = tokenCacheValue.getDownstreamToken();
-            }
-            else {
+            } else {
                 tokenToReturn = tokenCacheValue.getDownstreamToken();
             }
-        }
-        else if (accessTokenObj instanceof String accessToken) {
+        } else if (accessTokenObj instanceof String accessToken) {
             tokenToReturn = accessToken;
         } else {
             throw new DartsValidationException("Authorization Bearer Header missing JWT", CodeAndMessage.ERROR);

--- a/src/main/java/uk/gov/hmcts/darts/cache/token/component/TokenValidator.java
+++ b/src/main/java/uk/gov/hmcts/darts/cache/token/component/TokenValidator.java
@@ -1,6 +1,13 @@
 package uk.gov.hmcts.darts.cache.token.component;
 
+@FunctionalInterface
 public interface TokenValidator {
 
-    boolean validate(String accessToken);
+    /**
+     * validates a token
+     * @param validateUsingExpiryOffset We can expire slightly before the actual token expiry based on sysTem configuration
+     * @param accessToken The token to validate
+     * @return Whether validation had succeeded or not
+     */
+    boolean validate(boolean validateUsingExpiryOffset, String accessToken);
 }

--- a/src/main/java/uk/gov/hmcts/darts/cache/token/component/TokenValidator.java
+++ b/src/main/java/uk/gov/hmcts/darts/cache/token/component/TokenValidator.java
@@ -4,7 +4,7 @@ package uk.gov.hmcts.darts.cache.token.component;
 public interface TokenValidator {
 
     /**
-     * validates a token
+     * validates a token.
      * @param validateUsingExpiryOffset We can expire slightly before the actual token expiry based on sysTem configuration
      * @param accessToken The token to validate
      * @return Whether validation had succeeded or not

--- a/src/main/java/uk/gov/hmcts/darts/cache/token/component/impl/TokenValidatorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/cache/token/component/impl/TokenValidatorImpl.java
@@ -69,11 +69,11 @@ public class TokenValidatorImpl implements TokenValidator {
     }
 
     @Override
-    public boolean validate(String accessToken) {
+    public boolean validate(boolean useExpiryOffset, String accessToken) {
         log.debug("Validating JWT: {}", accessToken);
         boolean validated = false;
         try {
-            validated = validateTheTokenExpiry(accessToken);
+            validated = !useExpiryOffset || validateTheTokenExpiry(accessToken);
 
             if (validated) {
                 jwtProcessor.process(accessToken, null);

--- a/src/main/java/uk/gov/hmcts/darts/cache/token/service/CacheLockableUnitOfWork.java
+++ b/src/main/java/uk/gov/hmcts/darts/cache/token/service/CacheLockableUnitOfWork.java
@@ -26,18 +26,14 @@ public class CacheLockableUnitOfWork {
     }
 
     @FunctionalInterface
-    interface ExecuteValue {
-        void execute(CacheValue value) throws CacheException;
+    interface ExecuteForBoolean {
+        boolean execute(Token token) throws CacheException;
     }
+
 
     @FunctionalInterface
     interface ExecuteRefreshableValueReturn {
         Optional<CacheValue> execute(Token token) throws CacheException;
-    }
-
-    @FunctionalInterface
-    interface ExecuteTokenValueReturn {
-        Optional<Token> execute(CacheValue refresh) throws CacheException;
     }
 
     public void execute(Execute runnable, Token token) throws CacheException {
@@ -64,6 +60,28 @@ public class CacheLockableUnitOfWork {
         } else {
             return runnable.execute();
         }
+    }
+
+    public Optional<Token> execute(ExecuteForToken runnable, String id) throws CacheException {
+        Lock lock = lockRegistry.obtain(id);
+        lock.lock();
+        try {
+            return runnable.execute();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public boolean executeIsApplicable(ExecuteForBoolean runnable,  Token id) throws CacheException {
+
+            Lock lock = lockRegistry.obtain(id.getId());
+            lock.lock();
+            try {
+                return runnable.execute(id);
+            } finally {
+                lock.unlock();
+            }
+
     }
 
     public Optional<CacheValue> executeForRefreshValueReturn(ExecuteRefreshableValueReturn runnable, Token token) throws CacheException {

--- a/src/main/java/uk/gov/hmcts/darts/cache/token/service/CacheLockableUnitOfWork.java
+++ b/src/main/java/uk/gov/hmcts/darts/cache/token/service/CacheLockableUnitOfWork.java
@@ -73,18 +73,16 @@ public class CacheLockableUnitOfWork {
     }
 
     public boolean executeIsApplicable(ExecuteForBoolean runnable,  Token id) throws CacheException {
-
-            Lock lock = lockRegistry.obtain(id.getId());
-            lock.lock();
-            try {
-                return runnable.execute(id);
-            } finally {
-                lock.unlock();
-            }
-
+        Lock lock = lockRegistry.obtain(id.getId());
+        lock.lock();
+        try {
+            return runnable.execute(id);
+        } finally {
+            lock.unlock();
+        }
     }
 
-    public Optional<CacheValue> executeForRefreshValueReturn(ExecuteRefreshableValueReturn runnable, Token token) throws CacheException {
+    public Optional<CacheValue> executeForValueReturn(ExecuteRefreshableValueReturn runnable, Token token) throws CacheException {
         Lock lock = lockRegistry.obtain(token.getId());
         lock.lock();
         try {

--- a/src/main/java/uk/gov/hmcts/darts/cache/token/service/Token.java
+++ b/src/main/java/uk/gov/hmcts/darts/cache/token/service/Token.java
@@ -11,8 +11,6 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Function;
-import java.util.function.Predicate;
 
 @Getter
 @EqualsAndHashCode

--- a/src/main/java/uk/gov/hmcts/darts/cache/token/service/TokenGeneratable.java
+++ b/src/main/java/uk/gov/hmcts/darts/cache/token/service/TokenGeneratable.java
@@ -4,19 +4,19 @@ import documentum.contextreg.ServiceContext;
 import uk.gov.hmcts.darts.cache.token.exception.CacheException;
 
 /**
- * An interface that allows us to generate tokens
+ * An interface that allows us to generate tokens.
  */
 public interface TokenGeneratable {
 
     /**
-     * generates a token based on the service context credentials
+     * generates a token based on the service context credentials.
      * @return The credentials in token form
      * @throws CacheException Any cache related problems whilst getting the token
      */
     Token createToken(ServiceContext context) throws CacheException;
 
     /**
-     * gets a random token string and gets it in token form
+     * gets a random token string and gets it in token form.
      * @return The token
      */
     Token getToken(String token);

--- a/src/main/java/uk/gov/hmcts/darts/cache/token/service/TokenGeneratable.java
+++ b/src/main/java/uk/gov/hmcts/darts/cache/token/service/TokenGeneratable.java
@@ -3,8 +3,21 @@ package uk.gov.hmcts.darts.cache.token.service;
 import documentum.contextreg.ServiceContext;
 import uk.gov.hmcts.darts.cache.token.exception.CacheException;
 
+/**
+ * An interface that allows us to generate tokens
+ */
 public interface TokenGeneratable {
+
+    /**
+     * generates a token based on the service context credentials
+     * @return The credentials in token form
+     * @throws CacheException Any cache related problems whilst getting the token
+     */
     Token createToken(ServiceContext context) throws CacheException;
 
+    /**
+     * gets a random token string and gets it in token form
+     * @return The token
+     */
     Token getToken(String token);
 }

--- a/src/main/java/uk/gov/hmcts/darts/cache/token/service/TokenRegisterable.java
+++ b/src/main/java/uk/gov/hmcts/darts/cache/token/service/TokenRegisterable.java
@@ -8,14 +8,14 @@ import java.util.Optional;
 
 /**
  * This is a token registerable implementation (effectively a cache implementation) that allows us to set and get
- * values {@link uk.gov.hmcts.darts.cache.token.service.value.CacheValue} from the cache
+ * values {@link uk.gov.hmcts.darts.cache.token.service.value.CacheValue} from the cache.
  */
 public interface TokenRegisterable {
 
     String CACHE_PREFIX = "darts-gateway-token-service";
 
     /**
-     * Stores a cache value into he cache
+     * Stores a cache value into the cache.
      * @return The token in which the cache value is mapped against
      */
     Optional<Token> store(CacheValue value);
@@ -23,7 +23,6 @@ public interface TokenRegisterable {
     /**
      * Stores a cache value into the store. If the cache value is already mapped into the cache we can
      * return the same id if we choose to.
-     *
      * This method should ensure the token is valid
      * (whatever that may mean) before it is returned. Clients can validate the tokens at any time thereafter
      * by calling {@link Token#valid()}
@@ -32,32 +31,29 @@ public interface TokenRegisterable {
     Optional<Token> store(CacheValue value, Boolean reuseTokenIfPossible);
 
     /**
-     * lookup the token value
-     * @param holder The token
-     * @return The value. If the token could not be found or the existing token is found
-     * but it is invalid (whatever that means) we should return an empty value (no exception should be thrown)
-     * @return The cache value
-     */
-    Optional<CacheValue> lookup(Token holder) throws CacheException;
-
-    /**
-     * This method takes the service context and works out whether it needs to generate a new token ot not
-     *
+     * This method takes the service context and works out whether it needs to generate a new token ot not.
      * If a token does exists but it is invalid then a new token is expected to be generated
      *
-     * @param reuseTokenIfPossible The token to reuse if found. if false a new token is always generated
-     * for the same service context
+     * @param reuseTokenIfPossible The token to reuse if found. if false a new token is always generated for the same service context.
      *
-     * @return The token to be returned
+     * @return The token to be returned.
      */
     Optional<Token> store(ServiceContext context, Boolean reuseTokenIfPossible) throws CacheException;
 
     /**
-     * This method takes the service context to generate a new token
+     * This method takes the service context to generate a new token.
      *
      * @return The token to be returned
      */
     Optional<Token> store(ServiceContext context) throws CacheException;
+
+    /**
+     * lookup the token value.
+     * @param holder The token
+     * @return The value. If the token could not be found or the existing token is
+     *      found but it is invalid (whatever that means) we should return an empty value (no exception should be thrown).
+     */
+    Optional<CacheValue> lookup(Token holder) throws CacheException;
 
     /**
      * This evicts a token from the cache. No errors are expected. After this call {@link #lookup(Token)} should return empty,
@@ -68,14 +64,14 @@ public interface TokenRegisterable {
 
 
     /**
-     * Gets a token
-     * @param token
+     * Gets a token.
+     * @param token The token in string form
      * @return The token
      */
     Token getToken(String token);
 
     /**
-     * creates a value to be stored
+     * creates a value to be stored.
      * @param serviceContext The service context
      * @return The value sub type to be stored
      */

--- a/src/main/java/uk/gov/hmcts/darts/cache/token/service/TokenRegisterable.java
+++ b/src/main/java/uk/gov/hmcts/darts/cache/token/service/TokenRegisterable.java
@@ -6,21 +6,79 @@ import uk.gov.hmcts.darts.cache.token.service.value.CacheValue;
 
 import java.util.Optional;
 
+/**
+ * This is a token registerable implementation (effectively a cache implementation) that allows us to set and get
+ * values {@link uk.gov.hmcts.darts.cache.token.service.value.CacheValue} from the cache
+ */
 public interface TokenRegisterable {
 
-    public static final String CACHE_PREFIX = "darts-gateway-token-service";
+    String CACHE_PREFIX = "darts-gateway-token-service";
 
-    Optional<Token> store(CacheValue value) throws CacheException;
+    /**
+     * Stores a cache value into he cache
+     * @return The token in which the cache value is mapped against
+     */
+    Optional<Token> store(CacheValue value);
 
-    Optional<Token> store(CacheValue value, Boolean reuseTokenIfPossible) throws CacheException;
+    /**
+     * Stores a cache value into the store. If the cache value is already mapped into the cache we can
+     * return the same id if we choose to.
+     *
+     * This method should ensure the token is valid
+     * (whatever that may mean) before it is returned. Clients can validate the tokens at any time thereafter
+     * by calling {@link Token#valid()}
+     * @param reuseTokenIfPossible If set to true we reuse the token else we create a new one
+     */
+    Optional<Token> store(CacheValue value, Boolean reuseTokenIfPossible);
 
+    /**
+     * lookup the token value
+     * @param holder The token
+     * @return The value. If the token could not be found or the existing token is found
+     * but it is invalid (whatever that means) we should return an empty value (no exception should be thrown)
+     * @return The cache value
+     */
     Optional<CacheValue> lookup(Token holder) throws CacheException;
 
-    void evict(Token holder) throws CacheException;
+    /**
+     * This method takes the service context and works out whether it needs to generate a new token ot not
+     *
+     * If a token does exists but it is invalid then a new token is expected to be generated
+     *
+     * @param reuseTokenIfPossible The token to reuse if found. if false a new token is always generated
+     * for the same service context
+     *
+     * @return The token to be returned
+     */
+    Optional<Token> store(ServiceContext context, Boolean reuseTokenIfPossible) throws CacheException;
 
-    Token getToken(String token) throws CacheException;
+    /**
+     * This method takes the service context to generate a new token
+     *
+     * @return The token to be returned
+     */
+    Optional<Token> store(ServiceContext context) throws CacheException;
 
-    CacheValue createValue(ServiceContext serviceContext) throws CacheException;
+    /**
+     * This evicts a token from the cache. No errors are expected. After this call {@link #lookup(Token)} should return empty,
+     * except for the  case where we are sharing tokens
+     * @param token The token
+     */
+    void evict(Token token);
 
+
+    /**
+     * Gets a token
+     * @param token
+     * @return The token
+     */
+    Token getToken(String token);
+
+    /**
+     * creates a value to be stored
+     * @param serviceContext The service context
+     * @return The value sub type to be stored
+     */
+    CacheValue createValue(ServiceContext serviceContext);
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/cache/token/service/impl/TokenDocumentumIdToJwtCache.java
+++ b/src/main/java/uk/gov/hmcts/darts/cache/token/service/impl/TokenDocumentumIdToJwtCache.java
@@ -12,14 +12,12 @@ import uk.gov.hmcts.darts.cache.token.service.TokenGeneratable;
 import uk.gov.hmcts.darts.cache.token.service.value.CacheValue;
 import uk.gov.hmcts.darts.cache.token.service.value.impl.RefeshableTokenCacheValue;
 
-import java.util.function.Predicate;
-
 /**
  * A documentum token cache that maps to {@link uk.gov.hmcts.darts.cache.token.service.value.impl.RefeshableTokenCacheValue} which itself
- * stores and manages a downstream jwt token
+ * stores and manages a downstream jwt token.
  */
 public class TokenDocumentumIdToJwtCache extends AbstractTokenCache {
-    public final TokenValidator TOKEN_VALIDATION = (expiryBefore, token) -> true;
+    public final TokenValidator validator = (expiryBefore, token) -> true;
 
     private final TokenGeneratable cache;
 
@@ -31,7 +29,7 @@ public class TokenDocumentumIdToJwtCache extends AbstractTokenCache {
 
     @Override
     protected TokenValidator getValidateToken() {
-        return TOKEN_VALIDATION;
+        return validator;
     }
 
     @Override
@@ -51,7 +49,7 @@ public class TokenDocumentumIdToJwtCache extends AbstractTokenCache {
 
     @Override
     public Token getToken(String token) {
-        return Token.readToken(token, properties.isMapTokenToSession(), TOKEN_VALIDATION);
+        return Token.readToken(token, properties.isMapTokenToSession(), validator);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/darts/cache/token/service/impl/TokenJwtCache.java
+++ b/src/main/java/uk/gov/hmcts/darts/cache/token/service/impl/TokenJwtCache.java
@@ -16,15 +16,12 @@ import uk.gov.hmcts.darts.cache.token.service.Token;
 import uk.gov.hmcts.darts.cache.token.service.TokenGeneratable;
 import uk.gov.hmcts.darts.cache.token.service.value.CacheValue;
 import uk.gov.hmcts.darts.cache.token.service.value.impl.RefeshableTokenCacheValue;
-import uk.gov.hmcts.darts.cache.token.service.value.impl.ServiceContextCacheValue;
 
 import java.util.List;
-import java.util.Optional;
-import java.util.function.Predicate;
 
 /**
  * A jwt token cache that maps to {@link uk.gov.hmcts.darts.cache.token.service.value.impl.RefeshableTokenCacheValue} which itself
- * stores and manages a downstream jwt token
+ * stores and manages a downstream jwt token.
  */
 @Slf4j
 public class TokenJwtCache extends AbstractTokenCache implements TokenGeneratable {

--- a/src/main/java/uk/gov/hmcts/darts/cache/token/service/value/CacheValue.java
+++ b/src/main/java/uk/gov/hmcts/darts/cache/token/service/value/CacheValue.java
@@ -2,6 +2,9 @@ package uk.gov.hmcts.darts.cache.token.service.value;
 
 import documentum.contextreg.ServiceContext;
 
+/**
+ * A cache value that can be stored in the cache. The default cache expects to store a service context xml block
+ */
 public interface CacheValue {
     String getContextString();
 

--- a/src/main/java/uk/gov/hmcts/darts/cache/token/service/value/DownstreamTokenisableValue.java
+++ b/src/main/java/uk/gov/hmcts/darts/cache/token/service/value/DownstreamTokenisableValue.java
@@ -5,15 +5,33 @@ import uk.gov.hmcts.darts.cache.token.service.Token;
 
 import java.util.Optional;
 
+/**
+ * Defines a cache value that has the ability to store an authenticated token for downstream communication
+ */
 public interface DownstreamTokenisableValue extends CacheValue {
 
+    /**
+     * gets the validated token
+     * @return if the token is not valid we return an empty value else the token
+     */
     Optional<Token> getValidatedToken();
 
+    /**
+     * Gets the string representation of the token
+     * @return The token
+     */
     String getDownstreamToken();
 
     void setDownstreamToken(String token);
 
+    /**
+     * Determine if the internal downstream token is in need of a refresh i.e. it has expired
+     * @return True or false
+     */
     boolean refresh() throws CacheException;
 
-    void performRefresh() throws CacheException;
+    /**
+     * performs the internal refresh of the downstream token
+     */
+    void performRefresh();
 }

--- a/src/main/java/uk/gov/hmcts/darts/cache/token/service/value/DownstreamTokenisableValue.java
+++ b/src/main/java/uk/gov/hmcts/darts/cache/token/service/value/DownstreamTokenisableValue.java
@@ -6,18 +6,18 @@ import uk.gov.hmcts.darts.cache.token.service.Token;
 import java.util.Optional;
 
 /**
- * Defines a cache value that has the ability to store an authenticated token for downstream communication
+ * Defines a cache value that has the ability to store an authenticated token for downstream communication.
  */
 public interface DownstreamTokenisableValue extends CacheValue {
 
     /**
-     * gets the validated token
+     * gets the validated token.
      * @return if the token is not valid we return an empty value else the token
      */
     Optional<Token> getValidatedToken();
 
     /**
-     * Gets the string representation of the token
+     * Gets the string representation of the token.
      * @return The token
      */
     String getDownstreamToken();
@@ -25,13 +25,13 @@ public interface DownstreamTokenisableValue extends CacheValue {
     void setDownstreamToken(String token);
 
     /**
-     * Determine if the internal downstream token is in need of a refresh i.e. it has expired
+     * Determine if the internal downstream token is in need of a refresh i.e. it has expired.
      * @return True or false
      */
     boolean refresh() throws CacheException;
 
     /**
-     * performs the internal refresh of the downstream token
+     * performs the internal refresh of the downstream token.
      */
     void performRefresh();
 }

--- a/src/main/java/uk/gov/hmcts/darts/cache/token/service/value/impl/RefeshableTokenCacheValue.java
+++ b/src/main/java/uk/gov/hmcts/darts/cache/token/service/value/impl/RefeshableTokenCacheValue.java
@@ -13,6 +13,10 @@ import uk.gov.hmcts.darts.cache.token.service.value.DownstreamTokenisableValue;
 
 import java.util.Optional;
 
+/**
+ * A default implementation of the {@link DownstreamTokenisableValue} that uses {@link TokenGeneratable} to generate
+ * tokens
+ */
 @Slf4j
 @JsonTypeName("RefreshableCacheValueWithJwt")
 public class RefeshableTokenCacheValue extends ServiceContextCacheValue implements DownstreamTokenisableValue {
@@ -45,7 +49,7 @@ public class RefeshableTokenCacheValue extends ServiceContextCacheValue implemen
         Optional<Token> downstream = getValidatedToken();
 
         return EMPTY_DOWN_STREAM_TOKEN.equals(getDownstreamToken()) || (!EMPTY_DOWN_STREAM_TOKEN.equals(getDownstreamToken())
-            && downstream.isPresent() && !downstream.get().valid());
+            && downstream.isPresent() && !downstream.get().valid(true));
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/darts/cache/token/service/value/impl/RefeshableTokenCacheValue.java
+++ b/src/main/java/uk/gov/hmcts/darts/cache/token/service/value/impl/RefeshableTokenCacheValue.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 
 /**
  * A default implementation of the {@link DownstreamTokenisableValue} that uses {@link TokenGeneratable} to generate
- * tokens
+ * tokens.
  */
 @Slf4j
 @JsonTypeName("RefreshableCacheValueWithJwt")

--- a/src/main/java/uk/gov/hmcts/darts/cache/token/service/value/impl/ServiceContextCacheValue.java
+++ b/src/main/java/uk/gov/hmcts/darts/cache/token/service/value/impl/ServiceContextCacheValue.java
@@ -104,11 +104,12 @@ public class ServiceContextCacheValue implements CacheValue {
         return id;
     }
 
-    public void setId(String id) throws CacheException {
-        this.id = id;
-    }
 
     public static String getId(ServiceContext context) {
         return TokenRegisterable.CACHE_PREFIX + ":" + getUserName(context) + ":" + getPassword(context);
+    }
+
+    public void setId(String id) throws CacheException {
+        this.id = id;
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/cache/token/service/value/impl/ServiceContextCacheValue.java
+++ b/src/main/java/uk/gov/hmcts/darts/cache/token/service/value/impl/ServiceContextCacheValue.java
@@ -76,8 +76,8 @@ public class ServiceContextCacheValue implements CacheValue {
         return context;
     }
 
-    private String getUserName() throws CacheException {
-        ServiceContext serviceContext = getServiceContext();
+    private static String getUserName(ServiceContext context) throws CacheException {
+        ServiceContext serviceContext = context;
         Identity identity = serviceContext.getIdentities().get(0);
         if (identity instanceof BasicIdentity basicIdentity) {
             return basicIdentity.getUserName();
@@ -86,8 +86,8 @@ public class ServiceContextCacheValue implements CacheValue {
         throw new CacheException("Do not understand the service context");
     }
 
-    private String getPassword() throws CacheException {
-        ServiceContext serviceContext = getServiceContext();
+    private static String getPassword(ServiceContext context) throws CacheException {
+        ServiceContext serviceContext = context;
         Identity identity = serviceContext.getIdentities().get(0);
         if (identity instanceof BasicIdentity basicIdentity) {
             return basicIdentity.getPassword();
@@ -99,12 +99,16 @@ public class ServiceContextCacheValue implements CacheValue {
     @Override
     public String getId() throws CacheException {
         if (id == null) {
-            id = TokenRegisterable.CACHE_PREFIX + ":" + getUserName() + ":" + getPassword();
+            id = getId(getServiceContext());
         }
         return id;
     }
 
     public void setId(String id) throws CacheException {
         this.id = id;
+    }
+
+    public static String getId(ServiceContext context) {
+        return TokenRegisterable.CACHE_PREFIX + ":" + getUserName(context) + ":" + getPassword(context);
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/ws/ContextRegistryEndpoint.java
+++ b/src/main/java/uk/gov/hmcts/darts/ws/ContextRegistryEndpoint.java
@@ -34,11 +34,12 @@ public class ContextRegistryEndpoint {
         RegisterResponse registerResponse = new RegisterResponse();
 
         try {
+
             // create a session as the client needs this
-            Optional<Token> token = registerable.store(registerable.createValue(addDocument.getValue().getContext()));
+            Optional<Token> cacheValue = registerable.store(addDocument.getValue().getContext());
 
             // for now return a documentum id
-            token.ifPresent(value -> registerResponse.setReturn(value.getTokenString().orElse("")));
+            cacheValue.ifPresent(value -> registerResponse.setReturn(value.getTokenString().orElse("")));
         } catch (CacheTokenCreationException cte) {
             log.warn("Failed creation of token", cte);
         }

--- a/src/test/java/uk/gov/hmcts/darts/authentication/component/SecurityRequestAttributesWrapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authentication/component/SecurityRequestAttributesWrapperTest.java
@@ -7,7 +7,7 @@ import org.mockito.Mockito;
 import org.springframework.web.context.request.RequestAttributes;
 import uk.gov.hmcts.darts.cache.token.service.value.DownstreamTokenisableValue;
 
-public class SecurityRequestAttributesWrapperTest {
+class SecurityRequestAttributesWrapperTest {
 
     private SecurityRequestAttributesWrapper securityRequestAttributesWrapper;
 
@@ -20,7 +20,7 @@ public class SecurityRequestAttributesWrapperTest {
     }
 
     @Test
-    public void testGettingADownstreamTokenForRefresh() {
+    void testGettingADownstreamTokenForRefresh() {
         DownstreamTokenisableValue downstreamTokenisableValue = Mockito.mock(DownstreamTokenisableValue.class);
 
         String downstreamToken = "refreshedToken";
@@ -36,7 +36,7 @@ public class SecurityRequestAttributesWrapperTest {
     }
 
     @Test
-    public void testGettingADownstreamTokenNoNeedToRefresh() {
+    void testGettingADownstreamTokenNoNeedToRefresh() {
         DownstreamTokenisableValue downstreamTokenisableValue = Mockito.mock(DownstreamTokenisableValue.class);
 
         String downstreamToken = "refreshedToken";
@@ -52,7 +52,7 @@ public class SecurityRequestAttributesWrapperTest {
     }
 
     @Test
-    public void testGettingToken() {
+    void testGettingToken() {
         String downstreamToken = "refreshedToken";
 
         Mockito.when(atts.getAttribute(SecurityRequestAttributesWrapper.ACCESS_TOKEN_REQUEST_ATTR, 0))

--- a/src/test/java/uk/gov/hmcts/darts/authentication/component/SecurityRequestAttributesWrapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authentication/component/SecurityRequestAttributesWrapperTest.java
@@ -1,0 +1,63 @@
+package uk.gov.hmcts.darts.authentication.component;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.web.context.request.RequestAttributes;
+import uk.gov.hmcts.darts.cache.token.service.value.DownstreamTokenisableValue;
+
+public class SecurityRequestAttributesWrapperTest {
+
+    private SecurityRequestAttributesWrapper securityRequestAttributesWrapper;
+
+    private RequestAttributes atts;
+
+    @BeforeEach
+    public void beforeEach() {
+        atts = Mockito.mock(RequestAttributes.class);
+        securityRequestAttributesWrapper = new SecurityRequestAttributesWrapper(atts);
+    }
+
+    @Test
+    public void testGettingADownstreamTokenForRefresh() {
+        DownstreamTokenisableValue downstreamTokenisableValue = Mockito.mock(DownstreamTokenisableValue.class);
+
+        String downstreamToken = "refreshedToken";
+        Mockito.when(downstreamTokenisableValue.getDownstreamToken()).thenReturn(downstreamToken);
+        Mockito.when(downstreamTokenisableValue.refresh()).thenReturn(true);
+
+        Mockito.when(atts.getAttribute(SecurityRequestAttributesWrapper.ACCESS_TOKEN_REQUEST_ATTR, 0))
+            .thenReturn(downstreamTokenisableValue);
+
+        Assertions.assertEquals(downstreamToken, securityRequestAttributesWrapper.getAuthenticationToken());
+
+        Mockito.verify(downstreamTokenisableValue).performRefresh();
+    }
+
+    @Test
+    public void testGettingADownstreamTokenNoNeedToRefresh() {
+        DownstreamTokenisableValue downstreamTokenisableValue = Mockito.mock(DownstreamTokenisableValue.class);
+
+        String downstreamToken = "refreshedToken";
+        Mockito.when(downstreamTokenisableValue.getDownstreamToken()).thenReturn(downstreamToken);
+        Mockito.when(downstreamTokenisableValue.refresh()).thenReturn(false);
+
+        Mockito.when(atts.getAttribute(SecurityRequestAttributesWrapper.ACCESS_TOKEN_REQUEST_ATTR, 0))
+            .thenReturn(downstreamTokenisableValue);
+
+        Assertions.assertEquals(downstreamToken, securityRequestAttributesWrapper.getAuthenticationToken());
+
+        Mockito.verify(downstreamTokenisableValue, Mockito.times(0)).performRefresh();
+    }
+
+    @Test
+    public void testGettingToken() {
+        String downstreamToken = "refreshedToken";
+
+        Mockito.when(atts.getAttribute(SecurityRequestAttributesWrapper.ACCESS_TOKEN_REQUEST_ATTR, 0))
+            .thenReturn(downstreamToken);
+
+        Assertions.assertEquals(downstreamToken, securityRequestAttributesWrapper.getAuthenticationToken());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/darts/cache/token/BasicCacheTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cache/token/BasicCacheTest.java
@@ -375,7 +375,7 @@ class BasicCacheTest {
         }
 
         @Override
-        public String getIdForServiceContext(ServiceContext serviceContext) throws CacheException {
+        public String getIdForServiceContext(ServiceContext serviceContext) {
             return RefeshableTokenCacheValue.getId(serviceContext);
         }
     }

--- a/src/test/java/uk/gov/hmcts/darts/cache/token/TokenTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cache/token/TokenTest.java
@@ -13,8 +13,6 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 import uk.gov.hmcts.darts.cache.token.component.TokenValidator;
 import uk.gov.hmcts.darts.cache.token.service.Token;
 
-import java.util.function.Predicate;
-
 import static org.mockito.Mockito.verify;
 
 class TokenTest {

--- a/src/test/java/uk/gov/hmcts/darts/cache/token/TokenTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cache/token/TokenTest.java
@@ -10,6 +10,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
+import uk.gov.hmcts.darts.cache.token.component.TokenValidator;
 import uk.gov.hmcts.darts.cache.token.service.Token;
 
 import java.util.function.Predicate;
@@ -48,48 +49,43 @@ class TokenTest {
 
     @Test
     void createTokenWithSession() {
-        ValidateToken validate = Mockito.mock(ValidateToken.class);
-        Mockito.when(validate.test(Mockito.notNull())).thenReturn(true);
+        TokenValidator validate = Mockito.mock(TokenValidator.class);
+        Mockito.when(validate.validate(Mockito.eq(false), Mockito.notNull())).thenReturn(true);
         Token token = Token.generateDocumentumToken(true, validate);
         Assertions.assertNotNull(token.getTokenString());
         Assertions.assertEquals(EXISTING_SESSION_ID, token.getSessionId());
 
-        verify(validate).test(Mockito.notNull());
+        verify(validate).validate(Mockito.eq(false), Mockito.notNull());
     }
 
     @Test
     void createTokenWithNoSession() {
 
-        ValidateToken validate = Mockito.mock(ValidateToken.class);
-        Mockito.when(validate.test(Mockito.notNull())).thenReturn(true);
+        TokenValidator validate = Mockito.mock(TokenValidator.class);
+        Mockito.when(validate.validate(Mockito.eq(false), Mockito.notNull())).thenReturn(true);
         Token token = Token.generateDocumentumToken(false, validate);
         Assertions.assertNotNull(token.getTokenString());
         Assertions.assertTrue(token.getSessionId().isEmpty());
     }
 
-    @FunctionalInterface
-    interface ValidateToken extends Predicate<String> {
-
-    }
-
     @Test
     void createTokenWithStringAndNoSession() {
         String tokenStr = "token";
-        ValidateToken validate = Mockito.mock(ValidateToken.class);
-        Mockito.when(validate.test(Mockito.notNull())).thenReturn(true);
+        TokenValidator validate = Mockito.mock(TokenValidator.class);
+        Mockito.when(validate.validate(false, tokenStr)).thenReturn(true);
 
         Token token = Token.readToken(tokenStr, false, validate);
         Assertions.assertEquals(tokenStr,token.getTokenString().get());
         Assertions.assertTrue(token.getSessionId().isEmpty());
 
-        verify(validate).test(Mockito.notNull());
+        verify(validate).validate(Mockito.eq(false), Mockito.notNull());
     }
 
     @Test
     void createTokenWithStringAndSession() {
         String tokenStr = "token";
-        ValidateToken validate = Mockito.mock(ValidateToken.class);
-        Mockito.when(validate.test(Mockito.notNull())).thenReturn(true);
+        TokenValidator validate = Mockito.mock(TokenValidator.class);
+        Mockito.when(validate.validate(false, tokenStr)).thenReturn(true);
         Token token = Token.readToken(tokenStr, true, validate);
         Assertions.assertFalse(token.getSessionId().isEmpty());
         Assertions.assertNotNull(token.getTokenString());
@@ -98,8 +94,8 @@ class TokenTest {
     @Test
     void createTokenWithStringAndSessionValidateFalse() {
         String tokenStr = "token";
-        ValidateToken validate = Mockito.mock(ValidateToken.class);
-        Mockito.when(validate.test(Mockito.notNull())).thenReturn(false);
+        TokenValidator validate = Mockito.mock(TokenValidator.class);
+        Mockito.when(validate.validate(false, tokenStr)).thenReturn(false);
         Token token = Token.readToken(tokenStr, true, validate);
         Assertions.assertFalse(token.getSessionId().isEmpty());
         Assertions.assertTrue(token.getTokenString().isEmpty());
@@ -124,40 +120,40 @@ class TokenTest {
     @Test
     void createTokenWithStringAndSessionNoValidation() {
         String tokenStr = "token";
-        ValidateToken validate = Mockito.mock(ValidateToken.class);
-        Mockito.when(validate.test(Mockito.notNull())).thenReturn(false);
+        TokenValidator validate = Mockito.mock(TokenValidator.class);
+        Mockito.when(validate.validate(false, tokenStr)).thenReturn(true);
         Token token = Token.readToken(tokenStr, true, validate);
         Assertions.assertFalse(token.getSessionId().isEmpty());
         Assertions.assertNotNull(token.getTokenString(false));
 
-        verify(validate, Mockito.times(0)).test(Mockito.notNull());
+        verify(validate, Mockito.times(0)).validate(Mockito.eq(false), Mockito.notNull());
     }
 
     @Test
     void validateTokenTrue() {
-        ValidateToken validate = Mockito.mock(ValidateToken.class);
-        Mockito.when(validate.test(Mockito.notNull())).thenReturn(true);
+        TokenValidator validate = Mockito.mock(TokenValidator.class);
+        Mockito.when(validate.validate(Mockito.eq(false), Mockito.notNull())).thenReturn(true);
         Token token = Token.generateDocumentumToken(true, validate);
         Assertions.assertTrue(token.valid());
-        verify(validate, Mockito.times(1)).test(Mockito.notNull());
+        verify(validate, Mockito.times(1)).validate(Mockito.eq(false), Mockito.notNull());
     }
 
     @Test
     void validateTokenFalse() {
-        ValidateToken validate = Mockito.mock(ValidateToken.class);
-        Mockito.when(validate.test(Mockito.notNull())).thenReturn(false);
+        TokenValidator validate = Mockito.mock(TokenValidator.class);
+        Mockito.when(validate.validate(Mockito.eq(false), Mockito.notNull())).thenReturn(false);
         Token token = Token.generateDocumentumToken(true, validate);
         Assertions.assertFalse(token.valid());
-        verify(validate, Mockito.times(1)).test(Mockito.notNull());
+        verify(validate, Mockito.times(1)).validate(Mockito.eq(false), Mockito.notNull());
     }
 
     @Test
-    void validateToken() {
-        ValidateToken validate = Mockito.mock(ValidateToken.class);
-        Mockito.when(validate.test(Mockito.notNull())).thenReturn(true);
+    void validateTokenWithOffset() {
+        TokenValidator validate = Mockito.mock(TokenValidator.class);
+        Mockito.when(validate.validate(Mockito.eq(true), Mockito.notNull())).thenReturn(true);
         Token token = Token.generateDocumentumToken(true, validate);
-        Assertions.assertTrue(token.valid());
-        verify(validate, Mockito.times(1)).test(Mockito.notNull());
+        Assertions.assertTrue(token.valid(true));
+        verify(validate, Mockito.times(1)).validate(Mockito.eq(true), Mockito.notNull());
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/darts/cache/token/component/impl/TokenValidatorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cache/token/component/impl/TokenValidatorImplTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mockito;
 import uk.gov.hmcts.darts.cache.token.config.SecurityProperties;
 import uk.gov.hmcts.darts.cache.token.exception.CacheTokenValidationException;
 
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.text.ParseException;
@@ -125,7 +126,7 @@ class TokenValidatorImplTest {
 
         TokenValidatorImpl validator = new TokenValidatorImpl(securityProperties, custom);
 
-        Assertions.assertFalse(validator.validateTheTokenExpiry( """
+        Assertions.assertFalse(validator.validateTheTokenExpiry("""
                 eyJhbGciOiJSUzI1NiIsImtpZCI6Ilg1ZVhrNHh5b2pORnVtMWtsMll0djhkbE5QNC1jNTdkTzZRR1RWQndhTmsiLCJ0eXAiOiJKV1
                 QifQ.eyJpZHAiOiJMb2NhbEFjY291bnQiLCJvaWQiOiJkMDQwZTQxMy1mMWFjLTQ5MDItYjM0Ny0zNjlmNmU1ODI1NTkiLCJzdW
                 IiOiJkMDQwZTQxMy1mMWFjLTQ5MDItYjM0Ny0zNjlmNmU1ODI1NTkiLCJnaXZlbl9uYW1lIjoiWGhpYml0IiwiZmFtaWx5X25hbW
@@ -150,7 +151,7 @@ class TokenValidatorImplTest {
     class DefaultJwtProcessorThrows extends DefaultJWTProcessor<SecurityContext> {
         @Override
         public JWTClaimsSet process(String jwtString, SecurityContext context) throws ParseException, BadJOSEException, JOSEException {
-            throw new RuntimeException("error for test");
+            throw new UnsupportedOperationException("error for test");
         }
     }
 
@@ -162,7 +163,7 @@ class TokenValidatorImplTest {
     }
 
     class TokenValidatorImplCustom extends TokenValidatorImpl {
-        private boolean tokenExpiryOffsetCheck = true;
+        private final boolean tokenExpiryOffsetCheck;
 
 
         public TokenValidatorImplCustom(SecurityProperties securityProperties, DefaultJWTProcessor<SecurityContext> jwtProcessor,

--- a/src/test/java/uk/gov/hmcts/darts/cache/token/service/value/impl/RefreshableTokenCacheValueTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cache/token/service/value/impl/RefreshableTokenCacheValueTest.java
@@ -20,8 +20,6 @@ import uk.gov.hmcts.darts.cache.token.service.Token;
 import uk.gov.hmcts.darts.cache.token.service.TokenGeneratable;
 import uk.gov.hmcts.darts.cache.token.service.TokenRegisterable;
 
-import java.util.function.Predicate;
-
 import static org.mockito.Mockito.when;
 
 class RefreshableTokenCacheValueTest {
@@ -71,7 +69,7 @@ class RefreshableTokenCacheValueTest {
         context = jaxbMarshaller.unmarshal(ss, ServiceContext.class).getValue();
 
         TokenValidator validate = Mockito.mock(TokenValidator.class);
-        Mockito.when(validate.validate(Mockito.eq(true), Mockito.notNull())).thenReturn(true);
+        when(validate.validate(Mockito.eq(true), Mockito.notNull())).thenReturn(true);
         token = Token.readToken(CACHED_TOKEN_STRING, false, validate);
         replaceToken = Token.readToken(REPLACE_TOKEN_STRING, false, validate);
     }

--- a/src/test/java/uk/gov/hmcts/darts/cache/token/service/value/impl/RefreshableTokenCacheValueTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cache/token/service/value/impl/RefreshableTokenCacheValueTest.java
@@ -14,6 +14,7 @@ import org.mockito.Mockito;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.xml.transform.StringSource;
+import uk.gov.hmcts.darts.cache.token.component.TokenValidator;
 import uk.gov.hmcts.darts.cache.token.exception.CacheTokenCreationException;
 import uk.gov.hmcts.darts.cache.token.service.Token;
 import uk.gov.hmcts.darts.cache.token.service.TokenGeneratable;
@@ -23,7 +24,7 @@ import java.util.function.Predicate;
 
 import static org.mockito.Mockito.when;
 
-class RefeshableTokenCacheValueTest {
+class RefreshableTokenCacheValueTest {
     private static final String SERVICE_CONTEXT_UNDER_TEST = """
       <context xmlns:ns4="http://profiles.core.datamodel.fs.documentum.emc.com/"    xmlns:ns2="http://context.core.datamodel.fs.documentum.emc.com/" xmlns:ns3="http://properties.core.datamodel.fs.documentum.emc.com/" ><ns2:Identities
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ns2:RepositoryIdentity" repositoryName="moj_darts" password="${PASSWORD}" userName="${USER}">
@@ -69,9 +70,10 @@ class RefeshableTokenCacheValueTest {
         StringSource ss = new StringSource(SERVICE_CONTEXT_UNDER_TEST);
         context = jaxbMarshaller.unmarshal(ss, ServiceContext.class).getValue();
 
-        Predicate<String> mypredicate = (p) -> true;
-        token = Token.readToken(CACHED_TOKEN_STRING, false, mypredicate);
-        replaceToken = Token.readToken(REPLACE_TOKEN_STRING, false, mypredicate);
+        TokenValidator validate = Mockito.mock(TokenValidator.class);
+        Mockito.when(validate.validate(Mockito.eq(true), Mockito.notNull())).thenReturn(true);
+        token = Token.readToken(CACHED_TOKEN_STRING, false, validate);
+        replaceToken = Token.readToken(REPLACE_TOKEN_STRING, false, validate);
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/secure/RapidBoard.jspa?rapidView=2322&quickFilter=17124

### Change description ###

* Adds a mechanism whereby a downstream jwt token can be stored and managed
* The token expiration when refreshing the downstream token is 5 minutes before its official expiry so we always maintain a useable legit token
* Add a set of tests to prove the refresh of the token before any downstream communication takes place

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
