### PR TITLE
Log the GET WSDL request URL and response code

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/utils/IntegrationBase.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/utils/IntegrationBase.java
@@ -50,7 +50,7 @@ public class IntegrationBase implements CommandHolder {
     protected static final String DEFAULT_PASSWORD = "password";
 
     @Value("${local.server.port}")
-    private int port;
+    protected int port;
 
     @Autowired
     private Map<String, ContextRegistryClient> contextClients;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/WsdlTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/WsdlTest.java
@@ -15,20 +15,20 @@ class WsdlTest extends IntegrationBase {
     private RestTemplate template;
 
     @Test
-    public void testDartsWsdlSuccess() throws Exception {
+    void testDartsWsdlSuccess() throws Exception {
         String content = template.getForObject(getGatewayUri() + "/DARTSService?wsdl", String.class);
         Assertions.assertNotNull(content);
     }
 
     @Test
-    public void testContextRegistryWsdlSuccess() throws Exception {
+    void testContextRegistryWsdlSuccess() throws Exception {
         String content = template.getForObject(
             getGatewayUri() + "/runtime/ContextRegistryService?wsdl", String.class);
         Assertions.assertNotNull(content);
     }
 
     @Test
-    public void testWsdlFail() {
+    void testWsdlFail() {
         Assertions.assertThrows(HttpServerErrorException.InternalServerError.class, () -> {
             template.getForObject(getGatewayUri() + "/DARTSServiceUnknown?wsdl", String.class);
         });

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/WsdlTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/WsdlTest.java
@@ -1,0 +1,36 @@
+package uk.gov.hmcts.darts.ws;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.hmcts.darts.utils.IntegrationBase;
+
+@ActiveProfiles("int-test-jwt-token-shared")
+class WsdlTest extends IntegrationBase {
+
+    @Autowired
+    private RestTemplate template;
+
+    @Test
+    public void testDartsWsdlSuccess() throws Exception {
+        String content = template.getForObject(getGatewayUri() + "/DARTSService?wsdl", String.class);
+        Assertions.assertNotNull(content);
+    }
+
+    @Test
+    public void testContextRegistryWsdlSuccess() throws Exception {
+        String content = template.getForObject(
+            getGatewayUri() + "/runtime/ContextRegistryService?wsdl", String.class);
+        Assertions.assertNotNull(content);
+    }
+
+    @Test
+    public void testWsdlFail() {
+        Assertions.assertThrows(HttpServerErrorException.InternalServerError.class, () -> {
+            template.getForObject(getGatewayUri() + "/DARTSServiceUnknown?wsdl", String.class);
+        });
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/WsdlTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/WsdlTest.java
@@ -4,9 +4,11 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.hmcts.darts.utils.IntegrationBase;
+
+import java.net.URL;
 
 @ActiveProfiles("int-test-jwt-token-shared")
 class WsdlTest extends IntegrationBase {
@@ -28,9 +30,23 @@ class WsdlTest extends IntegrationBase {
     }
 
     @Test
+    void testContextRegistryWsdlSuccessWithoutQueryParamFail() throws Exception {
+        Assertions.assertThrows(HttpClientErrorException.NotFound.class, () -> {
+            template.getForObject(
+                getGatewayUri() + "/runtime/ContextRegistryService", String.class);
+        });
+    }
+
+    @Test
     void testWsdlFail() {
-        Assertions.assertThrows(HttpServerErrorException.InternalServerError.class, () -> {
+        Assertions.assertThrows(HttpClientErrorException.NotFound.class, () -> {
             template.getForObject(getGatewayUri() + "/DARTSServiceUnknown?wsdl", String.class);
         });
+    }
+
+    @Test
+    void testFaviconSuccess() throws Exception {
+        template.getForObject(new URL("http://localhost:" + port  + "/favicon.ico").toString(), String.class);
+        Assertions.assertTrue(true);
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/ws/DartsMessageDispatcherServlet.java
+++ b/src/main/java/uk/gov/hmcts/darts/ws/DartsMessageDispatcherServlet.java
@@ -8,9 +8,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.ws.transport.http.MessageDispatcherServlet;
 import uk.gov.hmcts.darts.common.multipart.JavaMailXmlWithFileMultiPartRequestFactory;
 import uk.gov.hmcts.darts.common.multipart.XmlWithFileMultiPartRequest;
@@ -48,11 +48,7 @@ public class DartsMessageDispatcherServlet extends MessageDispatcherServlet {
                     super.service(request, res);
                 }
             } else {
-                try {
-                    super.service(req, res);
-                } catch (Exception e) {
-                    log.error("An error occurred", e);
-                }
+                super.service(req, res);
             }
         }
     }
@@ -82,11 +78,7 @@ public class DartsMessageDispatcherServlet extends MessageDispatcherServlet {
                 log.trace("GET call made but no WSDL found on URL {}", getCalledUrl(req));
                 res.setStatus(HttpServletResponse.SC_NOT_FOUND);
             } else {
-                try {
-                    super.service(req, res);
-                } catch (Exception e) {
-                    log.error("An error occurred", e);
-                }
+                super.service(req, res);
             }
         }
 
@@ -103,7 +95,7 @@ public class DartsMessageDispatcherServlet extends MessageDispatcherServlet {
         response.getWriter().write(wsdlText);
     }
 
-    @Controller
+    @RestController
     static class FaviconController {
         @GetMapping("favicon.ico")
         @ResponseBody

--- a/src/main/java/uk/gov/hmcts/darts/ws/DartsMessageDispatcherServlet.java
+++ b/src/main/java/uk/gov/hmcts/darts/ws/DartsMessageDispatcherServlet.java
@@ -77,6 +77,7 @@ public class DartsMessageDispatcherServlet extends MessageDispatcherServlet {
             if (fndMetaData == null) {
                 log.trace("GET call made but no WSDL found on URL {}", getCalledUrl(req));
                 res.setStatus(HttpServletResponse.SC_NOT_FOUND);
+                processed = true;
             } else {
                 super.service(req, res);
             }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -101,5 +101,8 @@ logging:
             authentication:
               component:
                 SoapRequestInterceptor : trace
+
+            ws:
+              DartsMessageDispatcherServlet : trace
             common:
               client: debug


### PR DESCRIPTION
### JIRA link (if applicable) ###

NO jira

### Change description ###

Add logging for the GET WSDL and associated HTTP response

NOTE: Also added a Favicon controller to disable the exception logging when browsers naturally attempt to get the favicon

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
