### PR TITLE
DMP-2429 Update darts env var names (5 starting with AAD_B2C) for secret mappings - remove `_KEY` ending

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -6,29 +6,29 @@ def type = "java"
 def product = "darts"
 def component = "gateway"
 
-def branchesToSync = ['demo' ,'perftest','ithc']
+def branchesToSync = ['demo', 'perftest', 'ithc']
 
 def secrets = [
-  'darts-${env}': [
-    secret('app-insights-connection-string', 'app-insights-connection-string'),
-    secret('AzureAdB2CClientId', 'AAD_B2C_CLIENT_ID_KEY'),
-    secret('ExternalServiceBasicAuthorisationWhitelist', 'EXTERNAL_SERVICE_BASIC_AUTHORISATION_WHITELIST'),
-  ],
+        'darts-${env}': [
+                secret('app-insights-connection-string', 'app-insights-connection-string'),
+                secret('AzureAdB2CClientId', 'AAD_B2C_CLIENT_ID'),
+                secret('ExternalServiceBasicAuthorisationWhitelist', 'EXTERNAL_SERVICE_BASIC_AUTHORISATION_WHITELIST'),
+        ],
 ]
 
 static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
-  [$class     : 'AzureKeyVaultSecret',
-   secretType : 'Secret',
-   name       : secretName,
-   version    : '',
-   envVariable: envVar
-  ]
+    [$class     : 'AzureKeyVaultSecret',
+     secretType : 'Secret',
+     name       : secretName,
+     version    : '',
+     envVariable: envVar
+    ]
 }
 
 withPipeline(type, product, component) {
-  loadVaultSecrets(secrets)
-  enableSlackNotifications('#darts-builds')
+    loadVaultSecrets(secrets)
+    enableSlackNotifications('#darts-builds')
 
-  syncBranchesWithMaster(branchesToSync)
+    syncBranchesWithMaster(branchesToSync)
 }
 

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -1,8 +1,8 @@
 #!groovy
 
 properties([
-  // H allow predefined but random minute see https://en.wikipedia.org/wiki/Cron#Non-standard_characters
-  pipelineTriggers([cron('H 08 * * 1-5')])
+        // H allow predefined but random minute see https://en.wikipedia.org/wiki/Cron#Non-standard_characters
+        pipelineTriggers([cron('H 08 * * 1-5')])
 ])
 
 @Library("Infrastructure")
@@ -12,23 +12,23 @@ def product = "darts"
 def component = "gateway"
 
 def secrets = [
-  'darts-${env}': [
-    secret('app-insights-connection-string', 'app-insights-connection-string'),
-    secret('AzureAdB2CClientId', 'AAD_B2C_CLIENT_ID_KEY'),
-    secret('ExternalServiceBasicAuthorisationWhitelist', 'EXTERNAL_SERVICE_BASIC_AUTHORISATION_WHITELIST'),
-  ],
+        'darts-${env}': [
+                secret('app-insights-connection-string', 'app-insights-connection-string'),
+                secret('AzureAdB2CClientId', 'AAD_B2C_CLIENT_ID'),
+                secret('ExternalServiceBasicAuthorisationWhitelist', 'EXTERNAL_SERVICE_BASIC_AUTHORISATION_WHITELIST'),
+        ],
 ]
 
 static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
-  [$class     : 'AzureKeyVaultSecret',
-   secretType : 'Secret',
-   name       : secretName,
-   version    : '',
-   envVariable: envVar
-  ]
+    [$class     : 'AzureKeyVaultSecret',
+     secretType : 'Secret',
+     name       : secretName,
+     version    : '',
+     envVariable: envVar
+    ]
 }
 
 withNightlyPipeline(type, product, component) {
-  loadVaultSecrets(secrets)
-  enableSlackNotifications('#darts-builds')
+    loadVaultSecrets(secrets)
+    enableSlackNotifications('#darts-builds')
 }

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -7,23 +7,23 @@ def product = "darts"
 def component = "gateway"
 
 def secrets = [
-  'darts-${env}': [
-    secret('app-insights-connection-string', 'app-insights-connection-string'),
-    secret('AzureAdB2CClientId', 'AAD_B2C_CLIENT_ID_KEY'),
-    secret('ExternalServiceBasicAuthorisationWhitelist', 'EXTERNAL_SERVICE_BASIC_AUTHORISATION_WHITELIST'),
-  ],
+        'darts-${env}': [
+                secret('app-insights-connection-string', 'app-insights-connection-string'),
+                secret('AzureAdB2CClientId', 'AAD_B2C_CLIENT_ID'),
+                secret('ExternalServiceBasicAuthorisationWhitelist', 'EXTERNAL_SERVICE_BASIC_AUTHORISATION_WHITELIST'),
+        ],
 ]
 
 static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
-  [$class     : 'AzureKeyVaultSecret',
-   secretType : 'Secret',
-   name       : secretName,
-   version    : '',
-   envVariable: envVar
-  ]
+    [$class     : 'AzureKeyVaultSecret',
+     secretType : 'Secret',
+     name       : secretName,
+     version    : '',
+     envVariable: envVar
+    ]
 }
 
 withParameterizedPipeline(type, product, component, 'sbox', 'sbox') {
-  loadVaultSecrets(secrets)
-  enableSlackNotifications('#darts-builds')
+    loadVaultSecrets(secrets)
+    enableSlackNotifications('#darts-builds')
 }

--- a/README.md
+++ b/README.md
@@ -4,31 +4,34 @@
 
 * [SoapUI](https://www.soapui.org/downloads/soapui/) can be used for "Try it out" functionality
   using the ServiceContext Header with a valid system user (CPP / XHIBIT / MID_TIER). Firstly you will need to set the
-following properties within SoapUI
+  following properties within SoapUI
 
-  *  username - The user to authenticate with
-  *  password - The password to authenticate with
-  *  token - The token (either jwt or documentum) to authenticate with
+    * username - The user to authenticate with
+    * password - The password to authenticate with
+    * token - The token (either jwt or documentum) to authenticate with
 
-* **IMPORTANT! Do not add the properties as project properties as they will be saved back to the committed xml files. Instead set them as global properties. See https://www.soapui.org/docs/soap-and-wsdl/**
+* **IMPORTANT! Do not add the properties as project properties as they will be saved back to the committed xml files. Instead set them as global properties.
+  See https://www.soapui.org/docs/soap-and-wsdl/**
 
 ## DARTSService SoapUI
 
 * To View the application SOAP Web Services:
-  * http://localhost:8070/service/darts/DARTSService?wsdl
+    * http://localhost:8070/service/darts/DARTSService?wsdl
 * Import SOAP Project [README-DARTSService](README-DARTSService-soapui-project.xml) with
   initial [DARTSService WSDL](src/main/resources/ws/dartsService.wsdl).
-* Sample requests for all operations have been created (using both user name and password authentication as well as token authentication). Initial requests e.g. addCase will use the ServiceContext Soap Header with some custom project
+* Sample requests for all operations have been created (using both user name and password authentication as well as token authentication). Initial requests e.g.
+  addCase will use the ServiceContext Soap Header with some custom project
   properties: `userName="${#Project#userName}" password="${#Project#password}"`
 * When testing the add audio endpoint make sure to change the properties to support MTOM and Multipart. Additionally, attach an mp2 file
 
 ## ContextRegistryService SoapUI
 
 * To View the application SOAP Web Services:
-  * http://localhost:8070/service/darts/runtime/ContextRegistryService?wsdl
+    * http://localhost:8070/service/darts/runtime/ContextRegistryService?wsdl
 * Import SOAP Project [README-ContextRegistryService](README-ContextRegistryService-soapui-project.xml) with
   initial [ContextRegistryService WSDL](context/src/main/resources/ws/ContextRegistryService.wsdl).
-* Sample requests for all operations have been created (using both user name and password authentication as well as token authentication). Initial requests e.g. register will use the ServiceContext Soap Header with some custom project
+* Sample requests for all operations have been created (using both user name and password authentication as well as token authentication). Initial requests e.g.
+  register will use the ServiceContext Soap Header with some custom project
   properties: `userName="${#Project#userName}" password="${#Project#password}"`
 * Requests for lookup / unregister operations use the JWT token property provided in the Soap Body, so you will need to remember to update it using the register
   response: `<token>${#Project#token}</token>`
@@ -39,22 +42,22 @@ following properties within SoapUI
   using the ServiceContext Header with a valid system user (CPP / XHIBIT / MID_TIER). Firstly you will need to set the
   following properties within Postman NOTE: This excludes the add audio test. SoapUi must be used in the case of addaudio
 
-  *  userToUse - The user to authenticate with
-  *  passwordToUse - The password to authenticate with
-  *  tokenToUse - The token (jwt by default) to authenticate with
-  *  gatewayurl - The gateway url to use
+    * userToUse - The user to authenticate with
+    * passwordToUse - The password to authenticate with
+    * tokenToUse - The token (jwt by default) to authenticate with
+    * gatewayurl - The gateway url to use
 
 ## DARTSService Postman
 
 * To View the application SOAP Web Services:
-  * http://localhost:8070/service/darts/DARTSService?wsdl
-* Import  Project [README-DARTSService](README-DARTSService-postman-project.json)
+    * http://localhost:8070/service/darts/DARTSService?wsdl
+* Import Project [README-DARTSService](README-DARTSService-postman-project.json)
 * Sample requests for all operations have been created (using both user name and password authentication as well as token authentication)`
 
 ## ContextRegistryService Postman
 
 * To View the application SOAP Web Services:
-  * http://localhost:8070/service/darts/runtime/ContextRegistryService?wsdl
+    * http://localhost:8070/service/darts/runtime/ContextRegistryService?wsdl
 * Import Postman Project [README-ContextRegistryService](README-ContextRegistryService-postman-project.json)
 * Sample requests for all operations have been created (using both user name and password authentication as well as token authentication).
 
@@ -89,27 +92,27 @@ maven repository. To do this manually then follow these steps:-
 To run the service locally, you must set the following environment variables on your machine.
 The required value of each variable is stored in Azure Key Vault as a Secret.
 
-| Environment Variable Name           | Corresponding Azure Key Vault Secret Name                                                                      |
-|-------------------------------------|----------------------------------------------------------------------------------------------------------------|
-| AAD_B2C_TENANT_ID_KEY               | AzureAdB2CTenantId                                                                                             |
-| REDIS_CONNECTION_STRING             | redis-connection-string (local Redis uri by default)                                                           |
-| MAX_FILE_UPLOAD_SIZE_MEGABYTES      | MaxFileUploadSizeInMegabytes (350mb by default)                                                                |
-| AAD_B2C_ROPC_CLIENT_ID_KEY          | AzureAdB2CFuncTestROPCClientId                                                                                 |
-| AAD_B2C_CLIENT_ID_KEY               | AzureAdB2CClientId                                                                                             |
-| DAR_NOTIFY_EVENT_SECUREMENT_PASSWORD | darts-gateway-DarNotifyEventSecurementPassword                                                                 |
-| DAR_NOTIFY_EVENT_SECUREMENT_USERNAME | darts-gateway-DarNotifyEventSecurementUsername                                                                 |
-| DARTS_API_URL                       | N/A (local darts uri by default)                                                                               |
-| REDIS_SSL_ENABLED                   | N/A (true by default)                                                                                          |
-| VIQ_EXTERNAL_USER_NAME              | The VIQ username                                                                                               |
-| VIQ_EXTERNAL_PASSWORD               | The VIQ external facing password i.e. used by the client                                                       |
-| VIQ_INTERNAL_PASSWORD               | The VIQ internal facing password i.e. used by the gateway to talk to the Idp for token acquisition             |
-| XHIBIT_EXTERNAL_USER_NAME           | The XHIBIT username                                                                                            |
-| XHIBIT_EXTERNAL_PASSWORD            | The XHIBIT external facing password i.e. used by the client                                                    |
-| XHIBIT_INTERNAL_PASSWORD            | The XHIBIT internal facing password i.e. used by the gateway to talk to the Idp for token acquisition          |
-| CP_EXTERNAL_USER_NAME               | The common platform username                                                                                   |
-| CP_EXTERNAL_PASSWORD                | The common platform facing password i.e. used by the client                                                    |
-| CP_INTERNAL_PASSWORD                | The common platform facing password i.e. used by the gateway to talk to the Idp for token acquisition          |
-| EXTERNAL_SERVICE_BASIC_AUTHORISATION_WHITELIST   | comma separated list of external services ids which are allowed to call the DARTS API with basic authorisation |
+| Environment Variable Name                      | Corresponding Azure Key Vault Secret Name                                                                      |
+|------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
+| AAD_B2C_TENANT_ID                              | AzureAdB2CTenantId                                                                                             |
+| REDIS_CONNECTION_STRING                        | redis-connection-string (local Redis uri by default)                                                           |
+| MAX_FILE_UPLOAD_SIZE_MEGABYTES                 | MaxFileUploadSizeInMegabytes (350mb by default)                                                                |
+| AAD_B2C_ROPC_CLIENT_ID                         | AzureAdB2CFuncTestROPCClientId                                                                                 |
+| AAD_B2C_CLIENT_ID                              | AzureAdB2CClientId                                                                                             |
+| DAR_NOTIFY_EVENT_SECUREMENT_PASSWORD           | darts-gateway-DarNotifyEventSecurementPassword                                                                 |
+| DAR_NOTIFY_EVENT_SECUREMENT_USERNAME           | darts-gateway-DarNotifyEventSecurementUsername                                                                 |
+| DARTS_API_URL                                  | N/A (local darts uri by default)                                                                               |
+| REDIS_SSL_ENABLED                              | N/A (true by default)                                                                                          |
+| VIQ_EXTERNAL_USER_NAME                         | The VIQ username                                                                                               |
+| VIQ_EXTERNAL_PASSWORD                          | The VIQ external facing password i.e. used by the client                                                       |
+| VIQ_INTERNAL_PASSWORD                          | The VIQ internal facing password i.e. used by the gateway to talk to the Idp for token acquisition             |
+| XHIBIT_EXTERNAL_USER_NAME                      | The XHIBIT username                                                                                            |
+| XHIBIT_EXTERNAL_PASSWORD                       | The XHIBIT external facing password i.e. used by the client                                                    |
+| XHIBIT_INTERNAL_PASSWORD                       | The XHIBIT internal facing password i.e. used by the gateway to talk to the Idp for token acquisition          |
+| CP_EXTERNAL_USER_NAME                          | The common platform username                                                                                   |
+| CP_EXTERNAL_PASSWORD                           | The common platform facing password i.e. used by the client                                                    |
+| CP_INTERNAL_PASSWORD                           | The common platform facing password i.e. used by the gateway to talk to the Idp for token acquisition          |
+| EXTERNAL_SERVICE_BASIC_AUTHORISATION_WHITELIST | comma separated list of external services ids which are allowed to call the DARTS API with basic authorisation |
 
 To obtain the secret value, you may retrieve the keys from the Azure Vault by running the `az keyvault secret show`
 command in the terminal. E.g. to obtain the value for `GOVUK_NOTIFY_API_KEY`, you should run:
@@ -131,7 +134,8 @@ in the terminal, replacing `<<env var name>>` and `<<secret value>>` as necessar
 launchctl setenv <<env var name>> <<secret value>>
 ```
 
-> Note: there is also a convenient script for exporting all these secret values from the key-vault, ensure you have the Azure CLI, `az`, installed and have run `az login`.
+> Note: there is also a convenient script for exporting all these secret values from the key-vault, ensure you have the Azure CLI, `az`, installed and have
+> run `az login`.
 > ```bash
 > source bin/secrets-stg.sh
 > ```
@@ -142,15 +146,15 @@ to make the changes permanent, make a `.zshrc` file in your users folder and pop
 
 ```
 export GOVUK_NOTIFY_API_KEY=
-export AAD_B2C_TENANT_ID_KEY=
+export AAD_B2C_TENANT_ID=
 export REDIS_CONNECTION_STRING=
 export MAX_FILE_UPLOAD_SIZE_MEGABYTES=
-export AAD_B2C_ROPC_CLIENT_ID_KEY=
+export AAD_B2C_ROPC_CLIENT_ID=
 export DAR_NOTIFY_EVENT_SECUREMENT_PASSWORD=
 export DAR_NOTIFY_EVENT_SECUREMENT_USERNAME=
 export DARTS_API_URL=
 export REDIS_SSL_ENABLED=
-export AAD_B2C_CLIENT_ID_KEY=
+export AAD_B2C_CLIENT_ID=
 
 ```
 
@@ -258,7 +262,6 @@ Here are some other functionalities it provides:
   the number of concurrent calls to any given dependency
 * [Request caching](https://github.com/Netflix/Hystrix/wiki/How-it-Works#request-caching), allowing
   different code paths to execute Hystrix Commands without worrying about duplicating work
-
 
 ### Troubleshooting
 

--- a/bin/secrets-stg.sh
+++ b/bin/secrets-stg.sh
@@ -4,11 +4,11 @@
 
 echo "Exporting secrets from Azure keyvault (darts-stg), please ensure you have \"az\" installed and you have logged in, using \"az login\"."
 
-export AAD_B2C_TENANT_ID_KEY="$(az keyvault secret show --vault-name darts-stg --name AzureAdB2CTenantId | jq .value -r)"
+export AAD_B2C_TENANT_ID="$(az keyvault secret show --vault-name darts-stg --name AzureAdB2CTenantId | jq .value -r)"
 export REDIS_CONNECTION_STRING="$(az keyvault secret show --vault-name darts-stg --name redis-connection-string  | jq .value -r)"
 export MAX_FILE_UPLOAD_SIZE_MEGABYTES="$(az keyvault secret show --vault-name darts-stg --name MaxFileUploadSizeInMegabytes | jq .value -r)"
-export AAD_B2C_ROPC_CLIENT_ID_KEY="$(az keyvault secret show --vault-name darts-stg --name AzureAdB2CFuncTestROPCClientId | jq .value -r)"
-export AAD_B2C_CLIENT_ID_KEY="$(az keyvault secret show --vault-name darts-stg --name AzureAdB2CClientId | jq .value -r)"
+export AAD_B2C_ROPC_CLIENT_ID="$(az keyvault secret show --vault-name darts-stg --name AzureAdB2CFuncTestROPCClientId | jq .value -r)"
+export AAD_B2C_CLIENT_ID="$(az keyvault secret show --vault-name darts-stg --name AzureAdB2CClientId | jq .value -r)"
 export DAR_NOTIFY_EVENT_SECUREMENT_PASSWORD="$(az keyvault secret show --vault-name darts-stg --name darts-gateway-DarNotifyEventSecurementPassword | jq .value -r)"
 export DAR_NOTIFY_EVENT_SECUREMENT_USERNAME="$(az keyvault secret show --vault-name darts-stg --name darts-gateway-DarNotifyEventSecurementUsername   | jq .value -r)"
 export VIQ_EXTERNAL_USER_NAME="$(az keyvault secret show --vault-name darts-stg --name ViQExternalUserName | jq .value -r)"

--- a/charts/darts-gateway/values.dev.template.yaml
+++ b/charts/darts-gateway/values.dev.template.yaml
@@ -10,9 +10,9 @@ java:
         - name: darts-gateway-DarNotifyEventSecurementPassword
           alias: DAR_NOTIFY_EVENT_SECUREMENT_PASSWORD
         - name: AzureAdB2CFuncTestROPCClientId
-          alias: AAD_B2C_ROPC_CLIENT_ID_KEY
+          alias: AAD_B2C_ROPC_CLIENT_ID
         - name: AzureAdB2CClientId
-          alias: AAD_B2C_CLIENT_ID_KEY
+          alias: AAD_B2C_CLIENT_ID
         - name: app-insights-connection-string
           alias: app-insights-connection-string
         - name: MaxFileUploadSizeInMegabytes
@@ -20,7 +20,7 @@ java:
         - name: redis-connection-string
           alias: REDIS_CONNECTION_STRING
         - name: AzureAdB2CTenantId
-          alias: AAD_B2C_TENANT_ID_KEY
+          alias: AAD_B2C_TENANT_ID
         - name: ViQExternalUserName
           alias: VIQ_EXTERNAL_USER_NAME
         - name: ViQExternalPassword

--- a/charts/darts-gateway/values.yaml
+++ b/charts/darts-gateway/values.yaml
@@ -11,9 +11,9 @@ java:
         - name: darts-gateway-DarNotifyEventSecurementPassword
           alias: DAR_NOTIFY_EVENT_SECUREMENT_PASSWORD
         - name: AzureAdB2CFuncTestROPCClientId
-          alias: AAD_B2C_ROPC_CLIENT_ID_KEY
+          alias: AAD_B2C_ROPC_CLIENT_ID
         - name: AzureAdB2CClientId
-          alias: AAD_B2C_CLIENT_ID_KEY
+          alias: AAD_B2C_CLIENT_ID
         - name: app-insights-connection-string
           alias: app-insights-connection-string
         - name: MaxFileUploadSizeInMegabytes
@@ -21,7 +21,7 @@ java:
         - name: redis-connection-string
           alias: REDIS_CONNECTION_STRING
         - name: AzureAdB2CTenantId
-          alias: AAD_B2C_TENANT_ID_KEY
+          alias: AAD_B2C_TENANT_ID
         - name: ViQExternalUserName
           alias: VIQ_EXTERNAL_USER_NAME
         - name: ViQExternalPassword

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -13,12 +13,12 @@ services:
       - DARTS_API_DB_PASSWORD=darts
       - DARTS_API_DB_SCHEMA=darts
       - SPRING_PROFILES_ACTIVE=local
-      - AAD_B2C_CLIENT_ID_KEY
-      - AAD_B2C_CLIENT_SECRET_KEY
-      - AAD_B2C_TENANT_ID_KEY
+      - AAD_B2C_CLIENT_ID
+      - AAD_B2C_CLIENT_SECRET
+      - AAD_B2C_TENANT_ID
       - GOVUK_NOTIFY_API_KEY
-      - AAD_B2C_ROPC_CLIENT_ID_KEY
-      - AAD_B2C_ROPC_CLIENT_SECRET_KEY
+      - AAD_B2C_ROPC_CLIENT_ID
+      - AAD_B2C_ROPC_CLIENT_SECRET
       - AZURE_STORAGE_CONNECTION_STRING
       - AAD_TENANT_ID
       - AAD_CLIENT_ID
@@ -54,8 +54,8 @@ services:
     container_name: darts-gateway
     image: darts-gateway:master
     environment:
-      - AAD_B2C_ROPC_CLIENT_ID_KEY
-      - AAD_B2C_CLIENT_ID_KEY
+      - AAD_B2C_ROPC_CLIENT_ID
+      - AAD_B2C_CLIENT_ID
       - DARTS_API_URL=http://darts-api:4550
       - AAD_TENANT_ID
       - REDIS_CONNECTION_STRING
@@ -91,7 +91,7 @@ services:
       - POSTGRES_USER=darts
       - POSTGRES_PASSWORD=darts
       - POSTGRES_DB=darts
-    command: ["postgres", "-c", "log_statement=all"]
+    command: [ "postgres", "-c", "log_statement=all" ]
     ports:
       - "5432:5432"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
   darts-gateway:
     container_name: darts-gateway
     environment:
-      - AAD_B2C_ROPC_CLIENT_ID_KEY
-      - AAD_B2C_CLIENT_ID_KEY
+      - AAD_B2C_ROPC_CLIENT_ID
+      - AAD_B2C_CLIENT_ID
       - DARTS_API_URL
       - AAD_TENANT_ID
       - REDIS_CONNECTION_STRING

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -81,11 +81,11 @@ darts-gateway:
     base-uri: ${ACTIVE_DIRECTORY_B2C_BASE_URI:#{null}}
     auth-uri: ${ACTIVE_DIRECTORY_B2C_AUTH_URI:#{null}}
     token-uri: ${ACTIVE_DIRECTORY_B2C_AUTH_URI:#{null}}/${darts-gateway.security.signin-policy}/oauth2/v2.0/token
-    scope: ${ACTIVE_DIRECTORY_B2C_ON_MICROSOFT_URI:#{null}}/${AAD_B2C_CLIENT_ID_KEY:00000000-0000-0000-0000-000000000000}/Darts.ExternalService
-    client-id: ${AAD_B2C_CLIENT_ID_KEY:#{null}}
+    scope: ${ACTIVE_DIRECTORY_B2C_ON_MICROSOFT_URI:#{null}}/${AAD_B2C_CLIENT_ID:00000000-0000-0000-0000-000000000000}/Darts.ExternalService
+    client-id: ${AAD_B2C_CLIENT_ID:#{null}}
     jwk-set-uri: ${ACTIVE_DIRECTORY_B2C_AUTH_URI:https://hmctsstgextid.b2clogin.com/hmctsstgextid.onmicrosoft.com}/${darts-gateway.security.signin-policy}/discovery/v2.0/keys
     sign-in-policy: B2C_1_ropc_darts_signin
-    issuer-uri: ${ACTIVE_DIRECTORY_B2C_BASE_URI:#{null}}/${AAD_B2C_TENANT_ID_KEY:00000000-0000-0000-0000-000000000000}/v2.0/
+    issuer-uri: ${ACTIVE_DIRECTORY_B2C_BASE_URI:#{null}}/${AAD_B2C_TENANT_ID:00000000-0000-0000-0000-000000000000}/v2.0/
     claims: emails
     user-external-internal-mappings-enabled: true
     user-external-internal-mappings:
@@ -108,9 +108,9 @@ logging:
           darts:
             authentication:
               component:
-                SoapRequestInterceptor : trace
+                SoapRequestInterceptor: trace
 
             ws:
-              DartsMessageDispatcherServlet : trace
+              DartsMessageDispatcherServlet: trace
             common:
               client: debug


### PR DESCRIPTION
### JIRA link (if applicable) ###

[DMP-2429](https://tools.hmcts.net/jira/browse/DMP-2429)

### Change description ###

Update darts env var names (5 starting with AAD_B2C) for secret mappings - remove `_KEY` ending

| Environment Variable Name                | Corresponding Azure Key Vault Secret Name |
|------------------------------------------|-------------------------------------------|
| AAD_B2C_TENANT_ID                        | AzureAdB2CTenantId                        |
| AAD_B2C_CLIENT_ID                        | AzureAdB2CClientId                        |
| AAD_B2C_CLIENT_SECRET                    | AzureAdB2CClientSecret                    |
| AAD_B2C_ROPC_CLIENT_ID                   | AzureAdB2CFuncTestROPCClientId            |
| AAD_B2C_ROPC_CLIENT_SECRET               | AzureAdB2CFuncTestROPCClientSecret        |

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
