### PR TITLE
Setting HTTP session timeout to 4 hours 5 minutes

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,6 +5,7 @@ server:
       store-type: redis
       cookie:
         name: JSESSIONID
+      timeout: 245m
 
 management:
   endpoint:


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

- this is to ensure it lasts for just longer than the access token which expires after 4 hours.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
