### PR TITLE
DMP-3012 Setting audio metadata start/end time to use a 0 offset

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/common/util/DateConverters.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/util/DateConverters.java
@@ -2,11 +2,12 @@ package uk.gov.hmcts.darts.common.util;
 
 import com.service.mojdarts.synapps.com.addaudio.Audio;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.darts.utilities.DateUtil;
 
 import java.time.LocalDateTime;
+import java.time.Month;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
@@ -25,20 +26,17 @@ public class DateConverters {
     }
 
     public OffsetDateTime offsetDateTimeFrom(Audio.Start start) {
-        var offsetDateTime = OffsetDateTime.of(Integer.parseInt(start.getY()),
-                                 Integer.parseInt(start.getM()), Integer.parseInt(start.getD()),
-                                 Integer.parseInt(start.getH()), Integer.parseInt(start.getMIN()), Integer.parseInt(start.getS()),
-                                 0, ZoneOffset.UTC
-        );
-        return offsetDateTime.toLocalDateTime().atZone(ASSUMED_SOURCE_ZONE_ID).toOffsetDateTime();
+        var localDateTime = LocalDateTime.of(Integer.parseInt(start.getY()),
+                                             Month.of(Integer.parseInt(start.getM())), Integer.parseInt(start.getD()),
+                                             Integer.parseInt(start.getH()), Integer.parseInt(start.getMIN()), Integer.parseInt(start.getS()));
+
+        return DateUtil.toOffsetDateTime(localDateTime);
     }
 
     public OffsetDateTime offsetDateTimeFrom(Audio.End end) {
-        var offsetDateTime = OffsetDateTime.of(end.getY().intValue(), end.getM().intValue(), end.getD().intValue(),
-                                 end.getH().intValue(), end.getMIN().intValue(), end.getS().intValue(),
-                                 0, ZoneOffset.UTC
-        );
-        return offsetDateTime.toLocalDateTime().atZone(ASSUMED_SOURCE_ZONE_ID).toOffsetDateTime();
+        var localDateTime = LocalDateTime.of(end.getY().intValue(), end.getM().intValue(), end.getD().intValue(),
+                                             end.getH().intValue(), end.getMIN().intValue(), end.getS().intValue());
+        return DateUtil.toOffsetDateTime(localDateTime);
     }
 
     public ZonedDateTime offsetDateTimeToLegacyDateTime(final OffsetDateTime offsetDateTime) {

--- a/src/test/java/uk/gov/hmcts/darts/common/util/DateConvertersTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/util/DateConvertersTest.java
@@ -74,11 +74,11 @@ class DateConvertersTest {
         assertThat(offsetDateTime.getYear()).isEqualTo(2022);
         assertThat(offsetDateTime.getMonthValue()).isEqualTo(6);
         assertThat(offsetDateTime.getDayOfMonth()).isEqualTo(28);
-        assertThat(offsetDateTime.getHour()).isEqualTo(11);
+        assertThat(offsetDateTime.getHour()).isEqualTo(10);
         assertThat(offsetDateTime.getMinute()).isEqualTo(59);
         assertThat(offsetDateTime.getSecond()).isEqualTo(59);
 
-        assertThat(offsetDateTime.getOffset()).isEqualTo(ZoneOffset.ofHours(1));
+        assertThat(offsetDateTime.getOffset()).isEqualTo(ZoneOffset.ofHours(0));
     }
 
     @Test
@@ -116,11 +116,11 @@ class DateConvertersTest {
         assertThat(offsetDateTime.getYear()).isEqualTo(2022);
         assertThat(offsetDateTime.getMonthValue()).isEqualTo(6);
         assertThat(offsetDateTime.getDayOfMonth()).isEqualTo(28);
-        assertThat(offsetDateTime.getHour()).isEqualTo(11);
+        assertThat(offsetDateTime.getHour()).isEqualTo(10);
         assertThat(offsetDateTime.getMinute()).isEqualTo(59);
         assertThat(offsetDateTime.getSecond()).isEqualTo(59);
 
-        assertThat(offsetDateTime.getOffset()).isEqualTo(ZoneOffset.ofHours(1));
+        assertThat(offsetDateTime.getOffset()).isEqualTo(ZoneOffset.ofHours(0));
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-3012

### Change description ###

- seeing if this fixes the audio metadata as it's still appearing an hour ahead with the previous fix in place

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
