### PR TITLE
DMP-1557 Configured Toolchain Download Repositories to allow automati…

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,5 @@
+plugins {
+  id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
+}
 rootProject.name = 'darts-gateway'
 include 'context'


### PR DESCRIPTION
…c download of JDKs

### Change description ###
Gradle toolchains allow declaring the JDK version required for a build, and if no matching toolchain is found, Gradle can automatically download a matching one based on the configured toolchain download repositories. 
See [documentation](https://github.com/hmcts/darts-gateway/pull/469) point 4.
This PR is to configure in Darts-gateway the toolchain download repositories so that we don't have to manually install locally the required version of the JDK specified in the toolchain

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
