### PR TITLE
Renable mtom test using documentum client

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/workflow/AddAudioMtomMidTierWorkflowTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/workflow/AddAudioMtomMidTierWorkflowTest.java
@@ -30,7 +30,6 @@ import static org.mockito.Mockito.when;
 
 @ActiveProfiles("int-test-jwt-token")
 @org.testcontainers.junit.jupiter.Testcontainers(disabledWithoutDocker = true)
-@Disabled
 class AddAudioMtomMidTierWorkflowTest extends AbstractWorkflowCommand {
     @MockBean
     private TokenGenerator generator;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/workflow/command/AddAudioMidTierCommand.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/workflow/command/AddAudioMidTierCommand.java
@@ -147,7 +147,7 @@ public class AddAudioMidTierCommand implements Command {
         ImageFromDockerfile importDocker = new ImageFromDockerfile()
                 .withDockerfileFromBuilder(builder ->
                         builder
-                                .from("williamyeh/java8")
+                                .from("hmctspublic.azurecr.io/imported/williamyeh/java8")
                                 .cmd("tail", "-f", "/dev/null")
                                 .build());
         if (container == null || !container.isRunning()) {


### PR DESCRIPTION
### JIRA link (if applicable) ###

n/a

### Change description ###

re-enable the mtom transfer documentum client test using the hmcts docker registry

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
