### PR TITLE
DMP-3710 Fix logs containing dateTimes with zero seconds for Dynatrace

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/log/service/impl/DarNotificationLoggerServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/log/service/impl/DarNotificationLoggerServiceImpl.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.log.service.DarNotificationLoggerService;
 
 import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 
 @Service
 @Slf4j
@@ -19,7 +20,7 @@ public class DarNotificationLoggerServiceImpl implements DarNotificationLoggerSe
                 courthouse,
                 courtroom,
                 caseNumber,
-                offsetDateTime,
+                getDateTimeIsoFormatted(offsetDateTime),
                 responseCode);
     }
 
@@ -31,7 +32,7 @@ public class DarNotificationLoggerServiceImpl implements DarNotificationLoggerSe
                 courthouse,
                 courtroom,
                 caseNumber,
-                offsetDateTime,
+                getDateTimeIsoFormatted(offsetDateTime),
                 status,
                 message);
     }
@@ -53,9 +54,13 @@ public class DarNotificationLoggerServiceImpl implements DarNotificationLoggerSe
                 courthouse,
                 courtroom,
                 caseNumber,
-                offsetDateTime,
+                getDateTimeIsoFormatted(offsetDateTime),
                 status,
                 message,
                 responseCode);
+    }
+
+    private static String getDateTimeIsoFormatted(OffsetDateTime dateTime) {
+        return dateTime.format(DateTimeFormatter.ISO_DATE_TIME);
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/log/service/impl/DarNotificationLoggerServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/log/service/impl/DarNotificationLoggerServiceImplTest.java
@@ -28,7 +28,8 @@ import static org.slf4j.event.Level.WARN;
 class DarNotificationLoggerServiceImplTest {
 
     private static final Map<Level, Supplier<List<String>>> LOG_LEVEL_TO_CAPTURED_LOGS = new HashMap<>();
-    private static final OffsetDateTime SOME_TS = OffsetDateTime.parse("2021-01-01T02:00:00Z");
+    private static final String SOME_TS_STRING = "2021-01-01T02:00:00Z";
+    private static final OffsetDateTime SOME_TS = OffsetDateTime.parse(SOME_TS_STRING);
     private static final String SOME_URI = "some-uri";
     private static final String SOME_COURTHOUSE = "some-courthouse";
     private static final String SOME_COURTROOM = "some-courtroom";
@@ -71,7 +72,7 @@ class DarNotificationLoggerServiceImplTest {
                 SOME_URI, SOME_COURTHOUSE, SOME_COURTROOM, SOME_CASE_NUMBER, SOME_TS, 0);
 
         String expectedLogEntry = format("DAR Notify: uri=%s, courthouse=%s, courtroom=%s, caseNumber=%s, date_time=%s, response_status=OK, responseCode=0",
-                SOME_URI, SOME_COURTHOUSE, SOME_COURTROOM, SOME_CASE_NUMBER, SOME_TS);
+                SOME_URI, SOME_COURTHOUSE, SOME_COURTROOM, SOME_CASE_NUMBER, SOME_TS_STRING);
         assertThat(logCaptor.getInfoLogs()).containsExactly(expectedLogEntry);
     }
 
@@ -82,7 +83,7 @@ class DarNotificationLoggerServiceImplTest {
                 SOME_URI, SOME_COURTHOUSE, SOME_COURTROOM, SOME_CASE_NUMBER, SOME_TS, "FAILED", "some-msg", logLevel);
 
         String expectedLogEntry = format("DAR Notify: uri=%s, courthouse=%s, courtroom=%s, caseNumber=%s, date_time=%s, response_status=FAILED, " +
-                                             "message=some-msg", SOME_URI, SOME_COURTHOUSE, SOME_COURTROOM, SOME_CASE_NUMBER, SOME_TS);
+                                             "message=some-msg", SOME_URI, SOME_COURTHOUSE, SOME_COURTROOM, SOME_CASE_NUMBER, SOME_TS_STRING);
         assertThat(logsFor(logLevel)).containsExactly(expectedLogEntry);
     }
 
@@ -94,7 +95,7 @@ class DarNotificationLoggerServiceImplTest {
 
         String expectedLogEntry =
                 format("DAR Notify: uri=%s, courthouse=%s, courtroom=%s, caseNumber=%s, date_time=%s, response_status=FAILED, message=some-msg, responseCode=1",
-                SOME_URI, SOME_COURTHOUSE, SOME_COURTROOM, SOME_CASE_NUMBER, SOME_TS);
+                SOME_URI, SOME_COURTHOUSE, SOME_COURTROOM, SOME_CASE_NUMBER, SOME_TS_STRING);
         assertThat(logsFor(logLevel)).containsExactly(expectedLogEntry);
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-3710


### Change description ###
Fix for logs in Dynatrace not displaying date times correctly when timestamp contains zero seconds. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
