### PR TITLE
DMP-3723 - Use configured log setting in DARTS Gateway

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,15 +1,11 @@
 <configuration>
 
   <springProperty scope="context" name="dartsLogLevel" source="DARTS_LOG_LEVEL" defaultValue="INFO" />
+  <springProperty scope="context" name="dartsSoapRequestLogLevel" source="DARTS_SOAP_REQUEST_LOG_LEVEL" defaultValue="INFO" />
 
-  <logger name="org.springframework.web" level="DEBUG" />
-  <logger name="org.springframework.ws.client.MessageTracing.sent" level="TRACE" />
-  <logger name="org.springframework.ws.client.MessageTracing.received" level="TRACE" />
 
   <logger name="uk.gov.hmcts.darts" level="${dartsLogLevel}" />
-  <logger name="uk.gov.hmcts.darts.authentication.component.SoapRequestInterceptor" level="TRACE" />
-  <logger name="uk.gov.hmcts.darts.ws.DartsMessageDispatcherServlet" level="TRACE" />
-  <logger name="uk.gov.hmcts.darts.common.client" level="DEBUG" />
+  <logger name="uk.gov.hmcts.darts.authentication.component.SoapRequestInterceptor" level="${dartsSoapRequestLogLevel}" />
 
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/DMP-3723)


### Change description ###
The [logback.xml|https://github.com/hmcts/darts-gateway/blob/master/src/main/resources/logback.xml] in DARTS Gateway hardcodes some of the log levels, effectively ignoring the log level values passed in via Flux in some places.

There are several tasks in this ticket: 
- Remove any redundant logger configurations in logback.xml file (there looks to be some that aren't needed but needs investigation to confirm). Make as simple as possible. 
- Use the passed in log level via flux for all parts of logback.xml. Set to Info level on all environments
- Use a separate parameter for the SoapRequestInterceptor, configured in flux and then used in logback.xml. Set this to Trace in Demo and Prod. 

 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
