### PR TITLE
DMP-3314: Add payload log exclusion mechanism

### DIFF
--- a/README-DARTSService-postman-project.json
+++ b/README-DARTSService-postman-project.json
@@ -1,382 +1,293 @@
 {
-	"info": {
-		"_postman_id": "82e06121-ca57-43dc-b7f7-ad6e0a79afe4",
-		"name": "DARTSService Copy",
-		"description": "@author ewingsg",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "15829068",
-		"_collection_link": "https://speeding-resonance-716248.postman.co/workspace/darts-gateway~2dacd0ff-d9b8-4288-9aba-128732a590f2/collection/15829068-82e06121-ca57-43dc-b7f7-ad6e0a79afe4?action=share&source=collection_link&creator=15829068"
-	},
-	"item": [
-		{
-			"name": "addCase",
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "text/xml; charset=utf-8"
-					},
-					{
-						"key": "Client-Type",
-						"value": "Postman Gateway Suite",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">\n   <s:Header>\n      <ServiceContext token=\"temporary/127.0.0.1-1694086218480-789961425\" xmlns=\"http://context.core.datamodel.fs.documentum.emc.com/\">\n         <Identities xsi:type=\"RepositoryIdentity\" userName=\"{{userToUse}}\" password=\"{{passwordToUse}}\" repositoryName=\"moj_darts\" domain=\"\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"/>\n         <RuntimeProperties/>\n      </ServiceContext>\n   </s:Header>\n   <s:Body xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\n      <ns2:addCase xmlns:ns2=\"http://com.synapps.mojdarts.service.com\">\n         <document><![CDATA[<case type=\"1\" id=\"U20231129-1733\"><courthouse>Bristol</courthouse><courtroom>1</courtroom><defendants><defendant>U20221006-143541</defendant><defendant>U20221007-143542</defendant></defendants><judges><judge>Mr\n    Judge</judge><judge>Mrs Judge</judge></judges><prosecutors><prosecutor>Mr\n    Prosecutor</prosecutor><prosecutor>Mrs Prosecutor</prosecutor></prosecutors></case>]]></document>\n      </ns2:addCase>\n   </s:Body>\n</s:Envelope>",
-					"options": {
-						"raw": {
-							"language": "xml"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{DARTSServicePortBaseUrl}}",
-					"host": [
-						"{{DARTSServicePortBaseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "addCase with auth token",
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "text/xml; charset=utf-8"
-					},
-					{
-						"key": "Client-Type",
-						"value": "Postman Gateway Suite",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">\n   <s:Header>\n      <s:Header>\n      <wsse:Security xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\"><wsse:BinarySecurityToken QualificationValueType=\"http://schemas.emc.com/documentum#ResourceAccessToken\" xmlns:wsu=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\" wsu:Id=\"RAD\">{{tokenToUse}}</wsse:BinarySecurityToken></wsse:Security>\n   </s:Header>\n   </s:Header>\n   <s:Body xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\n      <ns2:addCase xmlns:ns2=\"http://com.synapps.mojdarts.service.com\">\n         <document><![CDATA[<case type=\"1\" id=\"U20231129-1733\"><courthouse>Bristol</courthouse><courtroom>1</courtroom><defendants><defendant>U20221006-143541</defendant><defendant>U20221007-143542</defendant></defendants><judges><judge>Mr\n    Judge</judge><judge>Mrs Judge</judge></judges><prosecutors><prosecutor>Mr\n    Prosecutor</prosecutor><prosecutor>Mrs Prosecutor</prosecutor></prosecutors></case>]]></document>\n      </ns2:addCase>\n   </s:Body>\n</s:Envelope>",
-					"options": {
-						"raw": {
-							"language": "xml"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{DARTSServicePortBaseUrl}}",
-					"host": [
-						"{{DARTSServicePortBaseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "registerNode with auth token",
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "text/xml; charset=utf-8"
-					},
-					{
-						"key": "Client-Type",
-						"value": "Postman Gateway Suite",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">\n   <s:Header>\n   \t<wsse:Security xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\"><wsse:BinarySecurityToken QualificationValueType=\"http://schemas.emc.com/documentum#ResourceAccessToken\" xmlns:wsu=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\" wsu:Id=\"RAD\">{{tokenToUse}}}</wsse:BinarySecurityToken></wsse:Security>\n   </s:Header>\n   <s:Body xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\n      <registerNode xmlns=\"http://com.synapps.mojdarts.service.com\">\n         <document xmlns=\"\"><![CDATA[<node type=\"DAR\">\n\t         <courthouse>Bristol</courthouse>\n\t         <courtroom>1</courtroom>\n\t         <hostname>hostname</hostname>\n\t         <ip_address>ip_address</ip_address>\n\t         <mac_address>mac_address</mac_address>\n\t         </node>]]></document>\n      </registerNode>\n   </s:Body>\n</s:Envelope>",
-					"options": {
-						"raw": {
-							"language": "xml"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{DARTSServicePortBaseUrl}}",
-					"host": [
-						"{{DARTSServicePortBaseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "registerNode",
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "text/xml; charset=utf-8"
-					},
-					{
-						"key": "Client-Type",
-						"value": "Postman Gateway Suite",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">\n   <s:Header>\n      <ServiceContext token=\"temporary/127.0.0.1-1694086218480-789961425\" xmlns=\"http://context.core.datamodel.fs.documentum.emc.com/\">\n         <Identities xsi:type=\"RepositoryIdentity\" userName=\"{{userToUse}}\" password=\"{{passwordToUse}}\" repositoryName=\"moj_darts\" domain=\"\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"/>\n         <RuntimeProperties/>\n      </ServiceContext>\n   </s:Header>\n   <s:Body xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\n      <registerNode xmlns=\"http://com.synapps.mojdarts.service.com\">\n         <document xmlns=\"\"><![CDATA[<node type=\"DAR\">\n\t         <courthouse>Bristol</courthouse>\n\t         <courtroom>1</courtroom>\n\t         <hostname>hostname</hostname>\n\t         <ip_address>ip_address</ip_address>\n\t         <mac_address>mac_address</mac_address>\n\t         </node>]]></document>\n      </registerNode>\n   </s:Body>\n</s:Envelope>",
-					"options": {
-						"raw": {
-							"language": "xml"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{DARTSServicePortBaseUrl}}",
-					"host": [
-						"{{DARTSServicePortBaseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "getCases",
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "text/xml; charset=utf-8"
-					},
-					{
-						"key": "Client-Type",
-						"value": "Postman Gateway Suite",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">\n   <s:Header>\n      <ServiceContext token=\"temporary/127.0.0.1-1694086218480-789961425\" xmlns=\"http://context.core.datamodel.fs.documentum.emc.com/\">\n         <Identities xsi:type=\"RepositoryIdentity\" userName=\"{{userToUse}}\" password=\"${{passwordToUse}}\" repositoryName=\"moj_darts\" domain=\"\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"/>\n         <RuntimeProperties/>\n      </ServiceContext>\n   </s:Header>\n   <s:Body xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\n      <registerNode xmlns=\"http://com.synapps.mojdarts.service.com\">\n         <document xmlns=\"\"><![CDATA[<node type=\"DAR\">\n\t         <courthouse>Bristol</courthouse>\n\t         <courtroom>1</courtroom>\n\t         <hostname>hostname</hostname>\n\t         <ip_address>ip_address</ip_address>\n\t         <mac_address>mac_address</mac_address>\n\t         </node>]]></document>\n      </registerNode>\n   </s:Body>\n</s:Envelope>",
-					"options": {
-						"raw": {
-							"language": "xml"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{DARTSServicePortBaseUrl}}",
-					"host": [
-						"{{DARTSServicePortBaseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "getCases with auth token",
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "text/xml; charset=utf-8"
-					},
-					{
-						"key": "Client-Type",
-						"value": "Postman Gateway Suite",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">\n   <s:Header>\n      <ServiceContext token=\"temporary/127.0.0.1-1694086218480-789961425\" xmlns=\"http://context.core.datamodel.fs.documentum.emc.com/\">\n         <Identities xsi:type=\"RepositoryIdentity\" userName=\"{{userToUse}}\" password=\"${{passwordToUse}}\" repositoryName=\"moj_darts\" domain=\"\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"/>\n         <RuntimeProperties/>\n      </ServiceContext>\n   </s:Header>\n   <s:Body xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\n      <registerNode xmlns=\"http://com.synapps.mojdarts.service.com\">\n         <document xmlns=\"\"><![CDATA[<node type=\"DAR\">\n\t         <courthouse>Bristol</courthouse>\n\t         <courtroom>1</courtroom>\n\t         <hostname>hostname</hostname>\n\t         <ip_address>ip_address</ip_address>\n\t         <mac_address>mac_address</mac_address>\n\t         </node>]]></document>\n      </registerNode>\n   </s:Body>\n</s:Envelope>",
-					"options": {
-						"raw": {
-							"language": "xml"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{DARTSServicePortBaseUrl}}",
-					"host": [
-						"{{DARTSServicePortBaseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "getCourtLog",
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "text/xml; charset=utf-8"
-					},
-					{
-						"key": "Client-Type",
-						"value": "Postman Gateway Suite",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Body>\n    <error>The element or type could not be found getCourtLog</error>\n  </soap:Body>\n</soap:Envelope>\n",
-					"options": {
-						"raw": {
-							"language": "xml"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{DARTSServicePortBaseUrl}}",
-					"host": [
-						"{{DARTSServicePortBaseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "addLogEntry",
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "text/xml; charset=utf-8"
-					},
-					{
-						"key": "Client-Type",
-						"value": "Postman Gateway Suite",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:com=\"http://com.synapps.mojdarts.service.com\">\n   <soapenv:Header>\n      <ServiceContext token=\"temporary/127.0.0.1-1694086218480-789961425\" xmlns=\"http://context.core.datamodel.fs.documentum.emc.com/\">\n         <Identities xsi:type=\"RepositoryIdentity\" userName=\"{{userToUse}}\" password=\"{{passwordToUse}}\" repositoryName=\"moj_darts\" domain=\"\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"/>\n         <RuntimeProperties/>\n      </ServiceContext>\n   </soapenv:Header>\n   <soapenv:Body>\n      <addLogEntry xmlns=\"http://com.synapps.mojdarts.service.com\">\n  <document xmlns=\"\">&lt;log_entry Y=&quot;2023&quot; M=&quot;01&quot; D=&quot;01&quot; H=&quot;10&quot; MIN=&quot;00&quot; S=&quot;00&quot;&gt;&lt;courthouse&gt;SWANSEA&lt;/courthouse&gt;&lt;courtroom&gt;CR1&lt;/courtroom&gt;&lt;case_numbers&gt;&lt;case_number&gt;CASE000001&lt;/case_number&gt;&lt;/case_numbers&gt;&lt;text&gt;THISISEVENTTEXT&lt;/text&gt;&lt;/log_entry&gt;\n  </document>\n</addLogEntry>\n\n   </soapenv:Body>\n</soapenv:Envelope>a",
-					"options": {
-						"raw": {
-							"language": "xml"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{DARTSServicePortBaseUrl}}",
-					"host": [
-						"{{DARTSServicePortBaseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "addLogEntry with auth token",
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "text/xml; charset=utf-8"
-					},
-					{
-						"key": "Client-Type",
-						"value": "Postman Gateway Suite",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "<soapenv:Envelope\n\txmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\"\n\txmlns:com=\"http://com.synapps.mojdarts.service.com\">\n\t<soapenv:Header>\n\t\t<wsse:Security\n\t\t\txmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\">\n\t\t\t<wsse:BinarySecurityToken QualificationValueType=\"http://schemas.emc.com/documentum#ResourceAccessToken\"\n\t\t\t\txmlns:wsu=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\" wsu:Id=\"RAD\">{{tokenToUse}}\n\t\t\t</wsse:BinarySecurityToken>\n\t\t</wsse:Security>\n\t</soapenv:Header>\n\t<soapenv:Body>\n\t\t<addLogEntry\n\t\t\txmlns=\"http://com.synapps.mojdarts.service.com\">\n\t\t\t<document\n\t\t\t\txmlns=\"\">&lt;log_entry Y=&quot;2023&quot; M=&quot;01&quot; D=&quot;01&quot; H=&quot;10&quot; MIN=&quot;00&quot; S=&quot;00&quot;&gt;&lt;courthouse&gt;SWANSEA&lt;/courthouse&gt;&lt;courtroom&gt;CR1&lt;/courtroom&gt;&lt;case_numbers&gt;&lt;case_number&gt;CASE000001&lt;/case_number&gt;&lt;/case_numbers&gt;&lt;text&gt;THISISEVENTTEXT&lt;/text&gt;&lt;/log_entry&gt;\n  \n\t\t\t</document>\n\t\t</addLogEntry>\n\t</soapenv:Body>\n</soapenv:Envelope>",
-					"options": {
-						"raw": {
-							"language": "xml"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{DARTSServicePortBaseUrl}}",
-					"host": [
-						"{{DARTSServicePortBaseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "addDocument",
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "text/xml; charset=utf-8"
-					},
-					{
-						"key": "Client-Type",
-						"value": "Postman Gateway Suite",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">\n   <s:Header>\n      <ServiceContext token=\"temporary/127.0.0.1-1694086218480-789961425\" xmlns=\"http://context.core.datamodel.fs.documentum.emc.com/\">\n         <Identities xsi:type=\"RepositoryIdentity\" userName=\"{{userToUse}}\" password=\"{{passwordToUse}}\" repositoryName=\"moj_darts\" domain=\"\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"/>\n         <RuntimeProperties/>\n      </ServiceContext>\n   </s:Header>\n   <s:Body>\n      <ns5:addDocument xmlns:ns5=\"http://com.synapps.mojdarts.service.com\">\n         <messageId>18418</messageId>\n         <type>DL</type>\n         <subType>DL</subType>\n         <document><![CDATA[<cs:DailyList xmlns:cs=\"http://www.courtservice.gov.uk/schemas/courtservice\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://www.courtservice.gov.uk/schemas/courtservice DailyList-v5-2.xsd\" xmlns:apd=\"http://www.govtalk.gov.uk/people/AddressAndPersonalDetails\"><cs:DocumentID><cs:DocumentName>DL 18/02/10 FINAL v1</cs:DocumentName><cs:UniqueID>DLTEST</cs:UniqueID><cs:DocumentType>DL</cs:DocumentType><cs:TimeStamp>2010-02-18T11:13:23.030</cs:TimeStamp><cs:Version>1.0</cs:Version><cs:SecurityClassification>NPM</cs:SecurityClassification><cs:SellByDate>2010-12-15</cs:SellByDate><cs:XSLstylesheetURL>http://www.courtservice.gov.uk/transforms/courtservice/dailyListHtml.xsl</cs:XSLstylesheetURL></cs:DocumentID><cs:ListHeader><cs:ListCategory>Criminal</cs:ListCategory><cs:StartDate>2010-02-18</cs:StartDate><cs:EndDate>2010-02-18</cs:EndDate><cs:Version>FINAL v1</cs:Version><cs:CRESTprintRef>MCD/112585</cs:CRESTprintRef><cs:PublishedTime>2010-02-17T16:16:50</cs:PublishedTime><cs:CRESTlistID>12298</cs:CRESTlistID></cs:ListHeader><cs:CrownCourt><cs:CourtHouseType>Crown Court</cs:CourtHouseType><cs:CourtHouseCode CourtHouseShortName=\"SNARE\">453</cs:CourtHouseCode><cs:CourtHouseName>Bristol</cs:CourtHouseName><cs:CourtHouseAddress><apd:Line>THE CROWN COURT AT Bristol</apd:Line><apd:Line>75 HOLLYBUSH HILL</apd:Line><apd:Line>Bristol, LONDON</apd:Line><apd:PostCode>E11 1QW</apd:PostCode></cs:CourtHouseAddress><cs:CourtHouseDX>DX 98240 WANSTEAD 2</cs:CourtHouseDX><cs:CourtHouseTelephone>02085300000</cs:CourtHouseTelephone><cs:CourtHouseFax>02085300072</cs:CourtHouseFax></cs:CrownCourt><cs:CourtLists><cs:CourtList><cs:CourtHouse><cs:CourtHouseType>Crown Court</cs:CourtHouseType><cs:CourtHouseCode>453</cs:CourtHouseCode><cs:CourtHouseName>Bristol</cs:CourtHouseName></cs:CourtHouse><cs:Sittings><cs:Sitting><cs:CourtRoomNumber>1AB</cs:CourtRoomNumber><cs:SittingSequenceNo>1</cs:SittingSequenceNo><cs:SittingAt>10:00:00</cs:SittingAt><cs:SittingPriority>T</cs:SittingPriority><cs:Judiciary><cs:Judge><apd:CitizenNameSurname>N&#47;A</apd:CitizenNameSurname><apd:CitizenNameRequestedName>N&#47;A</apd:CitizenNameRequestedName><cs:CRESTjudgeID>0</cs:CRESTjudgeID></cs:Judge></cs:Judiciary><cs:Hearings><cs:Hearing><cs:HearingSequenceNumber>1</cs:HearingSequenceNumber><cs:HearingDetails HearingType=\"TRL\"><cs:HearingDescription>For Trial</cs:HearingDescription><cs:HearingDate>2010-02-18</cs:HearingDate></cs:HearingDetails><cs:CRESThearingID>1</cs:CRESThearingID><cs:TimeMarkingNote>10:00 AM</cs:TimeMarkingNote><cs:CaseNumber>DMP461_Case358</cs:CaseNumber><cs:Prosecution ProsecutingAuthority=\"Crown Prosecution Service\"><cs:ProsecutingReference>CPS</cs:ProsecutingReference><cs:ProsecutingOrganisation><cs:OrganisationName>Crown Prosecution Service</cs:OrganisationName></cs:ProsecutingOrganisation></cs:Prosecution><cs:CommittingCourt><cs:CourtHouseType>Magistrates Court</cs:CourtHouseType><cs:CourtHouseCode CourtHouseShortName=\"BAM\">2725</cs:CourtHouseCode><cs:CourtHouseName>BARNET MAGISTRATES COURT</cs:CourtHouseName><cs:CourtHouseAddress><apd:Line>7C HIGH STREET</apd:Line><apd:Line>-</apd:Line><apd:Line>BARNET</apd:Line><apd:PostCode>EN5 5UE</apd:PostCode></cs:CourtHouseAddress><cs:CourtHouseDX>DX 8626 BARNET</cs:CourtHouseDX><cs:CourtHouseTelephone>02084419042</cs:CourtHouseTelephone></cs:CommittingCourt><cs:Defendants><cs:Defendant><cs:PersonalDetails><cs:Name><apd:CitizenNameForename>Franz</apd:CitizenNameForename><apd:CitizenNameSurname>KAFKA</apd:CitizenNameSurname></cs:Name><cs:IsMasked>no</cs:IsMasked><cs:DateOfBirth><apd:BirthDate>1962-06-12</apd:BirthDate><apd:VerifiedBy>not verified</apd:VerifiedBy></cs:DateOfBirth><cs:Sex>male</cs:Sex><cs:Address><apd:Line>ADDRESS LINE 1</apd:Line><apd:Line>ADDRESS LINE 2</apd:Line><apd:Line>ADDRESS LINE 3</apd:Line><apd:Line>ADDRESS LINE 4</apd:Line><apd:Line>SOMETOWN, SOMECOUNTY</apd:Line><apd:PostCode>GU12 7RT</apd:PostCode></cs:Address></cs:PersonalDetails><cs:ASNs><cs:ASN>0723XH1000000262665K</cs:ASN></cs:ASNs><cs:CRESTdefendantID>29161</cs:CRESTdefendantID><cs:PNCnumber>20123456789L</cs:PNCnumber><cs:URN>62AA1010646</cs:URN><cs:CustodyStatus>In custody</cs:CustodyStatus></cs:Defendant></cs:Defendants></cs:Hearing></cs:Hearings></cs:Sitting></cs:Sittings></cs:CourtList></cs:CourtLists></cs:DailyList>]]></document>\n      </ns5:addDocument>\n   </s:Body>\n</s:Envelope>",
-					"options": {
-						"raw": {
-							"language": "xml"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{gatewayurl}}",
-					"host": [
-						"{{gatewayurl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "addDocument Token",
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "text/xml; charset=utf-8"
-					},
-					{
-						"key": "Client-Type",
-						"value": "Postman Gateway Suite",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">\n   <s:Header>\n      <wsse:Security xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\"><wsse:BinarySecurityToken QualificationValueType=\"http://schemas.emc.com/documentum#ResourceAccessToken\" xmlns:wsu=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\" wsu:Id=\"RAD\">{{tokenToUse}}</wsse:BinarySecurityToken></wsse:Security>\n   </s:Header>\n   <s:Body>\n      <ns5:addDocument xmlns:ns5=\"http://com.synapps.mojdarts.service.com\">\n         <messageId>18418</messageId>\n         <type>DL</type>\n         <subType>DL</subType>\n         <document><![CDATA[<cs:DailyList xmlns:cs=\"http://www.courtservice.gov.uk/schemas/courtservice\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://www.courtservice.gov.uk/schemas/courtservice DailyList-v5-2.xsd\" xmlns:apd=\"http://www.govtalk.gov.uk/people/AddressAndPersonalDetails\"><cs:DocumentID><cs:DocumentName>DL 18/02/10 FINAL v1</cs:DocumentName><cs:UniqueID>CSDDL000000000576147</cs:UniqueID><cs:DocumentType>DL</cs:DocumentType><cs:TimeStamp>2010-02-18T11:13:23.030</cs:TimeStamp><cs:Version>1.0</cs:Version><cs:SecurityClassification>NPM</cs:SecurityClassification><cs:SellByDate>2010-12-15</cs:SellByDate><cs:XSLstylesheetURL>http://www.courtservice.gov.uk/transforms/courtservice/dailyListHtml.xsl</cs:XSLstylesheetURL></cs:DocumentID><cs:ListHeader><cs:ListCategory>Criminal</cs:ListCategory><cs:StartDate>2010-02-18</cs:StartDate><cs:EndDate>2010-02-18</cs:EndDate><cs:Version>FINAL v1</cs:Version><cs:CRESTprintRef>MCD/112585</cs:CRESTprintRef><cs:PublishedTime>2010-02-17T16:16:50</cs:PublishedTime><cs:CRESTlistID>12298</cs:CRESTlistID></cs:ListHeader><cs:CrownCourt><cs:CourtHouseType>Crown Court</cs:CourtHouseType><cs:CourtHouseCode CourtHouseShortName=\"SNARE\">453</cs:CourtHouseCode><cs:CourtHouseName>Bristol</cs:CourtHouseName><cs:CourtHouseAddress><apd:Line>THE CROWN COURT AT Bristol</apd:Line><apd:Line>75 HOLLYBUSH HILL</apd:Line><apd:Line>Bristol, LONDON</apd:Line><apd:PostCode>E11 1QW</apd:PostCode></cs:CourtHouseAddress><cs:CourtHouseDX>DX 98240 WANSTEAD 2</cs:CourtHouseDX><cs:CourtHouseTelephone>02085300000</cs:CourtHouseTelephone><cs:CourtHouseFax>02085300072</cs:CourtHouseFax></cs:CrownCourt><cs:CourtLists><cs:CourtList><cs:CourtHouse><cs:CourtHouseType>Crown Court</cs:CourtHouseType><cs:CourtHouseCode>453</cs:CourtHouseCode><cs:CourtHouseName>Bristol</cs:CourtHouseName></cs:CourtHouse><cs:Sittings><cs:Sitting><cs:CourtRoomNumber>1</cs:CourtRoomNumber><cs:SittingSequenceNo>1</cs:SittingSequenceNo><cs:SittingAt>10:00:00</cs:SittingAt><cs:SittingPriority>T</cs:SittingPriority><cs:Judiciary><cs:Judge><apd:CitizenNameSurname>N&#47;A</apd:CitizenNameSurname><apd:CitizenNameRequestedName>N&#47;A</apd:CitizenNameRequestedName><cs:CRESTjudgeID>0</cs:CRESTjudgeID></cs:Judge></cs:Judiciary><cs:Hearings><cs:Hearing><cs:HearingSequenceNumber>1</cs:HearingSequenceNumber><cs:HearingDetails HearingType=\"TRL\"><cs:HearingDescription>For Trial</cs:HearingDescription><cs:HearingDate>2010-02-18</cs:HearingDate></cs:HearingDetails><cs:CRESThearingID>1</cs:CRESThearingID><cs:TimeMarkingNote>10:00 AM</cs:TimeMarkingNote><cs:CaseNumber>T20107001</cs:CaseNumber><cs:Prosecution ProsecutingAuthority=\"Crown Prosecution Service\"><cs:ProsecutingReference>CPS</cs:ProsecutingReference><cs:ProsecutingOrganisation><cs:OrganisationName>Crown Prosecution Service</cs:OrganisationName></cs:ProsecutingOrganisation></cs:Prosecution><cs:CommittingCourt><cs:CourtHouseType>Magistrates Court</cs:CourtHouseType><cs:CourtHouseCode CourtHouseShortName=\"BAM\">2725</cs:CourtHouseCode><cs:CourtHouseName>BARNET MAGISTRATES COURT</cs:CourtHouseName><cs:CourtHouseAddress><apd:Line>7C HIGH STREET</apd:Line><apd:Line>-</apd:Line><apd:Line>BARNET</apd:Line><apd:PostCode>EN5 5UE</apd:PostCode></cs:CourtHouseAddress><cs:CourtHouseDX>DX 8626 BARNET</cs:CourtHouseDX><cs:CourtHouseTelephone>02084419042</cs:CourtHouseTelephone></cs:CommittingCourt><cs:Defendants><cs:Defendant><cs:PersonalDetails><cs:Name><apd:CitizenNameForename>Franz</apd:CitizenNameForename><apd:CitizenNameSurname>KAFKA</apd:CitizenNameSurname></cs:Name><cs:IsMasked>no</cs:IsMasked><cs:DateOfBirth><apd:BirthDate>1962-06-12</apd:BirthDate><apd:VerifiedBy>not verified</apd:VerifiedBy></cs:DateOfBirth><cs:Sex>male</cs:Sex><cs:Address><apd:Line>ADDRESS LINE 1</apd:Line><apd:Line>ADDRESS LINE 2</apd:Line><apd:Line>ADDRESS LINE 3</apd:Line><apd:Line>ADDRESS LINE 4</apd:Line><apd:Line>SOMETOWN, SOMECOUNTY</apd:Line><apd:PostCode>GU12 7RT</apd:PostCode></cs:Address></cs:PersonalDetails><cs:ASNs><cs:ASN>0723XH1000000262665K</cs:ASN></cs:ASNs><cs:CRESTdefendantID>29161</cs:CRESTdefendantID><cs:PNCnumber>20123456789L</cs:PNCnumber><cs:URN>62AA1010646</cs:URN><cs:CustodyStatus>In custody</cs:CustodyStatus></cs:Defendant></cs:Defendants></cs:Hearing></cs:Hearings></cs:Sitting></cs:Sittings></cs:CourtList></cs:CourtLists></cs:DailyList>]]></document>\n      </ns5:addDocument>\n   </s:Body>\n</s:Envelope>",
-					"options": {
-						"raw": {
-							"language": "xml"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{gatewayurl}}",
-					"host": [
-						"{{gatewayurl}}"
-					]
-				}
-			},
-			"response": []
-		}
-	],
-	"variable": [
-		{
-			"key": "DARTSServicePortBaseUrl",
-			"value": "http://test",
-			"type": "any"
-		}
-	]
+  "info": {
+    "_postman_id": "c8391d1a-84c6-4f03-8a7e-16c85e218956",
+    "name": "DARTSService",
+    "description": "@author ewingsg",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "15829068",
+    "_collection_link": "https://speeding-resonance-716248.postman.co/workspace/darts-gateway~2dacd0ff-d9b8-4288-9aba-128732a590f2/collection/15829068-c8391d1a-84c6-4f03-8a7e-16c85e218956?action=share&source=collection_link&creator=15829068"
+  },
+  "item": [
+    {
+      "name": "addCase",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "text/xml; charset=utf-8"
+          },
+          {
+            "key": "Client-Type",
+            "value": "Postman Gateway Suite",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">\n   <s:Header>\n      <ServiceContext token=\"temporary/127.0.0.1-1694086218480-789961425\" xmlns=\"http://context.core.datamodel.fs.documentum.emc.com/\">\n         <Identities xsi:type=\"RepositoryIdentity\" userName=\"{{userToUse}}\" password=\"{{passwordToUse}}\" repositoryName=\"moj_darts\" domain=\"\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"/>\n         <RuntimeProperties/>\n      </ServiceContext>\n   </s:Header>\n   <s:Body xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\n      <ns2:addCase xmlns:ns2=\"http://com.synapps.mojdarts.service.com\">\n         <document><![CDATA[<case type=\"1\" id=\"U20231129-1733\"><courthouse>Bristol</courthouse><courtroom>1</courtroom><defendants><defendant>U20221006-143541</defendant><defendant>U20221007-143542</defendant></defendants><judges><judge>Mr\n    Judge</judge><judge>Mrs Judge</judge></judges><prosecutors><prosecutor>Mr\n    Prosecutor</prosecutor><prosecutor>Mrs Prosecutor</prosecutor></prosecutors></case>]]></document>\n      </ns2:addCase>\n   </s:Body>\n</s:Envelope>",
+          "options": {
+            "raw": {
+              "language": "xml"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{DARTSServicePortBaseUrl}}",
+          "host": [
+            "{{DARTSServicePortBaseUrl}}"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "addCase with auth token",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "text/xml; charset=utf-8"
+          },
+          {
+            "key": "Client-Type",
+            "value": "Postman Gateway Suite",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">\n   <s:Header>\n      <s:Header>\n      <wsse:Security xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\"><wsse:BinarySecurityToken QualificationValueType=\"http://schemas.emc.com/documentum#ResourceAccessToken\" xmlns:wsu=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\" wsu:Id=\"RAD\">{{tokenToUse}}</wsse:BinarySecurityToken></wsse:Security>\n   </s:Header>\n   </s:Header>\n   <s:Body xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\n      <ns2:addCase xmlns:ns2=\"http://com.synapps.mojdarts.service.com\">\n         <document><![CDATA[<case type=\"1\" id=\"U20231129-1733\"><courthouse>Bristol</courthouse><courtroom>1</courtroom><defendants><defendant>U20221006-143541</defendant><defendant>U20221007-143542</defendant></defendants><judges><judge>Mr\n    Judge</judge><judge>Mrs Judge</judge></judges><prosecutors><prosecutor>Mr\n    Prosecutor</prosecutor><prosecutor>Mrs Prosecutor</prosecutor></prosecutors></case>]]></document>\n      </ns2:addCase>\n   </s:Body>\n</s:Envelope>",
+          "options": {
+            "raw": {
+              "language": "xml"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{DARTSServicePortBaseUrl}}",
+          "host": [
+            "{{DARTSServicePortBaseUrl}}"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "registerNode with auth token",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "text/xml; charset=utf-8"
+          },
+          {
+            "key": "Client-Type",
+            "value": "Postman Gateway Suite",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">\n   <s:Header>\n   \t<wsse:Security xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\"><wsse:BinarySecurityToken QualificationValueType=\"http://schemas.emc.com/documentum#ResourceAccessToken\" xmlns:wsu=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\" wsu:Id=\"RAD\">{{tokenToUse}}}</wsse:BinarySecurityToken></wsse:Security>\n   </s:Header>\n   <s:Body xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\n      <registerNode xmlns=\"http://com.synapps.mojdarts.service.com\">\n         <document xmlns=\"\"><![CDATA[<node type=\"DAR\">\n\t         <courthouse>Bristol</courthouse>\n\t         <courtroom>1</courtroom>\n\t         <hostname>hostname</hostname>\n\t         <ip_address>ip_address</ip_address>\n\t         <mac_address>mac_address</mac_address>\n\t         </node>]]></document>\n      </registerNode>\n   </s:Body>\n</s:Envelope>",
+          "options": {
+            "raw": {
+              "language": "xml"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{DARTSServicePortBaseUrl}}",
+          "host": [
+            "{{DARTSServicePortBaseUrl}}"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "registerNode",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "text/xml; charset=utf-8"
+          },
+          {
+            "key": "Client-Type",
+            "value": "Postman Gateway Suite",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">\n   <s:Header>\n      <ServiceContext token=\"temporary/127.0.0.1-1694086218480-789961425\" xmlns=\"http://context.core.datamodel.fs.documentum.emc.com/\">\n         <Identities xsi:type=\"RepositoryIdentity\" userName=\"{{userToUse}}\" password=\"{{passwordToUse}}\" repositoryName=\"moj_darts\" domain=\"\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"/>\n         <RuntimeProperties/>\n      </ServiceContext>\n   </s:Header>\n   <s:Body xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\n      <registerNode xmlns=\"http://com.synapps.mojdarts.service.com\">\n         <document xmlns=\"\"><![CDATA[<node type=\"DAR\">\n\t         <courthouse>Bristol</courthouse>\n\t         <courtroom>1</courtroom>\n\t         <hostname>hostname</hostname>\n\t         <ip_address>ip_address</ip_address>\n\t         <mac_address>mac_address</mac_address>\n\t         </node>]]></document>\n      </registerNode>\n   </s:Body>\n</s:Envelope>",
+          "options": {
+            "raw": {
+              "language": "xml"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{DARTSServicePortBaseUrl}}",
+          "host": [
+            "{{DARTSServicePortBaseUrl}}"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "getCases with auth token",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "text/xml; charset=utf-8"
+          },
+          {
+            "key": "Client-Type",
+            "value": "Postman Gateway Suite",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">\n   <s:Header>\n      <ServiceContext token=\"temporary/127.0.0.1-1694086218480-789961425\" xmlns=\"http://context.core.datamodel.fs.documentum.emc.com/\">\n         <Identities xsi:type=\"RepositoryIdentity\" userName=\"{{userToUse}}\" password=\"${{passwordToUse}}\" repositoryName=\"moj_darts\" domain=\"\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"/>\n         <RuntimeProperties/>\n      </ServiceContext>\n   </s:Header>\n   <s:Body xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\n      <registerNode xmlns=\"http://com.synapps.mojdarts.service.com\">\n         <document xmlns=\"\"><![CDATA[<node type=\"DAR\">\n\t         <courthouse>Bristol</courthouse>\n\t         <courtroom>1</courtroom>\n\t         <hostname>hostname</hostname>\n\t         <ip_address>ip_address</ip_address>\n\t         <mac_address>mac_address</mac_address>\n\t         </node>]]></document>\n      </registerNode>\n   </s:Body>\n</s:Envelope>",
+          "options": {
+            "raw": {
+              "language": "xml"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{DARTSServicePortBaseUrl}}",
+          "host": [
+            "{{DARTSServicePortBaseUrl}}"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "addLogEntry",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "text/xml; charset=utf-8"
+          },
+          {
+            "key": "Client-Type",
+            "value": "Postman Gateway Suite",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:com=\"http://com.synapps.mojdarts.service.com\">\n   <soapenv:Header>\n      <ServiceContext token=\"temporary/127.0.0.1-1694086218480-789961425\" xmlns=\"http://context.core.datamodel.fs.documentum.emc.com/\">\n         <Identities xsi:type=\"RepositoryIdentity\" userName=\"{{userToUse}}\" password=\"{{passwordToUse}}\" repositoryName=\"moj_darts\" domain=\"\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"/>\n         <RuntimeProperties/>\n      </ServiceContext>\n   </soapenv:Header>\n   <soapenv:Body>\n      <addLogEntry xmlns=\"http://com.synapps.mojdarts.service.com\">\n  <document xmlns=\"\">&lt;log_entry Y=&quot;2023&quot; M=&quot;01&quot; D=&quot;01&quot; H=&quot;10&quot; MIN=&quot;00&quot; S=&quot;00&quot;&gt;&lt;courthouse&gt;SWANSEA&lt;/courthouse&gt;&lt;courtroom&gt;CR1&lt;/courtroom&gt;&lt;case_numbers&gt;&lt;case_number&gt;CASE000001&lt;/case_number&gt;&lt;/case_numbers&gt;&lt;text&gt;THISISEVENTTEXT&lt;/text&gt;&lt;/log_entry&gt;\n  </document>\n</addLogEntry>\n\n   </soapenv:Body>\n</soapenv:Envelope>a",
+          "options": {
+            "raw": {
+              "language": "xml"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{DARTSServicePortBaseUrl}}",
+          "host": [
+            "{{DARTSServicePortBaseUrl}}"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "addLogEntry with auth token",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "text/xml; charset=utf-8"
+          },
+          {
+            "key": "Client-Type",
+            "value": "Postman Gateway Suite",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "<soapenv:Envelope\n\txmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\"\n\txmlns:com=\"http://com.synapps.mojdarts.service.com\">\n\t<soapenv:Header>\n\t\t<wsse:Security\n\t\t\txmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\">\n\t\t\t<wsse:BinarySecurityToken QualificationValueType=\"http://schemas.emc.com/documentum#ResourceAccessToken\"\n\t\t\t\txmlns:wsu=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\" wsu:Id=\"RAD\">{{tokenToUse}}\n\t\t\t</wsse:BinarySecurityToken>\n\t\t</wsse:Security>\n\t</soapenv:Header>\n\t<soapenv:Body>\n\t\t<addLogEntry\n\t\t\txmlns=\"http://com.synapps.mojdarts.service.com\">\n\t\t\t<document\n\t\t\t\txmlns=\"\">&lt;log_entry Y=&quot;2023&quot; M=&quot;01&quot; D=&quot;01&quot; H=&quot;10&quot; MIN=&quot;00&quot; S=&quot;00&quot;&gt;&lt;courthouse&gt;SWANSEA&lt;/courthouse&gt;&lt;courtroom&gt;CR1&lt;/courtroom&gt;&lt;case_numbers&gt;&lt;case_number&gt;CASE000001&lt;/case_number&gt;&lt;/case_numbers&gt;&lt;text&gt;THISISEVENTTEXT&lt;/text&gt;&lt;/log_entry&gt;\n  \n\t\t\t</document>\n\t\t</addLogEntry>\n\t</soapenv:Body>\n</soapenv:Envelope>",
+          "options": {
+            "raw": {
+              "language": "xml"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{DARTSServicePortBaseUrl}}",
+          "host": [
+            "{{DARTSServicePortBaseUrl}}"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "addDocument Token",
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "eyJhbGciOiJSUzI1NiIsImtpZCI6Ilg1ZVhrNHh5b2pORnVtMWtsMll0djhkbE5QNC1jNTdkTzZRR1RWQndhTmsiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiIzNjNjMTFjYi00OGI5LTQ0YmYtOWQwNi05YTM5NzNmNmY0MTMiLCJpc3MiOiJodHRwczovL2htY3Rzc3RnZXh0aWQuYjJjbG9naW4uY29tLzhiMTg1ZjhiLTY2NWQtNGJiMy1hZjRhLWFiN2VlNjFiOTMzNC92Mi4wLyIsImV4cCI6MTcyNTU3MjA3MiwibmJmIjoxNzI1NTI4ODcyLCJpZHAiOiJMb2NhbEFjY291bnQiLCJvaWQiOiI4YmRjYmFlYy04YWJjLTRmMzUtYWMzNy1kZDFkNGQ3NDc1ZGMiLCJzdWIiOiI4YmRjYmFlYy04YWJjLTRmMzUtYWMzNy1kZDFkNGQ3NDc1ZGMiLCJnaXZlbl9uYW1lIjoiQ1AiLCJmYW1pbHlfbmFtZSI6IkV4dGVybmFsIFVzZXIiLCJ0ZnAiOiJCMkNfMV9yb3BjX2RhcnRzX3NpZ25pbiIsInNjcCI6IkRhcnRzLkV4dGVybmFsU2VydmljZSIsImF6cCI6IjM2M2MxMWNiLTQ4YjktNDRiZi05ZDA2LTlhMzk3M2Y2ZjQxMyIsInZlciI6IjEuMCIsImlhdCI6MTcyNTUyODg3Mn0.OlCOuzNFZy72y4B2fs6jvFN7o_mzjhZH0uP-fwCgzVo2l-vQ1uNKHe6bnf1TG0eLURQ0bnQDKxA3M5xcsFjOCTuMfMu4n4M6ofBodLlqcA-5htnn96aGGr8E8VXvW8tE3DTjY1_DgrOWbY2ZCD4DQ4tb5uUtoqvA1qurY6ZY_SzTtXQr0fTptmsuw6ZFHru-fxqePwAdO1mz3mW4MMgC9VBLMgL4hCAJri9_JBZjL7MlWctLkAp-crHd4AJIb7KhJSP55ww2FD_9HF9Au3UyEv5sfIhsGIpBrR1zEBmSq_xWM-bwleKkIY5RnsZI1zLH-N9fDK0B147oTEMZL-rwXA",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "text/xml; charset=utf-8"
+          },
+          {
+            "key": "Client-Type",
+            "value": "Postman Gateway Suite",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">\n   <s:Header>\n      <wsse:Security xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\"><wsse:BinarySecurityToken QualificationValueType=\"http://schemas.emc.com/documentum#ResourceAccessToken\" xmlns:wsu=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\" wsu:Id=\"RAD\">{{tokenToUse}}</wsse:BinarySecurityToken></wsse:Security>\n   </s:Header>\n   <s:Body>\n      <ns5:addDocument xmlns:ns5=\"http://com.synapps.mojdarts.service.com\">\n         <messageId>18418</messageId>\n         <type>DL</type>\n         <subType>DL</subType>\n         <document><![CDATA[<cs:DailyList xmlns:cs=\"http://www.courtservice.gov.uk/schemas/courtservice\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://www.courtservice.gov.uk/schemas/courtservice DailyList-v5-2.xsd\" xmlns:apd=\"http://www.govtalk.gov.uk/people/AddressAndPersonalDetails\"><cs:DocumentID><cs:DocumentName>DL 18/02/10 FINAL v1</cs:DocumentName><cs:UniqueID>CSDDL000000000576147</cs:UniqueID><cs:DocumentType>DL</cs:DocumentType><cs:TimeStamp>2010-02-18T11:13:23.030</cs:TimeStamp><cs:Version>1.0</cs:Version><cs:SecurityClassification>NPM</cs:SecurityClassification><cs:SellByDate>2010-12-15</cs:SellByDate><cs:XSLstylesheetURL>http://www.courtservice.gov.uk/transforms/courtservice/dailyListHtml.xsl</cs:XSLstylesheetURL></cs:DocumentID><cs:ListHeader><cs:ListCategory>Criminal</cs:ListCategory><cs:StartDate>2010-02-18</cs:StartDate><cs:EndDate>2010-02-18</cs:EndDate><cs:Version>FINAL v1</cs:Version><cs:CRESTprintRef>MCD/112585</cs:CRESTprintRef><cs:PublishedTime>2010-02-17T16:16:50</cs:PublishedTime><cs:CRESTlistID>12298</cs:CRESTlistID></cs:ListHeader><cs:CrownCourt><cs:CourtHouseType>Crown Court</cs:CourtHouseType><cs:CourtHouseCode CourtHouseShortName=\"SNARE\">453</cs:CourtHouseCode><cs:CourtHouseName>Bristol</cs:CourtHouseName><cs:CourtHouseAddress><apd:Line>THE CROWN COURT AT Bristol</apd:Line><apd:Line>75 HOLLYBUSH HILL</apd:Line><apd:Line>Bristol, LONDON</apd:Line><apd:PostCode>E11 1QW</apd:PostCode></cs:CourtHouseAddress><cs:CourtHouseDX>DX 98240 WANSTEAD 2</cs:CourtHouseDX><cs:CourtHouseTelephone>02085300000</cs:CourtHouseTelephone><cs:CourtHouseFax>02085300072</cs:CourtHouseFax></cs:CrownCourt><cs:CourtLists><cs:CourtList><cs:CourtHouse><cs:CourtHouseType>Crown Court</cs:CourtHouseType><cs:CourtHouseCode>453</cs:CourtHouseCode><cs:CourtHouseName>Bristol</cs:CourtHouseName></cs:CourtHouse><cs:Sittings><cs:Sitting><cs:CourtRoomNumber>1</cs:CourtRoomNumber><cs:SittingSequenceNo>1</cs:SittingSequenceNo><cs:SittingAt>10:00:00</cs:SittingAt><cs:SittingPriority>T</cs:SittingPriority><cs:Judiciary><cs:Judge><apd:CitizenNameSurname>N&#47;A</apd:CitizenNameSurname><apd:CitizenNameRequestedName>N&#47;A</apd:CitizenNameRequestedName><cs:CRESTjudgeID>0</cs:CRESTjudgeID></cs:Judge></cs:Judiciary><cs:Hearings><cs:Hearing><cs:HearingSequenceNumber>1</cs:HearingSequenceNumber><cs:HearingDetails HearingType=\"TRL\"><cs:HearingDescription>For Trial</cs:HearingDescription><cs:HearingDate>2010-02-18</cs:HearingDate></cs:HearingDetails><cs:CRESThearingID>1</cs:CRESThearingID><cs:TimeMarkingNote>10:00 AM</cs:TimeMarkingNote><cs:CaseNumber>T20107001</cs:CaseNumber><cs:Prosecution ProsecutingAuthority=\"Crown Prosecution Service\"><cs:ProsecutingReference>CPS</cs:ProsecutingReference><cs:ProsecutingOrganisation><cs:OrganisationName>Crown Prosecution Service</cs:OrganisationName></cs:ProsecutingOrganisation></cs:Prosecution><cs:CommittingCourt><cs:CourtHouseType>Magistrates Court</cs:CourtHouseType><cs:CourtHouseCode CourtHouseShortName=\"BAM\">2725</cs:CourtHouseCode><cs:CourtHouseName>BARNET MAGISTRATES COURT</cs:CourtHouseName><cs:CourtHouseAddress><apd:Line>7C HIGH STREET</apd:Line><apd:Line>-</apd:Line><apd:Line>BARNET</apd:Line><apd:PostCode>EN5 5UE</apd:PostCode></cs:CourtHouseAddress><cs:CourtHouseDX>DX 8626 BARNET</cs:CourtHouseDX><cs:CourtHouseTelephone>02084419042</cs:CourtHouseTelephone></cs:CommittingCourt><cs:Defendants><cs:Defendant><cs:PersonalDetails><cs:Name><apd:CitizenNameForename>Franz</apd:CitizenNameForename><apd:CitizenNameSurname>KAFKA</apd:CitizenNameSurname></cs:Name><cs:IsMasked>no</cs:IsMasked><cs:DateOfBirth><apd:BirthDate>1962-06-12</apd:BirthDate><apd:VerifiedBy>not verified</apd:VerifiedBy></cs:DateOfBirth><cs:Sex>male</cs:Sex><cs:Address><apd:Line>ADDRESS LINE 1</apd:Line><apd:Line>ADDRESS LINE 2</apd:Line><apd:Line>ADDRESS LINE 3</apd:Line><apd:Line>ADDRESS LINE 4</apd:Line><apd:Line>SOMETOWN, SOMECOUNTY</apd:Line><apd:PostCode>GU12 7RT</apd:PostCode></cs:Address></cs:PersonalDetails><cs:ASNs><cs:ASN>0723XH1000000262665K</cs:ASN></cs:ASNs><cs:CRESTdefendantID>29161</cs:CRESTdefendantID><cs:PNCnumber>20123456789L</cs:PNCnumber><cs:URN>62AA1010646</cs:URN><cs:CustodyStatus>In custody</cs:CustodyStatus></cs:Defendant></cs:Defendants></cs:Hearing></cs:Hearings></cs:Sitting></cs:Sittings></cs:CourtList></cs:CourtLists></cs:DailyList>]]></document>\n      </ns5:addDocument>\n   </s:Body>\n</s:Envelope>",
+          "options": {
+            "raw": {
+              "language": "xml"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{gatewayurl}}",
+          "host": [
+            "{{gatewayurl}}"
+          ]
+        }
+      },
+      "response": []
+    }
+  ],
+  "variable": [
+    {
+      "key": "DARTSServicePortBaseUrl",
+      "value": "http://test",
+      "type": "any"
+    }
+  ]
 }

--- a/docker-compose-local-to-staging.yml
+++ b/docker-compose-local-to-staging.yml
@@ -3,10 +3,18 @@ version: '2.1'
 services:
   darts-gateway:
     container_name: darts-gateway
+    image: darts-gateway:latest
     environment:
       - AAD_B2C_ROPC_CLIENT_ID
       - AAD_B2C_CLIENT_ID
-      - DARTS_API_URL
+      - AAD_TENANT_ID
+      - REDIS_CONNECTION_STRING
+      - REDIS_SSL_ENABLED
+      - VIQ_EXTERNAL_USER_NAME
+      - VIQ_EXTERNAL_PASSWORD
+      - AAD_B2C_ROPC_CLIENT_ID
+      - AAD_B2C_CLIENT_ID
+      - DARTS_API_URL=https://darts-api.demo.platform.hmcts.net
       - AAD_TENANT_ID
       - REDIS_CONNECTION_STRING
       - REDIS_SSL_ENABLED
@@ -20,20 +28,32 @@ services:
       - CP_EXTERNAL_PASSWORD
       - CP_INTERNAL_PASSWORD
       - EXTERNAL_SERVICE_BASIC_AUTHORISATION_WHITELIST
+      - REDIS_SSL_ENABLED
+      - TESTING_SUPPORT_ENDPOINTS_ENABLED=true
+      - REDIS_CONNECTION_STRING
       - ACTIVE_DIRECTORY_B2C_BASE_URI
       - ACTIVE_DIRECTORY_B2C_AUTH_URI
       - ACTIVE_DIRECTORY_B2C_ON_MICROSOFT_URI
       - AAD_B2C_TENANT_ID
       - JWKS_REFRESH_PERIOD
       - JWKS_LIFETIME_PERIOD
+      # Allow local debugging
+      - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,address=*:8002,server=y,suspend=n
+
+      # Enabled request payload logging
+      - DARTS_SOAP_REQUEST_LOG_LEVEL=TRACE
+
+      # Enabled the local logging for all payloads, no exclusions
+      - DARTS-GATEWAY_LOGGING_EXCLUDE-PAYLOAD-REQUEST-LOGGING-BASED-ON-PAYLOAD-NAMESPACE-AND-TAG=
     build:
       context: .
       dockerfile: Dockerfile
-    image: darts-gateway:master
     ports:
       - "8070:8070"
+      - "8002:8002"
     networks:
       - darts-network
+
 networks:
   darts-network:
     driver: bridge

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -53,6 +53,9 @@ services:
   darts-gateway:
     container_name: darts-gateway
     image: darts-gateway:master
+    build:
+      context: .
+      dockerfile: Dockerfile
     environment:
       - AAD_B2C_ROPC_CLIENT_ID
       - AAD_B2C_CLIENT_ID
@@ -79,11 +82,20 @@ services:
       - AAD_B2C_TENANT_ID
       - JWKS_REFRESH_PERIOD
       - JWKS_LIFETIME_PERIOD
+
+      # Allow local debugging
+      - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,address=*:8002,server=y,suspend=n
+
+      # Enabled request payload logging
+      - DARTS_SOAP_REQUEST_LOG_LEVEL=TRACE
+
+      # Enabled the local logging for all payloads, no exclusions
+      - DARTS-GATEWAY_LOGGING_EXCLUDE-PAYLOAD-REQUEST-LOGGING-BASED-ON-PAYLOAD-NAMESPACE-AND-TAG=
     ports:
       - "8070:8070"
+      - "8002:8002"
     networks:
       - darts-network
-
   darts-stub-services:
     container_name: darts-stub-services
     image: darts-stub-services:master

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -76,9 +76,6 @@ services:
       - REDIS_SSL_ENABLED=false
       - TESTING_SUPPORT_ENDPOINTS_ENABLED=true
       - REDIS_CONNECTION_STRING=redis://darts-redis:6379
-      - ACTIVE_DIRECTORY_B2C_BASE_URI=https://hmctsstgextid.b2clogin.com
-      - ACTIVE_DIRECTORY_B2C_AUTH_URI=https://hmctsstgextid.b2clogin.com/hmctsstgextid.onmicrosoft.com
-      - ACTIVE_DIRECTORY_B2C_ON_MICROSOFT_URI=https://hmctsstgextid.onmicrosoft.com
       - AAD_B2C_TENANT_ID
       - JWKS_REFRESH_PERIOD
       - JWKS_LIFETIME_PERIOD

--- a/src/integrationTest/java/uk/gov/hmcts/darts/log/EventWebServiceLoggingTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/log/EventWebServiceLoggingTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.darts.ws;
+package uk.gov.hmcts.darts.log;
 
 
 import com.service.mojdarts.synapps.com.AddDocumentResponse;
@@ -19,6 +19,7 @@ import uk.gov.hmcts.darts.common.utils.client.SoapAssertionUtil;
 import uk.gov.hmcts.darts.common.utils.client.darts.DartsClientProvider;
 import uk.gov.hmcts.darts.common.utils.client.darts.DartsGatewayClient;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
+import uk.gov.hmcts.darts.ws.ContextRegistryParent;
 
 import java.nio.charset.Charset;
 
@@ -27,7 +28,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-@ActiveProfiles("int-test-jwt-token-shared")
+@ActiveProfiles({"int-test-jwt-token-shared", "no-payload-log-exclusions"})
 class EventWebServiceLoggingTest extends IntegrationBase {
 
     private @Value("classpath:payloads/events/valid-dailyList.xml") Resource validDlEvent;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/log/EventWebServiceLoggingTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/log/EventWebServiceLoggingTest.java
@@ -57,9 +57,6 @@ class EventWebServiceLoggingTest extends IntegrationBase {
         DartsGatewayClient client
     ) throws Exception {
 
-        // reset to make sure we do not log for the core darts operation
-        logAppender.reset();
-
         authenticationStub.assertWithUserNameAndPasswordHeader(client, () -> {
             dailyListApiStub.willRespondSuccessfully();
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/IntegrationBase.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/IntegrationBase.java
@@ -14,6 +14,7 @@ import org.springframework.cloud.openfeign.FeignAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import uk.gov.hmcts.darts.cache.token.config.SecurityProperties;
 import uk.gov.hmcts.darts.common.client.mapper.APIProblemResponseMapper;
 import uk.gov.hmcts.darts.common.client.mapper.ProblemResponseMapping;
@@ -48,8 +49,10 @@ import java.util.Map;
 @ComponentScan("uk.gov.hmcts.darts")
 @ActiveProfiles("int-test")
 @AutoConfigureWireMock(port = 8090)
-@SpringBootTest(classes = RedisConfiguration.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(classes = RedisConfiguration.class,
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @org.testcontainers.junit.jupiter.Testcontainers(disabledWithoutDocker = true)
+@TestPropertySource(properties = {"DARTS_SOAP_REQUEST_LOG_LEVEL=TRACE"})
 public class IntegrationBase implements CommandHolder {
 
     protected EventApiStub theEventApi = new EventApiStub();
@@ -58,6 +61,7 @@ public class IntegrationBase implements CommandHolder {
     protected PostCourtLogsApiStub postCourtLogsApi = new PostCourtLogsApiStub();
     protected GetCasesApiStub getCasesApiStub = new GetCasesApiStub();
     protected AuthenticationAssertion authenticationStub = new AuthenticationAssertion();
+    protected MemoryLogAppender logAppender = LogUtil.getMemoryLogger();
 
     protected static final String DEFAULT_HEADER_USERNAME = "some-user";
 
@@ -105,6 +109,8 @@ public class IntegrationBase implements CommandHolder {
 
         // populate the jkws keys endpoint with a global public key
         tokenStub.stubExternalJwksKeys(DartsTokenGenerator.getGlobalKey());
+
+        logAppender.reset();
     }
 
     public URL getGatewayUri() throws MalformedURLException {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/MemoryLogAppender.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/MemoryLogAppender.java
@@ -22,8 +22,7 @@ public class MemoryLogAppender extends AppenderBase<ILoggingEvent> {
         synchronized (GENERAL_LOGS) {
             return GENERAL_LOGS.stream()
                 .filter(event -> event.getLoggerName().startsWith(LOG_API_LOGGER_NAME_PACKAGE_PREFIX)
-                    && event.toString().contains(string)
-                    && event.getLevel().equals(level))
+                    && level == null || level != null && level.equals(event.getLevel()))
                 .collect(Collectors.toList());
         }
     }
@@ -32,8 +31,9 @@ public class MemoryLogAppender extends AppenderBase<ILoggingEvent> {
         synchronized (GENERAL_LOGS) {
             return GENERAL_LOGS.stream()
                 .filter(event -> event.toString().contains(string)
+                    && causeMessage == null || causeMessage != null && event.getThrowableProxy() != null
                     && event.getThrowableProxy().getMessage().contains(causeMessage)
-                    && event.getLevel().equals(level))
+                    && level == null || level != null && level.equals(event.getLevel()))
                 .collect(Collectors.toList());
         }
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/MemoryLogAppender.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/MemoryLogAppender.java
@@ -31,8 +31,8 @@ public class MemoryLogAppender extends AppenderBase<ILoggingEvent> {
         synchronized (GENERAL_LOGS) {
             return GENERAL_LOGS.stream()
                 .filter(event -> event.toString().contains(string)
-                    && causeMessage == null || causeMessage != null && event.getThrowableProxy() != null
-                    && event.getThrowableProxy().getMessage().contains(causeMessage)
+                    && causeMessage == null || (causeMessage != null && event.getThrowableProxy() != null
+                    && event.getThrowableProxy().getMessage().contains(causeMessage))
                     && level == null || level != null && level.equals(event.getLevel()))
                 .collect(Collectors.toList());
         }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/MemoryLogAppender.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/MemoryLogAppender.java
@@ -31,8 +31,8 @@ public class MemoryLogAppender extends AppenderBase<ILoggingEvent> {
         synchronized (GENERAL_LOGS) {
             return GENERAL_LOGS.stream()
                 .filter(event -> event.toString().contains(string)
-                    && causeMessage == null || (causeMessage != null && event.getThrowableProxy() != null
-                    && event.getThrowableProxy().getMessage().contains(causeMessage))
+                    && causeMessage == null || causeMessage != null && event.getThrowableProxy() != null
+                    && event.getThrowableProxy().getMessage().contains(causeMessage)
                     && level == null || level != null && level.equals(event.getLevel()))
                 .collect(Collectors.toList());
         }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/AddAudioWebServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/AddAudioWebServiceTest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.util.unit.DataSize;
 import uk.gov.hmcts.darts.addaudio.validator.AddAudioValidator;
+import uk.gov.hmcts.darts.authentication.component.SoapRequestInterceptor;
 import uk.gov.hmcts.darts.cache.token.component.TokenValidator;
 import uk.gov.hmcts.darts.cache.token.component.impl.OauthTokenGenerator;
 import uk.gov.hmcts.darts.cache.token.service.Token;
@@ -161,8 +162,9 @@ class AddAudioWebServiceTest extends IntegrationBase {
     @ArgumentsSource(DartsClientProvider.class)
     void testAddAudioWithAuthenticationToken(DartsGatewayClient client) throws Exception {
         authenticationStub.assertWithTokenHeader(client, () -> {
-            String soapRequestStr = TestUtils.getContentsFromFile(
-                "payloads/addAudio/register/soapRequest.xml");
+
+            // reset to make sure we do not log for the core darts operation
+            logAppender.reset();
 
             String dartsApiResponseStr = TestUtils.getContentsFromFile(
                 "payloads/addAudio/register/dartsApiResponse.json");
@@ -176,11 +178,18 @@ class AddAudioWebServiceTest extends IntegrationBase {
             XmlWithFileMultiPartRequest request = new DummyXmlWithFileMultiPartRequest(AddAudioMidTierCommand.SAMPLE_FILE);
             when(requestHolder.getRequest()).thenReturn(Optional.of(request));
 
+            String soapRequestStr = TestUtils.getContentsFromFile(
+                "payloads/addAudio/register/soapRequest.xml");
+
             SoapAssertionUtil<AddAudioResponse> response = client.addAudio(getGatewayUri(), soapRequestStr);
             response.assertIdenticalResponse(client.convertData(expectedResponseStr, AddAudioResponse.class).getValue());
 
             verify(postRequestedFor(urlPathEqualTo("/audios"))
                        .withRequestBody(new MultipartDartsProxyContentPattern()));
+
+            // ensure that the payload logging is turned off for this api call
+            Assertions.assertFalse(logAppender.searchLogs(SoapRequestInterceptor.REQUEST_PAYLOAD_PREFIX, null, null).isEmpty());
+
         }, getContextClient(), getGatewayUri(), DEFAULT_HEADER_USERNAME, DEFAULT_HEADER_PASSWORD);
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/AddAudioWebServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/AddAudioWebServiceTest.java
@@ -163,9 +163,6 @@ class AddAudioWebServiceTest extends IntegrationBase {
     void testAddAudioWithAuthenticationToken(DartsGatewayClient client) throws Exception {
         authenticationStub.assertWithTokenHeader(client, () -> {
 
-            // reset to make sure we do not log for the core darts operation
-            logAppender.reset();
-
             String dartsApiResponseStr = TestUtils.getContentsFromFile(
                 "payloads/addAudio/register/dartsApiResponse.json");
 
@@ -186,9 +183,6 @@ class AddAudioWebServiceTest extends IntegrationBase {
 
             verify(postRequestedFor(urlPathEqualTo("/audios"))
                        .withRequestBody(new MultipartDartsProxyContentPattern()));
-
-            // ensure that the payload logging is turned off for this api call
-            Assertions.assertFalse(logAppender.searchLogs(SoapRequestInterceptor.REQUEST_PAYLOAD_PREFIX, null, null).isEmpty());
 
         }, getContextClient(), getGatewayUri(), DEFAULT_HEADER_USERNAME, DEFAULT_HEADER_PASSWORD);
     }
@@ -238,6 +232,7 @@ class AddAudioWebServiceTest extends IntegrationBase {
     @ArgumentsSource(DartsClientProvider.class)
     void testAddAudio(DartsGatewayClient client) throws Exception {
         authenticationStub.assertWithUserNameAndPasswordHeader(client, () -> {
+
             String soapRequestStr = TestUtils.getContentsFromFile(
                 "payloads/addAudio/register/soapRequest.xml");
 
@@ -258,6 +253,9 @@ class AddAudioWebServiceTest extends IntegrationBase {
 
             verify(postRequestedFor(urlPathEqualTo("/audios"))
                        .withRequestBody(new MultipartDartsProxyContentPattern()));
+
+            // ensure that the payload logging is turned off for this api call
+            Assertions.assertFalse(logAppender.searchLogs(SoapRequestInterceptor.REQUEST_PAYLOAD_PREFIX, null, null).isEmpty());
         }, DEFAULT_HEADER_USERNAME, DEFAULT_HEADER_PASSWORD);
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/CasesWebServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/CasesWebServiceTest.java
@@ -182,9 +182,6 @@ class CasesWebServiceTest extends IntegrationBase {
     @ArgumentsSource(DartsClientProvider.class)
     void testHandlesGetCases(DartsGatewayClient client) throws IOException, JAXBException, InterruptedException {
         authenticationStub.assertWithUserNameAndPasswordHeader(client, () -> {
-            // reset to make sure we do not log for the core darts operation
-            logAppender.reset();
-
             String soapRequestStr = TestUtils.getContentsFromFile(
                 "payloads/getCases/soapRequest.xml");
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/CourtLogsWebServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/CourtLogsWebServiceTest.java
@@ -206,8 +206,6 @@ class CourtLogsWebServiceTest extends IntegrationBase {
     @ArgumentsSource(DartsClientProvider.class)
     void testRoutesGetCourtLogRequest(DartsGatewayClient client) throws Exception {
         authenticationStub.assertWithUserNameAndPasswordHeader(client, () -> {
-            // reset to make sure we do not log for the core darts operation
-            logAppender.reset();
 
             List<CourtLog> dartsApiCourtLogsResponse = someListOfCourtLog(3);
             courtLogsApi.returnsCourtLogs(dartsApiCourtLogsResponse);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/EventWebServiceLoggingTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/EventWebServiceLoggingTest.java
@@ -1,0 +1,87 @@
+package uk.gov.hmcts.darts.ws;
+
+
+import com.service.mojdarts.synapps.com.AddDocumentResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.io.Resource;
+import org.springframework.test.context.ActiveProfiles;
+import uk.gov.hmcts.darts.authentication.component.SoapRequestInterceptor;
+import uk.gov.hmcts.darts.cache.token.component.TokenGenerator;
+import uk.gov.hmcts.darts.cache.token.component.TokenValidator;
+import uk.gov.hmcts.darts.cache.token.service.Token;
+import uk.gov.hmcts.darts.common.utils.client.SoapAssertionUtil;
+import uk.gov.hmcts.darts.common.utils.client.darts.DartsClientProvider;
+import uk.gov.hmcts.darts.common.utils.client.darts.DartsGatewayClient;
+import uk.gov.hmcts.darts.testutils.IntegrationBase;
+
+import java.nio.charset.Charset;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ActiveProfiles("int-test-jwt-token-shared")
+class EventWebServiceLoggingTest extends IntegrationBase {
+
+    private @Value("classpath:payloads/events/valid-dailyList.xml") Resource validDlEvent;
+    private @Value("classpath:payloads/events/valid-event-response.xml") Resource validDlEventResponse;
+    @MockBean
+    private TokenGenerator mockOauthTokenGenerator;
+
+    @MockBean
+    private TokenValidator tokenValidator;
+
+    @BeforeEach
+    public void before() {
+        when(tokenValidator.test(Mockito.eq(Token.TokenExpiryEnum.DO_NOT_APPLY_EARLY_TOKEN_EXPIRY), Mockito.eq("test"))).thenReturn(true);
+        when(tokenValidator.test(Mockito.eq(Token.TokenExpiryEnum.APPLY_EARLY_TOKEN_EXPIRY), Mockito.eq("test"))).thenReturn(true);
+
+        when(mockOauthTokenGenerator.acquireNewToken(DEFAULT_HEADER_USERNAME, DEFAULT_HEADER_PASSWORD))
+            .thenReturn("test");
+
+        when(mockOauthTokenGenerator.acquireNewToken(ContextRegistryParent.SERVICE_CONTEXT_USER, ContextRegistryParent.SERVICE_CONTEXT_PASSWORD))
+            .thenReturn("test");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(DartsClientProvider.class)
+    void testRoutesValidDailyListPayload(
+        DartsGatewayClient client
+    ) throws Exception {
+
+        // reset to make sure we do not log for the core darts operation
+        logAppender.reset();
+
+        authenticationStub.assertWithUserNameAndPasswordHeader(client, () -> {
+            dailyListApiStub.willRespondSuccessfully();
+
+            SoapAssertionUtil<AddDocumentResponse> response = client.addDocument(
+                getGatewayUri(),
+                validDlEvent.getContentAsString(Charset.defaultCharset())
+            );
+            response.assertIdenticalResponse(client.convertData(
+                validDlEventResponse.getContentAsString(Charset.defaultCharset()),
+                AddDocumentResponse.class
+            ).getValue());
+
+            dailyListApiStub.verifyPostRequest();
+
+            // ensure that the payload logging is turned off for this api call
+            // ensure that the payload logging is turned on for this api call
+            Assertions.assertFalse(logAppender.searchLogs(SoapRequestInterceptor.REQUEST_PAYLOAD_PREFIX, null, null).isEmpty());
+        }, DEFAULT_HEADER_USERNAME, DEFAULT_HEADER_PASSWORD);
+
+        dailyListApiStub.verifyPostRequest();
+        dailyListApiStub.verifyPatchRequest();
+
+        verify(mockOauthTokenGenerator, times(2)).acquireNewToken(DEFAULT_HEADER_USERNAME, DEFAULT_HEADER_PASSWORD);
+        verifyNoMoreInteractions(mockOauthTokenGenerator);
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/EventWebServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/EventWebServiceTest.java
@@ -206,9 +206,6 @@ class EventWebServiceTest extends IntegrationBase {
         authenticationStub.assertWithUserNameAndPasswordHeader(client, () -> {
             theEventApi.willRespondSuccessfully();
 
-            // reset to make sure we do not log for the core darts operation
-            logAppender.reset();
-
             SoapAssertionUtil<AddDocumentResponse> response = client.addDocument(
                 getGatewayUri(),
                 validEvent.getContentAsString(
@@ -283,10 +280,6 @@ class EventWebServiceTest extends IntegrationBase {
     void testRoutesValidDailyListPayload(
         DartsGatewayClient client
     ) throws Exception {
-
-        // reset to make sure we do not log for the core darts operation
-        logAppender.reset();
-
         authenticationStub.assertWithUserNameAndPasswordHeader(client, () -> {
             dailyListApiStub.willRespondSuccessfully();
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/EventWebServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/EventWebServiceTest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.io.Resource;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.ws.soap.client.SoapFaultClientException;
+import uk.gov.hmcts.darts.authentication.component.SoapRequestInterceptor;
 import uk.gov.hmcts.darts.cache.token.component.TokenGenerator;
 import uk.gov.hmcts.darts.cache.token.component.TokenValidator;
 import uk.gov.hmcts.darts.cache.token.service.Token;
@@ -205,6 +206,9 @@ class EventWebServiceTest extends IntegrationBase {
         authenticationStub.assertWithUserNameAndPasswordHeader(client, () -> {
             theEventApi.willRespondSuccessfully();
 
+            // reset to make sure we do not log for the core darts operation
+            logAppender.reset();
+
             SoapAssertionUtil<AddDocumentResponse> response = client.addDocument(
                 getGatewayUri(),
                 validEvent.getContentAsString(
@@ -218,6 +222,9 @@ class EventWebServiceTest extends IntegrationBase {
 
         WireMock.verify(postRequestedFor(urlPathEqualTo("/events"))
                             .withHeader("Authorization", new RegexPattern("Bearer test")));
+
+        // ensure that the payload logging is turned off for this api call
+        Assertions.assertFalse(logAppender.searchLogs(SoapRequestInterceptor.REQUEST_PAYLOAD_PREFIX, null, null).isEmpty());
 
         verify(mockOauthTokenGenerator, times(2)).acquireNewToken(DEFAULT_HEADER_USERNAME, DEFAULT_HEADER_PASSWORD);
         theEventApi.verifyPostRequest("payloads/events/valid-event-api-request.json");
@@ -277,6 +284,9 @@ class EventWebServiceTest extends IntegrationBase {
         DartsGatewayClient client
     ) throws Exception {
 
+        // reset to make sure we do not log for the core darts operation
+        logAppender.reset();
+
         authenticationStub.assertWithUserNameAndPasswordHeader(client, () -> {
             dailyListApiStub.willRespondSuccessfully();
 
@@ -290,6 +300,9 @@ class EventWebServiceTest extends IntegrationBase {
             ).getValue());
 
             dailyListApiStub.verifyPostRequest();
+
+            // ensure that the payload logging is turned off for this api call
+            Assertions.assertTrue(logAppender.searchLogs(SoapRequestInterceptor.REQUEST_PAYLOAD_PREFIX, null, null).isEmpty());
         }, DEFAULT_HEADER_USERNAME, DEFAULT_HEADER_PASSWORD);
 
         dailyListApiStub.verifyPostRequest();

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/RegisterNodeWebServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/RegisterNodeWebServiceTest.java
@@ -11,6 +11,7 @@ import org.mockito.Mockito;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.ws.soap.client.SoapFaultClientException;
+import uk.gov.hmcts.darts.authentication.component.SoapRequestInterceptor;
 import uk.gov.hmcts.darts.cache.token.component.TokenGenerator;
 import uk.gov.hmcts.darts.cache.token.component.TokenValidator;
 import uk.gov.hmcts.darts.cache.token.service.Token;
@@ -202,6 +203,9 @@ class RegisterNodeWebServiceTest extends IntegrationBase {
     void testHandlesRegisterNode(DartsGatewayClient client) throws Exception {
 
         authenticationStub.assertWithUserNameAndPasswordHeader(client, () -> {
+            // reset to make sure we do not log for the core darts operation
+            logAppender.reset();
+
             String soapRequestStr = TestUtils.getContentsFromFile(
                 "payloads/registernode/soapRequest.xml");
 
@@ -217,6 +221,10 @@ class RegisterNodeWebServiceTest extends IntegrationBase {
 
             SoapAssertionUtil<RegisterNodeResponse> response = client.registerNode(getGatewayUri(), soapRequestStr);
             response.assertIdenticalResponse(client.convertData(expectedResponseStr, RegisterNodeResponse.class).getValue());
+
+            // ensure that the payload logging is turned off for this api call
+            org.junit.jupiter.api.Assertions.assertFalse(logAppender.searchLogs(SoapRequestInterceptor.REQUEST_PAYLOAD_PREFIX, null, null).isEmpty());
+
         }, DEFAULT_HEADER_USERNAME, DEFAULT_HEADER_PASSWORD);
 
         WireMock.verify(postRequestedFor(urlPathEqualTo("/register-devices"))

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/RegisterNodeWebServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/RegisterNodeWebServiceTest.java
@@ -203,8 +203,6 @@ class RegisterNodeWebServiceTest extends IntegrationBase {
     void testHandlesRegisterNode(DartsGatewayClient client) throws Exception {
 
         authenticationStub.assertWithUserNameAndPasswordHeader(client, () -> {
-            // reset to make sure we do not log for the core darts operation
-            logAppender.reset();
 
             String soapRequestStr = TestUtils.getContentsFromFile(
                 "payloads/registernode/soapRequest.xml");

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/token/TokenValidatorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/token/TokenValidatorTest.java
@@ -14,7 +14,6 @@ import uk.gov.hmcts.darts.common.utils.client.ctxt.ContextRegistryClientProvider
 import uk.gov.hmcts.darts.testutils.DartsTokenAndJwksKey;
 import uk.gov.hmcts.darts.testutils.DartsTokenGenerator;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
-import uk.gov.hmcts.darts.testutils.LogUtil;
 import uk.gov.hmcts.darts.testutils.request.ContextRequestHelper;
 
 import java.net.URL;
@@ -82,7 +81,7 @@ class TokenValidatorTest extends IntegrationBase {
         }
         );
 
-        Assertions.assertFalse(LogUtil.getMemoryLogger().searchLogs("JWT Token could not be validated", "Expired JWT", Level.ERROR).isEmpty());
+        Assertions.assertFalse(logAppender.searchLogs("JWT Token could not be validated", "Expired JWT", Level.ERROR).isEmpty());
     }
 
     @ParameterizedTest
@@ -100,7 +99,7 @@ class TokenValidatorTest extends IntegrationBase {
             }
         );
 
-        Assertions.assertFalse(LogUtil.getMemoryLogger().searchLogs("JWT Token could not be validated", "JWT audience rejected", Level.ERROR).isEmpty());
+        Assertions.assertFalse(logAppender.searchLogs("JWT Token could not be validated", "JWT audience rejected", Level.ERROR).isEmpty());
     }
 
     @ParameterizedTest
@@ -118,7 +117,7 @@ class TokenValidatorTest extends IntegrationBase {
             }
         );
 
-        Assertions.assertFalse(LogUtil.getMemoryLogger().searchLogs(
+        Assertions.assertFalse(logAppender.searchLogs(
             "JWT Token could not be validated", "JWT iss claim has value invalidIssuer, must be test-issuer", Level.ERROR).isEmpty());
     }
 
@@ -138,7 +137,7 @@ class TokenValidatorTest extends IntegrationBase {
             }
         );
 
-        Assertions.assertFalse(LogUtil.getMemoryLogger().searchLogs(
+        Assertions.assertFalse(logAppender.searchLogs(
             "JWT Token could not be validated", "Signed JWT rejected: Invalid signature", Level.ERROR).isEmpty());
     }
 }

--- a/src/integrationTest/resources/application-int-test-jwt-token-shared.yaml
+++ b/src/integrationTest/resources/application-int-test-jwt-token-shared.yaml
@@ -27,3 +27,5 @@ darts-gateway:
     validate: false
   security:
     external-service-basic-authorisation-whitelist: some-user, some-user2
+  logging:
+    exclude-payload-request-logging-based-on-payload-namespace-and-tag:

--- a/src/integrationTest/resources/application-int-test-jwt-token-shared.yaml
+++ b/src/integrationTest/resources/application-int-test-jwt-token-shared.yaml
@@ -27,5 +27,3 @@ darts-gateway:
     validate: false
   security:
     external-service-basic-authorisation-whitelist: some-user, some-user2
-  logging:
-    exclude-payload-request-logging-based-on-payload-namespace-and-tag:

--- a/src/integrationTest/resources/application-no-payload-log-exclusions.yaml
+++ b/src/integrationTest/resources/application-no-payload-log-exclusions.yaml
@@ -1,0 +1,3 @@
+darts-gateway:
+  logging:
+    exclude-payload-request-logging-based-on-payload-namespace-and-tag:

--- a/src/integrationTest/resources/logback-test.xml
+++ b/src/integrationTest/resources/logback-test.xml
@@ -1,16 +1,29 @@
 <configuration>
-    <appender name="MEMORY" class="uk.gov.hmcts.darts.testutils.MemoryLogAppender">
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
-    <root level="error">
-        <appender-ref ref="MEMORY"/>
-        <appender-ref ref="CONSOLE"/>
-    </root>
+<springProperty scope="context" name="dartsLogLevel" source="DARTS_LOG_LEVEL" defaultValue="INFO" />
+<springProperty scope="context" name="dartsSoapRequestLogLevel" source="DARTS_SOAP_REQUEST_LOG_LEVEL" defaultValue="INFO" />
+
+<logger name="uk.gov.hmcts.darts" level="${dartsLogLevel}" />
+<logger name="uk.gov.hmcts.darts.authentication.component.SoapRequestInterceptor" level="${dartsSoapRequestLogLevel}" />
+
+<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+  <encoder>
+    <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+  </encoder>
+</appender>
+
+<appender name="MEMORY" class="uk.gov.hmcts.darts.testutils.MemoryLogAppender">
+  <encoder>
+    <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+  </encoder>
+</appender>
+
+<appender name="ASYNC_CONSOLE" class="ch.qos.logback.classic.AsyncAppender">
+  <appender-ref ref="CONSOLE" />
+</appender>
+
+<root level="INFO">
+  <appender-ref ref="MEMORY"/>
+  <appender-ref ref="ASYNC_CONSOLE" />
+</root>
+
 </configuration>

--- a/src/main/java/uk/gov/hmcts/darts/authentication/component/SoapRequestInterceptor.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/component/SoapRequestInterceptor.java
@@ -247,15 +247,15 @@ public class SoapRequestInterceptor implements SoapEndpointInterceptor {
         // lets not process any of the payloads if trace level is disabled
         if (log.isTraceEnabled()) {
             try {
-                ByteArrayTransportOutputStream byteArrayTransportOutputStream =
-                    new ByteArrayTransportOutputStream();
-                message.writeTo(byteArrayTransportOutputStream);
-
                 Optional<ExcludePayloadLogging> excludePayloadLogging;
                 if (message.getPayloadSource() instanceof DOMSource) {
                     excludePayloadLogging =  logProperties.excludePayload((DOMSource) message.getPayloadSource());
 
                     if (excludePayloadLogging.isEmpty()) {
+                        ByteArrayTransportOutputStream byteArrayTransportOutputStream =
+                            new ByteArrayTransportOutputStream();
+                        message.writeTo(byteArrayTransportOutputStream);
+
                         String payloadMessage = NEW_LINE + MESSAGE_SEPERATOR
                             + NEW_LINE + new String(byteArrayTransportOutputStream.toByteArray()) + NEW_LINE
                             + MESSAGE_SEPERATOR + NEW_LINE;

--- a/src/main/java/uk/gov/hmcts/darts/log/conf/ExcludePayloadLogging.java
+++ b/src/main/java/uk/gov/hmcts/darts/log/conf/ExcludePayloadLogging.java
@@ -1,0 +1,18 @@
+package uk.gov.hmcts.darts.log.conf;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExcludePayloadLogging {
+    private String namespace;
+
+    private String tag;
+
+    private String type;
+}

--- a/src/main/java/uk/gov/hmcts/darts/log/conf/LogProperties.java
+++ b/src/main/java/uk/gov/hmcts/darts/log/conf/LogProperties.java
@@ -1,0 +1,75 @@
+package uk.gov.hmcts.darts.log.conf;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import javax.xml.namespace.NamespaceContext;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+@Component
+@ConfigurationProperties("darts-gateway.logging")
+@Getter
+@Setter
+@ToString
+@Validated
+@Slf4j
+public class LogProperties {
+    private List<ExcludePayloadLogging> excludePayloadRequestLoggingBasedOnPayloadNamespaceAndTag;
+
+    @SuppressWarnings("AbbreviationAsWordInName")
+    public Optional<ExcludePayloadLogging> excludePayload(DOMSource xml) {
+        Stream<ExcludePayloadLogging> excludeFromLogging = getExcludePayloadRequestLoggingBasedOnPayloadNamespaceAndTag()
+            .stream().filter(payloadFilterDetails -> {
+                NamespaceContext ctx = new NamespaceContext() {
+                    public String getNamespaceURI(String prefix) {
+                        return prefix.equals("docNamespace") ? payloadFilterDetails.getNamespace() : null;
+                    }
+
+                    public Iterator<String> getPrefixes(String val) {
+                        return null;
+                    }
+
+                    public String getPrefix(String uri) {
+                        return null;
+                    }
+                };
+
+                try {
+                    XPathFactory pathFactory = XPathFactory.newInstance();
+                    XPath xpath = pathFactory.newXPath();
+                    xpath.setNamespaceContext(ctx);
+
+                    if (payloadFilterDetails.getType() != null) {
+                        return !xpath.evaluate(
+                            "//docNamespace:" + payloadFilterDetails.getTag() + "/type[text()='" + payloadFilterDetails.getType() + "']",
+                            xml.getNode()
+                        ).isEmpty();
+                    } else {
+                        return !xpath.evaluate(
+                            "//docNamespace:" + payloadFilterDetails.getTag(),
+                            xml.getNode()
+                        ).isEmpty();
+                    }
+                } catch (XPathExpressionException pathExpressionException) {
+                    log.error("Error when filtering payload from logs", pathExpressionException);
+                }
+
+                // always exclude in the eventuality of an xpath error
+                return true;
+            });
+
+        return excludeFromLogging.findAny();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/routing/EventRoutingService.java
+++ b/src/main/java/uk/gov/hmcts/darts/routing/EventRoutingService.java
@@ -16,7 +16,7 @@ import static java.util.Arrays.asList;
 @RequiredArgsConstructor
 public class EventRoutingService {
 
-    private static final Set<String> DAILY_LIST_TYPES = new HashSet<>(asList("CPPDL", "DL"));
+    public static final Set<String> DAILY_LIST_TYPES = new HashSet<>(asList("CPPDL", "DL"));
 
     private final DailyListRoute dailyListRoute;
     private final EventRoute eventRoute;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -101,14 +101,14 @@ darts-gateway:
     connection-string: ${REDIS_CONNECTION_STRING:redis://localhost:6379}
     ssl-enabled: ${REDIS_SSL_ENABLED:true}
   security:
-    base-uri: ${ACTIVE_DIRECTORY_B2C_BASE_URI:#{null}}
-    auth-uri: ${ACTIVE_DIRECTORY_B2C_AUTH_URI:#{null}}
-    token-uri: ${ACTIVE_DIRECTORY_B2C_AUTH_URI:#{null}}/${darts-gateway.security.signin-policy}/oauth2/v2.0/token
-    scope: ${ACTIVE_DIRECTORY_B2C_ON_MICROSOFT_URI:#{null}}/${AAD_B2C_CLIENT_ID:00000000-0000-0000-0000-000000000000}/Darts.ExternalService
+    base-uri: ${ACTIVE_DIRECTORY_B2C_BASE_URI:https://hmctsstgextid.b2clogin.com}
+    auth-uri: ${ACTIVE_DIRECTORY_B2C_AUTH_URI:https://hmctsstgextid.b2clogin.com/hmctsstgextid.onmicrosoft.com}
+    token-uri: ${ACTIVE_DIRECTORY_B2C_AUTH_URI:https://hmctsstgextid.b2clogin.com/hmctsstgextid.onmicrosoft.com}/${darts-gateway.security.signin-policy}/oauth2/v2.0/token
+    scope: ${ACTIVE_DIRECTORY_B2C_ON_MICROSOFT_URI:https://hmctsstgextid.onmicrosoft.com}/${AAD_B2C_CLIENT_ID:00000000-0000-0000-0000-000000000000}/Darts.ExternalService
     client-id: ${AAD_B2C_CLIENT_ID:#{null}}
     jwk-set-uri: ${ACTIVE_DIRECTORY_B2C_AUTH_URI:https://hmctsstgextid.b2clogin.com/hmctsstgextid.onmicrosoft.com}/${darts-gateway.security.signin-policy}/discovery/v2.0/keys
     sign-in-policy: B2C_1_ropc_darts_signin
-    issuer-uri: ${ACTIVE_DIRECTORY_B2C_BASE_URI:#{null}}/${AAD_B2C_TENANT_ID:00000000-0000-0000-0000-000000000000}/v2.0/
+    issuer-uri: ${ACTIVE_DIRECTORY_B2C_BASE_URI:${darts-gateway.security.base-uri}}/${AAD_B2C_TENANT_ID:00000000-0000-0000-0000-000000000000}/v2.0/
     claims: emails
     user-external-internal-mappings-enabled: true
     user-external-internal-mappings:
@@ -124,3 +124,13 @@ darts-gateway:
     external-service-basic-authorisation-whitelist: ${EXTERNAL_SERVICE_BASIC_AUTHORISATION_WHITELIST:#{null}}
     jwks-cache-refresh_period: ${JWKS_REFRESH_PERIOD:30m}
     jwks-cache-lifetime_period:  ${JWKS_LIFETIME_PERIOD:60m}
+
+  # Default payload logging to be disabled for add document payloads
+  logging:
+    exclude-payload-request-logging-based-on-payload-namespace-and-tag:
+      - namespace:  http://com.synapps.mojdarts.service.com
+        tag: addDocument
+        type: CPPDL
+      - namespace: http://com.synapps.mojdarts.service.com
+        tag: addDocument
+        type: DL

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -125,7 +125,7 @@ darts-gateway:
     jwks-cache-refresh_period: ${JWKS_REFRESH_PERIOD:30m}
     jwks-cache-lifetime_period:  ${JWKS_LIFETIME_PERIOD:60m}
 
-  # Default payload logging to be disabled for add document payloads
+  # Default payload logging to be disabled for daily list payloads
   logging:
     exclude-payload-request-logging-based-on-payload-namespace-and-tag:
       - namespace:  http://com.synapps.mojdarts.service.com

--- a/src/test/java/uk/gov/hmcts/darts/log/config/LogPropertiesTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/log/config/LogPropertiesTest.java
@@ -1,0 +1,132 @@
+package uk.gov.hmcts.darts.log.config;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+import uk.gov.hmcts.darts.log.conf.ExcludePayloadLogging;
+import uk.gov.hmcts.darts.log.conf.LogProperties;
+
+import java.io.StringReader;
+import java.util.List;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.dom.DOMSource;
+
+class LogPropertiesTest {
+
+    private static final String EXCLUSION_LOGGING_PAYLOAD_DL = """
+        <ns5:addDocument xmlns:ns5="http://com.synapps.mojdarts.service.com">
+                 <messageId>18418</messageId>
+                 <type>DL</type>
+                 <subType>DL</subType>
+                 <document><![CDATA[<cs:DailyList xmlns:cs="http://www.courtservice.gov.uk/schemas/courtservice" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.courtservice.gov.uk/schemas/courtservice DailyList-v5-2.xsd" xmlns:apd="http://www.govtalk.gov.uk/people/AddressAndPersonalDetails"><cs:DocumentID><cs:DocumentName>DL 18/02/10 FINAL v1</cs:DocumentName><cs:UniqueID>CSDDL000000000576147</cs:UniqueID><cs:DocumentType>DL</cs:DocumentType><cs:TimeStamp>2010-02-18T11:13:23.030</cs:TimeStamp><cs:Version>1.0</cs:Version><cs:SecurityClassification>NPM</cs:SecurityClassification><cs:SellByDate>2010-12-15</cs:SellByDate><cs:XSLstylesheetURL>http://www.courtservice.gov.uk/transforms/courtservice/dailyListHtml.xsl</cs:XSLstylesheetURL></cs:DocumentID><cs:ListHeader><cs:ListCategory>Criminal</cs:ListCategory><cs:StartDate>2010-02-18</cs:StartDate><cs:EndDate>2010-02-18</cs:EndDate><cs:Version>FINAL v1</cs:Version><cs:CRESTprintRef>MCD/112585</cs:CRESTprintRef><cs:PublishedTime>2010-02-17T16:16:50</cs:PublishedTime><cs:CRESTlistID>12298</cs:CRESTlistID></cs:ListHeader><cs:CrownCourt><cs:CourtHouseType>Crown Court</cs:CourtHouseType><cs:CourtHouseCode CourtHouseShortName="SNARE">453</cs:CourtHouseCode><cs:CourtHouseName>Bristol</cs:CourtHouseName><cs:CourtHouseAddress><apd:Line>THE CROWN COURT AT Bristol</apd:Line><apd:Line>75 HOLLYBUSH HILL</apd:Line><apd:Line>Bristol, LONDON</apd:Line><apd:PostCode>E11 1QW</apd:PostCode></cs:CourtHouseAddress><cs:CourtHouseDX>DX 98240 WANSTEAD 2</cs:CourtHouseDX><cs:CourtHouseTelephone>02085300000</cs:CourtHouseTelephone><cs:CourtHouseFax>02085300072</cs:CourtHouseFax></cs:CrownCourt><cs:CourtLists><cs:CourtList><cs:CourtHouse><cs:CourtHouseType>Crown Court</cs:CourtHouseType><cs:CourtHouseCode>453</cs:CourtHouseCode><cs:CourtHouseName>Bristol</cs:CourtHouseName></cs:CourtHouse><cs:Sittings><cs:Sitting><cs:CourtRoomNumber>1</cs:CourtRoomNumber><cs:SittingSequenceNo>1</cs:SittingSequenceNo><cs:SittingAt>10:00:00</cs:SittingAt><cs:SittingPriority>T</cs:SittingPriority><cs:Judiciary><cs:Judge><apd:CitizenNameSurname>N&#47;A</apd:CitizenNameSurname><apd:CitizenNameRequestedName>N&#47;A</apd:CitizenNameRequestedName><cs:CRESTjudgeID>0</cs:CRESTjudgeID></cs:Judge></cs:Judiciary><cs:Hearings><cs:Hearing><cs:HearingSequenceNumber>1</cs:HearingSequenceNumber><cs:HearingDetails HearingType="TRL"><cs:HearingDescription>For Trial</cs:HearingDescription><cs:HearingDate>2010-02-18</cs:HearingDate></cs:HearingDetails><cs:CRESThearingID>1</cs:CRESThearingID><cs:TimeMarkingNote>10:00 AM</cs:TimeMarkingNote><cs:CaseNumber>T20107001</cs:CaseNumber><cs:Prosecution ProsecutingAuthority="Crown Prosecution Service"><cs:ProsecutingReference>CPS</cs:ProsecutingReference><cs:ProsecutingOrganisation><cs:OrganisationName>Crown Prosecution Service</cs:OrganisationName></cs:ProsecutingOrganisation></cs:Prosecution><cs:CommittingCourt><cs:CourtHouseType>Magistrates Court</cs:CourtHouseType><cs:CourtHouseCode CourtHouseShortName="BAM">2725</cs:CourtHouseCode><cs:CourtHouseName>BARNET MAGISTRATES COURT</cs:CourtHouseName><cs:CourtHouseAddress><apd:Line>7C HIGH STREET</apd:Line><apd:Line>-</apd:Line><apd:Line>BARNET</apd:Line><apd:PostCode>EN5 5UE</apd:PostCode></cs:CourtHouseAddress><cs:CourtHouseDX>DX 8626 BARNET</cs:CourtHouseDX><cs:CourtHouseTelephone>02084419042</cs:CourtHouseTelephone></cs:CommittingCourt><cs:Defendants><cs:Defendant><cs:PersonalDetails><cs:Name><apd:CitizenNameForename>Franz</apd:CitizenNameForename><apd:CitizenNameSurname>KAFKA</apd:CitizenNameSurname></cs:Name><cs:IsMasked>no</cs:IsMasked><cs:DateOfBirth><apd:BirthDate>1962-06-12</apd:BirthDate><apd:VerifiedBy>not verified</apd:VerifiedBy></cs:DateOfBirth><cs:Sex>male</cs:Sex><cs:Address><apd:Line>ADDRESS LINE 1</apd:Line><apd:Line>ADDRESS LINE 2</apd:Line><apd:Line>ADDRESS LINE 3</apd:Line><apd:Line>ADDRESS LINE 4</apd:Line><apd:Line>SOMETOWN, SOMECOUNTY</apd:Line><apd:PostCode>GU12 7RT</apd:PostCode></cs:Address></cs:PersonalDetails><cs:ASNs><cs:ASN>0723XH1000000262665K</cs:ASN></cs:ASNs><cs:CRESTdefendantID>29161</cs:CRESTdefendantID><cs:PNCnumber>20123456789L</cs:PNCnumber><cs:URN>62AA1010646</cs:URN><cs:CustodyStatus>In custody</cs:CustodyStatus></cs:Defendant></cs:Defendants></cs:Hearing></cs:Hearings></cs:Sitting></cs:Sittings></cs:CourtList></cs:CourtLists></cs:DailyList>]]></document>
+              </ns5:addDocument>
+        """;
+
+    private static final String EXCLUSION_LOGGING_PAYLOAD_CPPDL = """
+        <ns5:addDocument xmlns:ns5="http://com.synapps.mojdarts.service.com">
+                 <messageId>18418</messageId>
+                 <type>CPPDL</type>
+                 <subType>DL</subType>
+                 <document><![CDATA[<cs:DailyList xmlns:cs="http://www.courtservice.gov.uk/schemas/courtservice" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.courtservice.gov.uk/schemas/courtservice DailyList-v5-2.xsd" xmlns:apd="http://www.govtalk.gov.uk/people/AddressAndPersonalDetails"><cs:DocumentID><cs:DocumentName>DL 18/02/10 FINAL v1</cs:DocumentName><cs:UniqueID>CSDDL000000000576147</cs:UniqueID><cs:DocumentType>DL</cs:DocumentType><cs:TimeStamp>2010-02-18T11:13:23.030</cs:TimeStamp><cs:Version>1.0</cs:Version><cs:SecurityClassification>NPM</cs:SecurityClassification><cs:SellByDate>2010-12-15</cs:SellByDate><cs:XSLstylesheetURL>http://www.courtservice.gov.uk/transforms/courtservice/dailyListHtml.xsl</cs:XSLstylesheetURL></cs:DocumentID><cs:ListHeader><cs:ListCategory>Criminal</cs:ListCategory><cs:StartDate>2010-02-18</cs:StartDate><cs:EndDate>2010-02-18</cs:EndDate><cs:Version>FINAL v1</cs:Version><cs:CRESTprintRef>MCD/112585</cs:CRESTprintRef><cs:PublishedTime>2010-02-17T16:16:50</cs:PublishedTime><cs:CRESTlistID>12298</cs:CRESTlistID></cs:ListHeader><cs:CrownCourt><cs:CourtHouseType>Crown Court</cs:CourtHouseType><cs:CourtHouseCode CourtHouseShortName="SNARE">453</cs:CourtHouseCode><cs:CourtHouseName>Bristol</cs:CourtHouseName><cs:CourtHouseAddress><apd:Line>THE CROWN COURT AT Bristol</apd:Line><apd:Line>75 HOLLYBUSH HILL</apd:Line><apd:Line>Bristol, LONDON</apd:Line><apd:PostCode>E11 1QW</apd:PostCode></cs:CourtHouseAddress><cs:CourtHouseDX>DX 98240 WANSTEAD 2</cs:CourtHouseDX><cs:CourtHouseTelephone>02085300000</cs:CourtHouseTelephone><cs:CourtHouseFax>02085300072</cs:CourtHouseFax></cs:CrownCourt><cs:CourtLists><cs:CourtList><cs:CourtHouse><cs:CourtHouseType>Crown Court</cs:CourtHouseType><cs:CourtHouseCode>453</cs:CourtHouseCode><cs:CourtHouseName>Bristol</cs:CourtHouseName></cs:CourtHouse><cs:Sittings><cs:Sitting><cs:CourtRoomNumber>1</cs:CourtRoomNumber><cs:SittingSequenceNo>1</cs:SittingSequenceNo><cs:SittingAt>10:00:00</cs:SittingAt><cs:SittingPriority>T</cs:SittingPriority><cs:Judiciary><cs:Judge><apd:CitizenNameSurname>N&#47;A</apd:CitizenNameSurname><apd:CitizenNameRequestedName>N&#47;A</apd:CitizenNameRequestedName><cs:CRESTjudgeID>0</cs:CRESTjudgeID></cs:Judge></cs:Judiciary><cs:Hearings><cs:Hearing><cs:HearingSequenceNumber>1</cs:HearingSequenceNumber><cs:HearingDetails HearingType="TRL"><cs:HearingDescription>For Trial</cs:HearingDescription><cs:HearingDate>2010-02-18</cs:HearingDate></cs:HearingDetails><cs:CRESThearingID>1</cs:CRESThearingID><cs:TimeMarkingNote>10:00 AM</cs:TimeMarkingNote><cs:CaseNumber>T20107001</cs:CaseNumber><cs:Prosecution ProsecutingAuthority="Crown Prosecution Service"><cs:ProsecutingReference>CPS</cs:ProsecutingReference><cs:ProsecutingOrganisation><cs:OrganisationName>Crown Prosecution Service</cs:OrganisationName></cs:ProsecutingOrganisation></cs:Prosecution><cs:CommittingCourt><cs:CourtHouseType>Magistrates Court</cs:CourtHouseType><cs:CourtHouseCode CourtHouseShortName="BAM">2725</cs:CourtHouseCode><cs:CourtHouseName>BARNET MAGISTRATES COURT</cs:CourtHouseName><cs:CourtHouseAddress><apd:Line>7C HIGH STREET</apd:Line><apd:Line>-</apd:Line><apd:Line>BARNET</apd:Line><apd:PostCode>EN5 5UE</apd:PostCode></cs:CourtHouseAddress><cs:CourtHouseDX>DX 8626 BARNET</cs:CourtHouseDX><cs:CourtHouseTelephone>02084419042</cs:CourtHouseTelephone></cs:CommittingCourt><cs:Defendants><cs:Defendant><cs:PersonalDetails><cs:Name><apd:CitizenNameForename>Franz</apd:CitizenNameForename><apd:CitizenNameSurname>KAFKA</apd:CitizenNameSurname></cs:Name><cs:IsMasked>no</cs:IsMasked><cs:DateOfBirth><apd:BirthDate>1962-06-12</apd:BirthDate><apd:VerifiedBy>not verified</apd:VerifiedBy></cs:DateOfBirth><cs:Sex>male</cs:Sex><cs:Address><apd:Line>ADDRESS LINE 1</apd:Line><apd:Line>ADDRESS LINE 2</apd:Line><apd:Line>ADDRESS LINE 3</apd:Line><apd:Line>ADDRESS LINE 4</apd:Line><apd:Line>SOMETOWN, SOMECOUNTY</apd:Line><apd:PostCode>GU12 7RT</apd:PostCode></cs:Address></cs:PersonalDetails><cs:ASNs><cs:ASN>0723XH1000000262665K</cs:ASN></cs:ASNs><cs:CRESTdefendantID>29161</cs:CRESTdefendantID><cs:PNCnumber>20123456789L</cs:PNCnumber><cs:URN>62AA1010646</cs:URN><cs:CustodyStatus>In custody</cs:CustodyStatus></cs:Defendant></cs:Defendants></cs:Hearing></cs:Hearings></cs:Sitting></cs:Sittings></cs:CourtList></cs:CourtLists></cs:DailyList>]]></document>
+              </ns5:addDocument>
+        """;
+
+    private static final String INCLUSION_LOGGING_PAYLOAD = """
+        <registerNode xmlns="http://com.synapps.mojdarts.service.com">
+             <document xmlns=""><![CDATA[<node type="DAR">
+                 <courthouse>Bristol</courthouse>
+                 <courtroom>1</courtroom>
+                 <hostname>hostname</hostname>
+                 <ip_address>ip_address</ip_address>
+                 <mac_address>mac_address</mac_address>
+                 </node>]]></document>
+            </registerNode>
+        """;
+
+    private static final String INCLUSION_LOGGING_PAYLOAD_DOC_INCLUSION_TYPE = """
+        <ns5:addDocument xmlns:ns5="http://com.synapps.mojdarts.service.com">
+                 <messageId>18418</messageId>
+                 <type>THIS WILL BE INCLUDED</type>
+                 <subType>DL</subType>
+                 <document><![CDATA[<cs:DailyList xmlns:cs="http://www.courtservice.gov.uk/schemas/courtservice" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.courtservice.gov.uk/schemas/courtservice DailyList-v5-2.xsd" xmlns:apd="http://www.govtalk.gov.uk/people/AddressAndPersonalDetails"><cs:DocumentID><cs:DocumentName>DL 18/02/10 FINAL v1</cs:DocumentName><cs:UniqueID>CSDDL000000000576147</cs:UniqueID><cs:DocumentType>DL</cs:DocumentType><cs:TimeStamp>2010-02-18T11:13:23.030</cs:TimeStamp><cs:Version>1.0</cs:Version><cs:SecurityClassification>NPM</cs:SecurityClassification><cs:SellByDate>2010-12-15</cs:SellByDate><cs:XSLstylesheetURL>http://www.courtservice.gov.uk/transforms/courtservice/dailyListHtml.xsl</cs:XSLstylesheetURL></cs:DocumentID><cs:ListHeader><cs:ListCategory>Criminal</cs:ListCategory><cs:StartDate>2010-02-18</cs:StartDate><cs:EndDate>2010-02-18</cs:EndDate><cs:Version>FINAL v1</cs:Version><cs:CRESTprintRef>MCD/112585</cs:CRESTprintRef><cs:PublishedTime>2010-02-17T16:16:50</cs:PublishedTime><cs:CRESTlistID>12298</cs:CRESTlistID></cs:ListHeader><cs:CrownCourt><cs:CourtHouseType>Crown Court</cs:CourtHouseType><cs:CourtHouseCode CourtHouseShortName="SNARE">453</cs:CourtHouseCode><cs:CourtHouseName>Bristol</cs:CourtHouseName><cs:CourtHouseAddress><apd:Line>THE CROWN COURT AT Bristol</apd:Line><apd:Line>75 HOLLYBUSH HILL</apd:Line><apd:Line>Bristol, LONDON</apd:Line><apd:PostCode>E11 1QW</apd:PostCode></cs:CourtHouseAddress><cs:CourtHouseDX>DX 98240 WANSTEAD 2</cs:CourtHouseDX><cs:CourtHouseTelephone>02085300000</cs:CourtHouseTelephone><cs:CourtHouseFax>02085300072</cs:CourtHouseFax></cs:CrownCourt><cs:CourtLists><cs:CourtList><cs:CourtHouse><cs:CourtHouseType>Crown Court</cs:CourtHouseType><cs:CourtHouseCode>453</cs:CourtHouseCode><cs:CourtHouseName>Bristol</cs:CourtHouseName></cs:CourtHouse><cs:Sittings><cs:Sitting><cs:CourtRoomNumber>1</cs:CourtRoomNumber><cs:SittingSequenceNo>1</cs:SittingSequenceNo><cs:SittingAt>10:00:00</cs:SittingAt><cs:SittingPriority>T</cs:SittingPriority><cs:Judiciary><cs:Judge><apd:CitizenNameSurname>N&#47;A</apd:CitizenNameSurname><apd:CitizenNameRequestedName>N&#47;A</apd:CitizenNameRequestedName><cs:CRESTjudgeID>0</cs:CRESTjudgeID></cs:Judge></cs:Judiciary><cs:Hearings><cs:Hearing><cs:HearingSequenceNumber>1</cs:HearingSequenceNumber><cs:HearingDetails HearingType="TRL"><cs:HearingDescription>For Trial</cs:HearingDescription><cs:HearingDate>2010-02-18</cs:HearingDate></cs:HearingDetails><cs:CRESThearingID>1</cs:CRESThearingID><cs:TimeMarkingNote>10:00 AM</cs:TimeMarkingNote><cs:CaseNumber>T20107001</cs:CaseNumber><cs:Prosecution ProsecutingAuthority="Crown Prosecution Service"><cs:ProsecutingReference>CPS</cs:ProsecutingReference><cs:ProsecutingOrganisation><cs:OrganisationName>Crown Prosecution Service</cs:OrganisationName></cs:ProsecutingOrganisation></cs:Prosecution><cs:CommittingCourt><cs:CourtHouseType>Magistrates Court</cs:CourtHouseType><cs:CourtHouseCode CourtHouseShortName="BAM">2725</cs:CourtHouseCode><cs:CourtHouseName>BARNET MAGISTRATES COURT</cs:CourtHouseName><cs:CourtHouseAddress><apd:Line>7C HIGH STREET</apd:Line><apd:Line>-</apd:Line><apd:Line>BARNET</apd:Line><apd:PostCode>EN5 5UE</apd:PostCode></cs:CourtHouseAddress><cs:CourtHouseDX>DX 8626 BARNET</cs:CourtHouseDX><cs:CourtHouseTelephone>02084419042</cs:CourtHouseTelephone></cs:CommittingCourt><cs:Defendants><cs:Defendant><cs:PersonalDetails><cs:Name><apd:CitizenNameForename>Franz</apd:CitizenNameForename><apd:CitizenNameSurname>KAFKA</apd:CitizenNameSurname></cs:Name><cs:IsMasked>no</cs:IsMasked><cs:DateOfBirth><apd:BirthDate>1962-06-12</apd:BirthDate><apd:VerifiedBy>not verified</apd:VerifiedBy></cs:DateOfBirth><cs:Sex>male</cs:Sex><cs:Address><apd:Line>ADDRESS LINE 1</apd:Line><apd:Line>ADDRESS LINE 2</apd:Line><apd:Line>ADDRESS LINE 3</apd:Line><apd:Line>ADDRESS LINE 4</apd:Line><apd:Line>SOMETOWN, SOMECOUNTY</apd:Line><apd:PostCode>GU12 7RT</apd:PostCode></cs:Address></cs:PersonalDetails><cs:ASNs><cs:ASN>0723XH1000000262665K</cs:ASN></cs:ASNs><cs:CRESTdefendantID>29161</cs:CRESTdefendantID><cs:PNCnumber>20123456789L</cs:PNCnumber><cs:URN>62AA1010646</cs:URN><cs:CustodyStatus>In custody</cs:CustodyStatus></cs:Defendant></cs:Defendants></cs:Hearing></cs:Hearings></cs:Sitting></cs:Sittings></cs:CourtList></cs:CourtLists></cs:DailyList>]]></document>
+              </ns5:addDocument>
+        """;
+
+    private LogProperties properties;
+
+    @BeforeEach
+    public void setup() {
+        properties = new LogProperties();
+        ExcludePayloadLogging excludePayloadLogging = new ExcludePayloadLogging();
+        excludePayloadLogging.setNamespace("http://com.synapps.mojdarts.service.com");
+        excludePayloadLogging.setTag("addDocument");
+        excludePayloadLogging.setType("DL");
+
+        ExcludePayloadLogging excludePayloadLogging2 = new ExcludePayloadLogging();
+        excludePayloadLogging2.setNamespace("http://com.synapps.mojdarts.service.com");
+        excludePayloadLogging2.setTag("addDocument");
+        excludePayloadLogging2.setType("CPPDL");
+
+        properties.setExcludePayloadRequestLoggingBasedOnPayloadNamespaceAndTag(List.of(excludePayloadLogging, excludePayloadLogging2));
+    }
+
+    @Test
+    void testExclusion_DL() throws Exception {
+        DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
+        builderFactory.setNamespaceAware(true);
+        DocumentBuilder builder = builderFactory.newDocumentBuilder();
+        Document xmlDocument = builder.parse(new InputSource(new StringReader(EXCLUSION_LOGGING_PAYLOAD_DL)));
+
+        Assertions.assertTrue(properties.excludePayload(new DOMSource(xmlDocument)).isPresent());
+    }
+
+    @Test
+    void testExclusion_Cppdl() throws Exception {
+        DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
+        builderFactory.setNamespaceAware(true);
+        DocumentBuilder builder = builderFactory.newDocumentBuilder();
+        Document xmlDocument = builder.parse(new InputSource(new StringReader(EXCLUSION_LOGGING_PAYLOAD_CPPDL)));
+
+        Assertions.assertTrue(properties.excludePayload(new DOMSource(xmlDocument)).isPresent());
+    }
+
+    @Test
+    void testExclusion_DocWithNoDlType() throws Exception {
+        properties = new LogProperties();
+        ExcludePayloadLogging excludePayloadLogging = new ExcludePayloadLogging();
+        excludePayloadLogging.setNamespace("http://com.synapps.mojdarts.service.com");
+        excludePayloadLogging.setTag("addDocument");
+
+        properties.setExcludePayloadRequestLoggingBasedOnPayloadNamespaceAndTag(List.of(excludePayloadLogging));
+
+        DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
+        builderFactory.setNamespaceAware(true);
+        DocumentBuilder builder = builderFactory.newDocumentBuilder();
+        Document xmlDocument = builder.parse(new InputSource(new StringReader(EXCLUSION_LOGGING_PAYLOAD_DL)));
+
+        Assertions.assertTrue(properties.excludePayload(new DOMSource(xmlDocument)).isPresent());
+    }
+
+    @Test
+    void testInclusion() throws Exception {
+        DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
+        builderFactory.setNamespaceAware(true);
+        DocumentBuilder builder = builderFactory.newDocumentBuilder();
+        Document xmlDocument = builder.parse(new InputSource(new StringReader(INCLUSION_LOGGING_PAYLOAD)));
+
+        Assertions.assertFalse(properties.excludePayload(new DOMSource(xmlDocument)).isPresent());
+    }
+
+    @Test
+    void testInclusionWithDocButNoDlType() throws Exception {
+        DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
+        builderFactory.setNamespaceAware(true);
+        DocumentBuilder builder = builderFactory.newDocumentBuilder();
+        Document xmlDocument = builder.parse(new InputSource(new StringReader(INCLUSION_LOGGING_PAYLOAD_DOC_INCLUSION_TYPE)));
+
+        Assertions.assertFalse(properties.excludePayload(new DOMSource(xmlDocument)).isPresent());
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-3314

### Change description ###

Allow a configurable set of payload logging exclusion criteria. The data is defaulted to ONLY exclude daily list payloads at the time of writing but could include different exclusions as required. All exclusion config is defaulted in Spring application.xml but can be overridden by docker using environment variables.

All integration tests have been updated to prove the logs are included/excluded appropriately according to the exclusion criteria and the payload that is used.

Also:-

* Added some new docker compose files for ease of testing
* Defaulted data in the application.xml taking the hard coded values away from the docker files
* Removed some postman endpoints that would never be able to successfully work e.g. endpoints using basic auth whos user is excluded from the basic auth white list

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
