### PR TITLE
DMP-2402: Upload audio to azure directly from DARTS gateway

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -12,6 +12,7 @@ def secrets = [
         'darts-${env}': [
                 secret('app-insights-connection-string', 'app-insights-connection-string'),
                 secret('AzureAdB2CClientId', 'AAD_B2C_CLIENT_ID'),
+                secret('AzureStorageConnectionString', 'AZURE_STORAGE_CONNECTION_STRING'),
                 secret('ExternalServiceBasicAuthorisationWhitelist', 'EXTERNAL_SERVICE_BASIC_AUTHORISATION_WHITELIST'),
                 secret('ViQExternalUserName', 'VIQ_EXTERNAL_USER_NAME'),
                 secret('ViQExternalPassword', 'VIQ_EXTERNAL_PASSWORD'),

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -15,6 +15,7 @@ def secrets = [
         'darts-${env}': [
           secret('app-insights-connection-string', 'app-insights-connection-string'),
           secret('AzureAdB2CClientId', 'AAD_B2C_CLIENT_ID'),
+          secret('AzureStorageConnectionString', 'AZURE_STORAGE_CONNECTION_STRING'),
           secret('ExternalServiceBasicAuthorisationWhitelist', 'EXTERNAL_SERVICE_BASIC_AUTHORISATION_WHITELIST'),
           secret('ViQExternalUserName', 'VIQ_EXTERNAL_USER_NAME'),
           secret('ViQExternalPassword', 'VIQ_EXTERNAL_PASSWORD'),

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -10,6 +10,7 @@ def secrets = [
         'darts-${env}': [
           secret('app-insights-connection-string', 'app-insights-connection-string'),
           secret('AzureAdB2CClientId', 'AAD_B2C_CLIENT_ID'),
+          secret('AzureStorageConnectionString', 'AZURE_STORAGE_CONNECTION_STRING'),
           secret('ExternalServiceBasicAuthorisationWhitelist', 'EXTERNAL_SERVICE_BASIC_AUTHORISATION_WHITELIST'),
           secret('ViQExternalUserName', 'VIQ_EXTERNAL_USER_NAME'),
           secret('ViQExternalPassword', 'VIQ_EXTERNAL_PASSWORD'),

--- a/bin/secrets-stg-environment.sh
+++ b/bin/secrets-stg-environment.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# To set the secrets in your shell, source this file ie. source ./bin/secrets-stg.sh
+# To set the secrets in your shell, source this file ie. source ./bin/secrets-stg-environment.sh
 
 echo "Exporting secrets from Azure keyvault (darts-stg), please ensure you have \"az\" installed and you have logged in, using \"az login\"."
 

--- a/bin/secrets-stg-environment.sh
+++ b/bin/secrets-stg-environment.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# To set the secrets in your shell, source this file ie. source ./bin/secrets-stg.sh
+
+echo "Exporting secrets from Azure keyvault (darts-stg), please ensure you have \"az\" installed and you have logged in, using \"az login\"."
+
+echo "AAD_B2C_TENANT_ID=$(az keyvault secret show --vault-name darts-stg --name AzureAdB2CTenantId | jq .value -r)"
+echo "REDIS_CONNECTION_STRING=$(az keyvault secret show --vault-name darts-stg --name redis-connection-string | jq .value -r)"
+echo "MAX_FILE_UPLOAD_SIZE_MEGABYTES=$(az keyvault secret show --vault-name darts-stg --name MaxFileUploadSizeInMegabytes | jq .value -r)"
+echo "AAD_B2C_ROPC_CLIENT_ID=$(az keyvault secret show --vault-name darts-stg --name AzureAdB2CFuncTestROPCClientId | jq .value -r)"
+echo "AAD_B2C_CLIENT_ID=$(az keyvault secret show --vault-name darts-stg --name AzureAdB2CClientId | jq .value -r)"
+echo "DAR_NOTIFY_EVENT_SECUREMENT_PASSWORD=$(az keyvault secret show --vault-name darts-stg --name darts-gateway-DarNotifyEventSecurementPassword | jq .value -r)"
+echo "DAR_NOTIFY_EVENT_SECUREMENT_USERNAME=$(az keyvault secret show --vault-name darts-stg --name darts-gateway-DarNotifyEventSecurementUsername | jq .value -r)"
+echo "EXTERNAL_SERVICE_BASIC_AUTHORISATION_WHITELIST=$(az keyvault secret show --vault-name darts-stg --name ExternalServiceBasicAuthorisationWhitelist | jq .value -r)"
+echo "VIQ_EXTERNAL_USER_NAME=$(az keyvault secret show --vault-name darts-stg --name ViQExternalUserName | jq .value -r)"
+echo "VIQ_EXTERNAL_PASSWORD=$(az keyvault secret show --vault-name darts-stg --name ViQExternalPassword | jq .value -r)"
+echo "VIQ_INTERNAL_PASSWORD=$(az keyvault secret show --vault-name darts-stg --name ViQInternalPassword | jq .value -r)"
+
+echo "AZURE_STORAGE_CONNECTION_STRING=$(az keyvault secret show --vault-name darts-stg --name AzureStorageConnectionString | jq .value -r)"

--- a/bin/secrets-stg-environment.sh
+++ b/bin/secrets-stg-environment.sh
@@ -15,5 +15,11 @@ echo "EXTERNAL_SERVICE_BASIC_AUTHORISATION_WHITELIST=$(az keyvault secret show -
 echo "VIQ_EXTERNAL_USER_NAME=$(az keyvault secret show --vault-name darts-stg --name ViQExternalUserName | jq .value -r)"
 echo "VIQ_EXTERNAL_PASSWORD=$(az keyvault secret show --vault-name darts-stg --name ViQExternalPassword | jq .value -r)"
 echo "VIQ_INTERNAL_PASSWORD=$(az keyvault secret show --vault-name darts-stg --name ViQInternalPassword | jq .value -r)"
+echo "CP_EXTERNAL_USER_NAME=$(az keyvault secret show --vault-name darts-stg --name CPExternalUserName | jq .value -r)"
+echo "CP_EXTERNAL_PASSWORD=$(az keyvault secret show --vault-name darts-stg --name CPExternalPassword | jq .value -r)"
+echo "CP_INTERNAL_PASSWORD=$(az keyvault secret show --vault-name darts-stg --name CPInternalPassword | jq .value -r)"
+echo "XHIBIT_EXTERNAL_USER_NAME=$(az keyvault secret show --vault-name darts-stg --name XhibitExternalUserName | jq .value -r)"
+echo "XHIBIT_EXTERNAL_PASSWORD=$(az keyvault secret show --vault-name darts-stg --name XhibitExternalPassword | jq .value -r)"
+echo "XHIBIT_INTERNAL_PASSWORD=$(az keyvault secret show --vault-name darts-stg --name XhibitInternalPassword | jq .value -r)"
 
 echo "AZURE_STORAGE_CONNECTION_STRING=$(az keyvault secret show --vault-name darts-stg --name AzureStorageConnectionString | jq .value -r)"

--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,18 @@
 plugins {
-  id 'application'
-  id 'checkstyle'
-  id 'pmd'
-  id 'jacoco'
-  id 'idea'
-  id "io.freefair.lombok" version "8.10.2"
-  id 'io.spring.dependency-management' version '1.1.6'
-  id 'org.springframework.boot' version '3.3.5'
-  id 'org.owasp.dependencycheck' version '11.1.0'
-  id 'com.github.ben-manes.versions' version '0.51.0'
-  id 'org.sonarqube' version '5.1.0.4882'
-  id 'java-library'
-  id "org.openapi.generator" version "7.9.0"
-  id("com.github.bjornvester.wsdl2java") version "2.0.2"
+    id 'application'
+    id 'checkstyle'
+    id 'pmd'
+    id 'jacoco'
+    id 'idea'
+    id "io.freefair.lombok" version "8.10.2"
+    id 'io.spring.dependency-management' version '1.1.6'
+    id 'org.springframework.boot' version '3.3.5'
+    id 'org.owasp.dependencycheck' version '11.1.0'
+    id 'com.github.ben-manes.versions' version '0.51.0'
+    id 'org.sonarqube' version '5.1.0.4882'
+    id 'java-library'
+    id "org.openapi.generator" version "7.9.0"
+    id("com.github.bjornvester.wsdl2java") version "2.0.2"
 }
 
 import static groovy.io.FileType.FILES
@@ -21,201 +21,201 @@ group = 'uk.gov.hmcts'
 version = '0.0.1'
 
 java {
-  toolchain {
-    languageVersion = JavaLanguageVersion.of(21)
-  }
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 configurations.all {
-  exclude group: 'org.bouncycastle', module: 'bcpkix-jdk15on'
-  exclude group: 'org.bouncycastle', module: 'bcprov-jdk15on' // bcprov-jdk15on-1.69.jar CVE-2023-33201
-  exclude group: 'org.bouncycastle', module: 'bcutil-jdk15on'
+    exclude group: 'org.bouncycastle', module: 'bcpkix-jdk15on'
+    exclude group: 'org.bouncycastle', module: 'bcprov-jdk15on' // bcprov-jdk15on-1.69.jar CVE-2023-33201
+    exclude group: 'org.bouncycastle', module: 'bcutil-jdk15on'
 
-  resolutionStrategy.capabilitiesResolution.withCapability('org.codehaus.groovy:groovy-json') {
-    selectHighestVersion()
-  }
-  resolutionStrategy.capabilitiesResolution.withCapability('org.codehaus.groovy:groovy-xml') {
-    selectHighestVersion()
-  }
-  resolutionStrategy.capabilitiesResolution.withCapability('org.codehaus.groovy:groovy-jso') {
-    selectHighestVersion()
-  }
-  resolutionStrategy.capabilitiesResolution.withCapability('org.codehaus.groovy:groovy') {
-    selectHighestVersion()
-  }
+    resolutionStrategy.capabilitiesResolution.withCapability('org.codehaus.groovy:groovy-json') {
+        selectHighestVersion()
+    }
+    resolutionStrategy.capabilitiesResolution.withCapability('org.codehaus.groovy:groovy-xml') {
+        selectHighestVersion()
+    }
+    resolutionStrategy.capabilitiesResolution.withCapability('org.codehaus.groovy:groovy-jso') {
+        selectHighestVersion()
+    }
+    resolutionStrategy.capabilitiesResolution.withCapability('org.codehaus.groovy:groovy') {
+        selectHighestVersion()
+    }
 }
 
 configurations {
-  jaxb
-  openapispec
+    jaxb
+    openapispec
 }
 
 sourceSets {
-  main {
-    java.srcDir "$buildDir/generated/openapi/src/main/java"
-  }
-
-  testCommon {
-    java {
-      compileClasspath += main.output
-      runtimeClasspath += main.output
-      srcDir file('src/testCommon/java')
+    main {
+        java.srcDir "$buildDir/generated/openapi/src/main/java"
     }
-    resources.srcDir file('src/testCommon/resources')
-  }
 
-  functionalTest {
-    java {
-      compileClasspath += main.output
-      compileClasspath += testCommon.output
-      runtimeClasspath += main.output
-      runtimeClasspath += testCommon.output
-      srcDir file('src/functionalTest/java')
+    testCommon {
+        java {
+            compileClasspath += main.output
+            runtimeClasspath += main.output
+            srcDir file('src/testCommon/java')
+        }
+        resources.srcDir file('src/testCommon/resources')
     }
-    resources.srcDir file('src/functionalTest/resources')
-  }
 
-  integrationTest {
-    java {
-      compileClasspath += main.output
-      compileClasspath += testCommon.output
-      runtimeClasspath += main.output
-      runtimeClasspath += testCommon.output
-      srcDir file('src/integrationTest/java')
+    functionalTest {
+        java {
+            compileClasspath += main.output
+            compileClasspath += testCommon.output
+            runtimeClasspath += main.output
+            runtimeClasspath += testCommon.output
+            srcDir file('src/functionalTest/java')
+        }
+        resources.srcDir file('src/functionalTest/resources')
     }
-    resources.srcDir file('src/integrationTest/resources')
-  }
 
-  smokeTest {
-    java {
-      compileClasspath += main.output
-      runtimeClasspath += main.output
-      srcDir file('src/smokeTest/java')
+    integrationTest {
+        java {
+            compileClasspath += main.output
+            compileClasspath += testCommon.output
+            runtimeClasspath += main.output
+            runtimeClasspath += testCommon.output
+            srcDir file('src/integrationTest/java')
+        }
+        resources.srcDir file('src/integrationTest/resources')
     }
-    resources.srcDir file('src/smokeTest/resources')
-  }
 
-  test {
-    java {
-      compileClasspath += main.output
-      compileClasspath += testCommon.output
-      runtimeClasspath += main.output
-      runtimeClasspath += testCommon.output
-      srcDir file('src/test/java')
+    smokeTest {
+        java {
+            compileClasspath += main.output
+            runtimeClasspath += main.output
+            srcDir file('src/smokeTest/java')
+        }
+        resources.srcDir file('src/smokeTest/resources')
     }
-    resources.srcDir file('src/test/resources')
-  }
+
+    test {
+        java {
+            compileClasspath += main.output
+            compileClasspath += testCommon.output
+            runtimeClasspath += main.output
+            runtimeClasspath += testCommon.output
+            srcDir file('src/test/java')
+        }
+        resources.srcDir file('src/test/resources')
+    }
 }
 
 idea {
-  module {
-    testSources.from(sourceSets.integrationTest.allSource.srcDirs)
-    testResources.from(sourceSets.integrationTest.resources.srcDirs)
-    testSources.from(sourceSets.functionalTest.allSource.srcDirs)
-    testResources.from(sourceSets.functionalTest.resources.srcDirs)
-    testSources.from(sourceSets.smokeTest.allSource.srcDirs)
-    testResources.from(sourceSets.smokeTest.resources.srcDirs)
-    testSources.from(sourceSets.testCommon.allSource.srcDirs)
-    testResources.from(sourceSets.testCommon.resources.srcDirs)
-  }
+    module {
+        testSources.from(sourceSets.integrationTest.allSource.srcDirs)
+        testResources.from(sourceSets.integrationTest.resources.srcDirs)
+        testSources.from(sourceSets.functionalTest.allSource.srcDirs)
+        testResources.from(sourceSets.functionalTest.resources.srcDirs)
+        testSources.from(sourceSets.smokeTest.allSource.srcDirs)
+        testResources.from(sourceSets.smokeTest.resources.srcDirs)
+        testSources.from(sourceSets.testCommon.allSource.srcDirs)
+        testResources.from(sourceSets.testCommon.resources.srcDirs)
+    }
 }
 
 configurations {
-  testCommonImplementation.extendsFrom testImplementation
+    testCommonImplementation.extendsFrom testImplementation
 
-  functionalTestImplementation.extendsFrom testCommonImplementation
-  functionalTestRuntimeOnly.extendsFrom runtimeOnly
+    functionalTestImplementation.extendsFrom testCommonImplementation
+    functionalTestRuntimeOnly.extendsFrom runtimeOnly
 
-  integrationTestImplementation.extendsFrom testCommonImplementation
-  integrationTestRuntimeOnly.extendsFrom runtimeOnly
+    integrationTestImplementation.extendsFrom testCommonImplementation
+    integrationTestRuntimeOnly.extendsFrom runtimeOnly
 
-  smokeTestImplementation.extendsFrom testImplementation
-  smokeTestRuntimeOnly.extendsFrom runtimeOnly
+    smokeTestImplementation.extendsFrom testImplementation
+    smokeTestRuntimeOnly.extendsFrom runtimeOnly
 }
 
 tasks.withType(JavaCompile) {
-  options.compilerArgs << "-Xlint:unchecked" << "-Werror"
+    options.compilerArgs << "-Xlint:unchecked" << "-Werror"
 }
 
 // https://github.com/gradle/gradle/issues/16791
 tasks.withType(JavaExec).configureEach {
-  javaLauncher.set(javaToolchains.launcherFor(java.toolchain))
+    javaLauncher.set(javaToolchains.launcherFor(java.toolchain))
 }
 
 tasks.withType(Test) {
-  useJUnitPlatform()
+    useJUnitPlatform()
 
-  testLogging {
-    exceptionFormat = 'full'
-  }
+    testLogging {
+        exceptionFormat = 'full'
+    }
 }
 
 test {
-  failFast = false
+    failFast = false
 }
 
 task functional(type: Test) {
-  description = "Runs functional tests"
-  group = "Verification"
-  testClassesDirs = sourceSets.functionalTest.output.classesDirs
-  exclude '**/performance/*'
-  classpath = sourceSets.functionalTest.runtimeClasspath
+    description = "Runs functional tests"
+    group = "Verification"
+    testClassesDirs = sourceSets.functionalTest.output.classesDirs
+    exclude '**/performance/*'
+    classpath = sourceSets.functionalTest.runtimeClasspath
 }
 
 task functionalPerformance(type: Test) {
-  useJUnitPlatform()
-  description = "Runs functional tests"
-  group = "Verification"
-  testClassesDirs = sourceSets.functionalTest.output.classesDirs
-  include '**/performance/*'
-  classpath = sourceSets.functionalTest.runtimeClasspath
+    useJUnitPlatform()
+    description = "Runs functional tests"
+    group = "Verification"
+    testClassesDirs = sourceSets.functionalTest.output.classesDirs
+    include '**/performance/*'
+    classpath = sourceSets.functionalTest.runtimeClasspath
 }
 
 task integration(type: Test) {
-  description = "Runs integration tests"
-  group = "Verification"
-  testClassesDirs = sourceSets.integrationTest.output.classesDirs
-  classpath = sourceSets.integrationTest.runtimeClasspath
-  failFast = false
+    description = "Runs integration tests"
+    group = "Verification"
+    testClassesDirs = sourceSets.integrationTest.output.classesDirs
+    classpath = sourceSets.integrationTest.runtimeClasspath
+    failFast = false
 }
 
 task smoke(type: Test) {
-  description = "Runs Smoke Tests"
-  testClassesDirs = sourceSets.smokeTest.output.classesDirs
-  classpath = sourceSets.smokeTest.runtimeClasspath
+    description = "Runs Smoke Tests"
+    testClassesDirs = sourceSets.smokeTest.output.classesDirs
+    classpath = sourceSets.smokeTest.runtimeClasspath
 }
 
 
 checkstyle {
-  maxWarnings = 0
+    maxWarnings = 0
 }
 
 var sourceSetsCopy = sourceSets
 pmd {
-  toolVersion = "7.7.0"
-  sourceSets = [sourceSetsCopy.main]
-  reportsDir = file("$project.buildDir/reports/pmd")
-  // https://github.com/pmd/pmd/issues/876
-  ruleSets = []
-  ruleSetFiles = files("config/pmd/main-ruleset.xml")
+    toolVersion = "7.7.0"
+    sourceSets = [sourceSetsCopy.main]
+    reportsDir = file("$project.buildDir/reports/pmd")
+    // https://github.com/pmd/pmd/issues/876
+    ruleSets = []
+    ruleSetFiles = files("config/pmd/main-ruleset.xml")
 }
 
 pmd {
-  toolVersion = "7.7.0"
-  sourceSets = [sourceSetsCopy.test, sourceSetsCopy.functionalTest, sourceSetsCopy.integrationTest, sourceSetsCopy.smokeTest]
-  reportsDir = file("$project.buildDir/reports/pmd")
-  // https://github.com/pmd/pmd/issues/876
-  ruleSets = []
-  ruleSetFiles = files("config/pmd/test-ruleset.xml")
+    toolVersion = "7.7.0"
+    sourceSets = [sourceSetsCopy.test, sourceSetsCopy.functionalTest, sourceSetsCopy.integrationTest, sourceSetsCopy.smokeTest]
+    reportsDir = file("$project.buildDir/reports/pmd")
+    // https://github.com/pmd/pmd/issues/876
+    ruleSets = []
+    ruleSetFiles = files("config/pmd/test-ruleset.xml")
 }
 
 jacocoTestReport {
-  executionData(test, integration)
-  reports {
-    xml.required = true
-    csv.required = false
-    html.required = true
-  }
+    executionData(test, integration)
+    reports {
+        xml.required = true
+        csv.required = false
+        html.required = true
+    }
 }
 
 
@@ -224,457 +224,458 @@ project.tasks['check'].finalizedBy integration
 
 
 def sonarExclusions = [
-  '**/com/emc/**',
-  '**/com/service/**',
-  '**/com/synapps/**',
-  '**/com/viqsoultions/**',
-  '**/uk/gov/courtservice/**',
-  '**/uk/gov/addcase/**',
-  'src/main/java/generated/**',
-  '**/uk/gov/hmcts/darts/**/model/**',
-  '**/uk/gov/hmcts/darts/**/config/**',
-  '**/enums/**',
-  '**/DocumentumIdToJwtCache*',
-  '**/CacheValueWithJwt*',
-  '**/com/service/viq/event/**',
-  '**/uk/gov/hmcts/darts/cache/token/service/**',
-  '**/uk/gov/hmcts/darts/test/**'
+        '**/com/emc/**',
+        '**/com/service/**',
+        '**/com/synapps/**',
+        '**/com/viqsoultions/**',
+        '**/uk/gov/courtservice/**',
+        '**/uk/gov/addcase/**',
+        'src/main/java/generated/**',
+        '**/uk/gov/hmcts/darts/**/model/**',
+        '**/uk/gov/hmcts/darts/**/config/**',
+        '**/enums/**',
+        '**/DocumentumIdToJwtCache*',
+        '**/CacheValueWithJwt*',
+        '**/com/service/viq/event/**',
+        '**/uk/gov/hmcts/darts/cache/token/service/**',
+        '**/uk/gov/hmcts/darts/test/**'
 ]
 
 sonarqube {
-  properties {
-    property "sonar.projectName", "DARTS :: darts-gateway"
-    property "sonar.projectKey", "uk.gov.hmcts.reform:darts-gateway"
-    property "sonar.exclusions", sonarExclusions.join(', ')
-  }
+    properties {
+        property "sonar.projectName", "DARTS :: darts-gateway"
+        property "sonar.projectKey", "uk.gov.hmcts.reform:darts-gateway"
+        property "sonar.exclusions", sonarExclusions.join(', ')
+    }
 }
 
 // before committing a change, make sure task still works
 dependencyUpdates {
-  def isNonStable = { String version ->
-    def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { qualifier -> version.toUpperCase().contains(qualifier) }
-    def regex = /^[0-9,.v-]+$/
-    return !stableKeyword && !(version ==~ regex)
-  }
-  rejectVersionIf { selection -> // <---- notice how the closure argument is named
-    return isNonStable(selection.candidate.version) && !isNonStable(selection.currentVersion)
-  }
+    def isNonStable = { String version ->
+        def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { qualifier -> version.toUpperCase().contains(qualifier) }
+        def regex = /^[0-9,.v-]+$/
+        return !stableKeyword && !(version ==~ regex)
+    }
+    rejectVersionIf { selection -> // <---- notice how the closure argument is named
+        return isNonStable(selection.candidate.version) && !isNonStable(selection.currentVersion)
+    }
 }
 
 // https://jeremylong.github.io/DependencyCheck/dependency-check-gradle/configuration.html
 dependencyCheck {
-  // Specifies if the build should be failed if a CVSS score above a specified level is identified.
-  // range of 0-10 fails the build, anything greater and it doesn't fail the build
-  failBuildOnCVSS = 0
-  suppressionFile = 'config/owasp/suppressions.xml'
+    // Specifies if the build should be failed if a CVSS score above a specified level is identified.
+    // range of 0-10 fails the build, anything greater and it doesn't fail the build
+    failBuildOnCVSS = 0
+    suppressionFile = 'config/owasp/suppressions.xml'
 
-  analyzers {
-    // Disable scanning of .NET related binaries
-    assemblyEnabled = false
-  }
-  skipConfigurations = [
-    "compileOnly",
-    "pmd",
-    "integrationTest",
-    "functionalTest",
-    "smokeTest",
-    "contractTestRuntimeClasspath",
-    "contractTestCompileClasspath"
-  ]
+    analyzers {
+        // Disable scanning of .NET related binaries
+        assemblyEnabled = false
+    }
+    skipConfigurations = [
+            "compileOnly",
+            "pmd",
+            "integrationTest",
+            "functionalTest",
+            "smokeTest",
+            "contractTestRuntimeClasspath",
+            "contractTestCompileClasspath"
+    ]
 }
 
 repositories {
-  mavenLocal()
-  mavenCentral()
-  maven { url 'https://jitpack.io' }
+    mavenLocal()
+    mavenCentral()
+    maven { url 'https://jitpack.io' }
 }
 
 ext {
-  log4JVersion = "2.24.1"
-  wsdl4jVersion = "1.6.3"
+    log4JVersion = "2.24.1"
+    wsdl4jVersion = "1.6.3"
 }
 
 ext['snakeyaml.version'] = '2.0'
 
 
 task generateCodeFromSpecification() {
-  doFirst {
+    doFirst {
 
-    def openApiGenerateTaskList = []
+        def openApiGenerateTaskList = []
 
-    //here we are going to store swagger files
-    def swaggerList = []
+        //here we are going to store swagger files
+        def swaggerList = []
 
-    //iteration by swagger file root folder and save into swaggerList variable
-    def dir = new File(layout.buildDirectory.dir("extractedSpecs").get().asFile.absolutePath)
+        //iteration by swagger file root folder and save into swaggerList variable
+        def dir = new File(layout.buildDirectory.dir("extractedSpecs").get().asFile.absolutePath)
 
-    dir.eachFileRecurse(FILES) { file ->
-      if (file.getName().endsWith(".yaml") && !file.getName().contains("problem"))
-        swaggerList << file
-    }
+        dir.eachFileRecurse(FILES) { file ->
+            if (file.getName().endsWith(".yaml") && !file.getName().contains("problem"))
+                swaggerList << file
+        }
 
-    // Iterate on all swagger files and generate a task for each one with the nomenclature openApiGenerate + swagger name
-    swaggerList.each {
-        def apiName = it.getName().replace(".yaml", "");
-        def apiLocation = it.getAbsolutePath();
+        // Iterate on all swagger files and generate a task for each one with the nomenclature openApiGenerate + swagger name
+        swaggerList.each {
+            def apiName = it.getName().replace(".yaml", "");
+            def apiLocation = it.getAbsolutePath();
 
-        def taskName = "openApiGenerate" + apiName.capitalize()
-        openApiGenerateTaskList << taskName
+            def taskName = "openApiGenerate" + apiName.capitalize()
+            openApiGenerateTaskList << taskName
 
-        Task task = tasks.create(taskName, org.openapitools.generator.gradle.plugin.tasks.GenerateTask, {
-          generatorName = "spring"
-          inputSpec = "${apiLocation}"
-          outputDir = "$buildDir/generated/openapi".toString()
-          modelPackage = "uk.gov.hmcts.darts.model.".toString() + "${apiName}"
-          outputDir = "$buildDir/generated/openapi"
-          apiPackage = "uk.gov.hmcts.darts.api.${apiName}"
-          modelPackage = "uk.gov.hmcts.darts.model.${apiName}"
-          invokerPackage = "uk.gov.hmcts.darts.invoker.${apiName}"
-          library="spring-cloud"
-          //    https://openapi-generator.tech/docs/generators/java/#config-options
-          skipOperationExample = true
-          skipValidateSpec = true
-          configOptions = [
-            dateLibrary   : "java8",
-            serializationLibrary       : "jackson",
-            useJakartaEe :"true",
-            library : "spring-cloud",
-            interfaceOnly : "true"
-          ]
-        })
+            Task task = tasks.create(taskName, org.openapitools.generator.gradle.plugin.tasks.GenerateTask, {
+                generatorName = "spring"
+                inputSpec = "${apiLocation}"
+                outputDir = "$buildDir/generated/openapi".toString()
+                modelPackage = "uk.gov.hmcts.darts.model.".toString() + "${apiName}"
+                outputDir = "$buildDir/generated/openapi"
+                apiPackage = "uk.gov.hmcts.darts.api.${apiName}"
+                modelPackage = "uk.gov.hmcts.darts.model.${apiName}"
+                invokerPackage = "uk.gov.hmcts.darts.invoker.${apiName}"
+                library = "spring-cloud"
+                //    https://openapi-generator.tech/docs/generators/java/#config-options
+                skipOperationExample = true
+                skipValidateSpec = true
+                configOptions = [
+                        dateLibrary         : "java8",
+                        serializationLibrary: "jackson",
+                        useJakartaEe        : "true",
+                        library             : "spring-cloud",
+                        interfaceOnly       : "true"
+                ]
+            })
 
-        task.actions.each { it.execute(task) }
-      }
+            task.actions.each { it.execute(task) }
+        }
     }
 }
 
 sourceSets {
-  main {
-    java {
-      srcDir("$buildDir/generated/openapi/src/main/java")
+    main {
+        java {
+            srcDir("$buildDir/generated/openapi/src/main/java")
+        }
     }
-  }
 }
 
 dependencies {
-  implementation group: 'io.rest-assured', name: 'rest-assured'
-  implementation 'org.apache.tomcat.embed:tomcat-embed-core:10.1.31'
-  implementation 'org.apache.tomcat.embed:tomcat-embed-websocket:10.1.31'
-  implementation 'org.apache.tomcat.embed:tomcat-embed-el:10.1.31'
-  implementation 'org.apache.santuario:xmlsec:4.0.3'
+    implementation group: 'io.rest-assured', name: 'rest-assured'
+    implementation 'org.apache.tomcat.embed:tomcat-embed-core:10.1.31'
+    implementation 'org.apache.tomcat.embed:tomcat-embed-websocket:10.1.31'
+    implementation 'org.apache.tomcat.embed:tomcat-embed-el:10.1.31'
+    implementation 'org.apache.santuario:xmlsec:4.0.3'
 
-  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
-  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
-  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-aop'
-  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-json'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-aop'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-json'
 
-  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation'
-  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web-services'
-  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-cache'
-  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-redis'
-  implementation group: 'org.springframework.session', name: 'spring-session-data-redis'
-  implementation group: 'org.springframework', name: 'spring-context'
-  implementation 'org.springframework.integration:spring-integration-redis:6.3.5'
-  implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.46'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web-services'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-cache'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-redis'
+    implementation group: 'org.springframework.session', name: 'spring-session-data-redis'
+    implementation group: 'org.springframework', name: 'spring-context'
+    implementation 'org.springframework.integration:spring-integration-redis:6.3.5'
+    implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.46'
 
-  implementation group: 'org.openapitools', name: 'jackson-databind-nullable', version: '0.2.6'
-  implementation group: 'org.springframework.ws', name: 'spring-ws-security', {
-    exclude group: 'com.google.guava', module: 'guava' // guava-30.1-jre.jar CVE-2023-2976, CVE-2020-8908
-  }
-  implementation group: 'com.google.guava', name: 'guava', version: '33.3.1-jre'
-  implementation group: 'org.bouncycastle', name: 'bcpkix-jdk18on', version: '1.79'
-  implementation group: 'org.bouncycastle', name: 'bcprov-jdk18on', version: '1.79'
-  implementation group: 'org.bouncycastle', name: 'bcutil-jdk18on', version: '1.79'
-
-  implementation group: 'wsdl4j', name: 'wsdl4j', version: wsdl4jVersion
-  jaxb( 'org.glassfish.jaxb:jaxb-xjc:4.0.5')
-  implementation( 'org.glassfish.jaxb:jaxb-runtime:4.0.5')
-  implementation group: 'org.apache.tika', name: 'tika-core', version: '3.0.0'
-
-  // https://mvnrepository.com/artifact/io.github.openfeign/feign-jackson
-  implementation 'com.fasterxml.jackson.core:jackson-databind'
-
-  implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.6.0'
-  implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '4.1.3', {
-    exclude group: 'commons-fileupload', module: 'commons-fileupload'
-  }
-  implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
-
-  implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '6.1.7'
-  implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: log4JVersion
-  implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: log4JVersion
-  implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.5.12'
-  implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.5.12'
-
-  implementation group: 'io.github.openfeign', name: 'feign-okhttp', version: '13.5'
-  constraints {
-    implementation('com.squareup.okio:okio:3.9.1') {
-      because 'version 3.0.0 has vulnerability CVE-2023-3635'
+    implementation group: 'org.openapitools', name: 'jackson-databind-nullable', version: '0.2.6'
+    implementation group: 'org.springframework.ws', name: 'spring-ws-security', {
+        exclude group: 'com.google.guava', module: 'guava' // guava-30.1-jre.jar CVE-2023-2976, CVE-2020-8908
     }
-  }
+    implementation group: 'com.google.guava', name: 'guava', version: '33.3.1-jre'
+    implementation group: 'org.bouncycastle', name: 'bcpkix-jdk18on', version: '1.79'
+    implementation group: 'org.bouncycastle', name: 'bcprov-jdk18on', version: '1.79'
+    implementation group: 'org.bouncycastle', name: 'bcutil-jdk18on', version: '1.79'
 
-  implementation 'org.zalando:problem-spring-web-starter:0.29.1'
-  implementation 'org.apache.commons:commons-collections4:4.4'
+    implementation group: 'wsdl4j', name: 'wsdl4j', version: wsdl4jVersion
+    jaxb('org.glassfish.jaxb:jaxb-xjc:4.0.5')
+    implementation('org.glassfish.jaxb:jaxb-runtime:4.0.5')
+    implementation group: 'org.apache.tika', name: 'tika-core', version: '3.0.0'
 
-  implementation 'org.mapstruct:mapstruct:1.6.3'
-  implementation 'org.openapitools:jackson-databind-nullable:0.2.6'
-  implementation group: 'org.apache.xmlbeans', name: 'xmlbeans', version: '5.2.2'
+    // https://mvnrepository.com/artifact/io.github.openfeign/feign-jackson
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
 
-  // https://mvnrepository.com/artifact/org.apache.ws.xmlschema/xmlschema-core
-  implementation group: 'org.apache.ws.xmlschema', name: 'xmlschema-core', version: '2.3.1'
-  // https://mvnrepository.com/artifact/javax.mail/javax.mail-api
-  implementation group: 'javax.mail', name: 'javax.mail-api', version: '1.6.2'
-  // https://mvnrepository.com/artifact/javax.activation/activation
-  implementation group: 'javax.activation', name: 'activation', version: '1.1.1'
-  // https://mvnrepository.com/artifact/com.sun.mail/javax.mail
-  implementation group: 'com.sun.mail', name: 'javax.mail', version: '1.6.2'
+    implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.6.0'
+    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '4.1.3', {
+        exclude group: 'commons-fileupload', module: 'commons-fileupload'
+    }
+    implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
 
-  implementation project(path: ':context')
-  implementation 'javax.annotation:javax.annotation-api:1.3.2'
+    implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '6.1.7'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: log4JVersion
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: log4JVersion
+    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.5.12'
+    implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.5.12'
 
-  annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
+    implementation group: 'io.github.openfeign', name: 'feign-okhttp', version: '13.5'
+    constraints {
+        implementation('com.squareup.okio:okio:3.9.1') {
+            because 'version 3.0.0 has vulnerability CVE-2023-3635'
+        }
+    }
 
-  testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
-  testImplementation(platform('org.junit:junit-bom:5.11.3'))
-  testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', {
-    exclude group: 'junit', module: 'junit'
-    exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
-  }
-  testImplementation group: 'org.mockito', name: 'mockito-inline', version: '5.2.0'
-  testImplementation group: 'org.springframework.ws', name: 'spring-ws-test', version: '4.0.11'
-  testImplementation group: 'commons-io', name: 'commons-io', version: '2.17.0'// CVE-2021-29425
-  testImplementation group: 'commons-collections', name: 'commons-collections', version: '3.2.2'
-  testImplementation 'org.xmlunit:xmlunit-core:2.10.0'
-  testImplementation 'org.xmlunit:xmlunit-matchers:2.10.0'
-  testImplementation 'org.testcontainers:testcontainers:1.20.3'
-  testImplementation 'org.springframework.boot:spring-boot-testcontainers'
-  testImplementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-contract-stub-runner', version: '4.1.4'
+    implementation 'org.zalando:problem-spring-web-starter:0.29.1'
+    implementation 'org.apache.commons:commons-collections4:4.4'
 
-  testImplementation group: 'org.testcontainers', name: 'junit-jupiter', version: '1.20.3'
-  testImplementation 'it.ozimov:embedded-redis:0.7.3'
-  testImplementation 'io.github.hakky54:logcaptor:2.9.3'
-  testImplementation group: 'org.apache.jmeter', name: 'ApacheJMeter_core', version: '5.6.3', {
-    exclude group: 'org.codehaus.groovy', module: 'groovy-json'
-    exclude group: 'org.codehaus.groovy', module: 'groovy-xml'
-    exclude group: 'org.codehaus.groovy', module: 'groovy-jso'
-    exclude group: 'org.codehaus.groovy', module: 'groovy'
-  }
+    implementation 'org.mapstruct:mapstruct:1.6.3'
+    implementation 'org.openapitools:jackson-databind-nullable:0.2.6'
+    implementation group: 'org.apache.xmlbeans', name: 'xmlbeans', version: '5.2.2'
 
-  testImplementation group: 'org.apache.jmeter', name: 'ApacheJMeter_http', version: '5.6.3'
+    // https://mvnrepository.com/artifact/org.apache.ws.xmlschema/xmlschema-core
+    implementation group: 'org.apache.ws.xmlschema', name: 'xmlschema-core', version: '2.3.1'
+    // https://mvnrepository.com/artifact/javax.mail/javax.mail-api
+    implementation group: 'javax.mail', name: 'javax.mail-api', version: '1.6.2'
+    // https://mvnrepository.com/artifact/javax.activation/activation
+    implementation group: 'javax.activation', name: 'activation', version: '1.1.1'
+    // https://mvnrepository.com/artifact/com.sun.mail/javax.mail
+    implementation group: 'com.sun.mail', name: 'javax.mail', version: '1.6.2'
+
+    implementation project(path: ':context')
+    implementation 'javax.annotation:javax.annotation-api:1.3.2'
+    implementation platform('com.azure:azure-sdk-bom:1.2.29')
+    implementation 'com.azure:azure-storage-blob'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
+
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+    testImplementation(platform('org.junit:junit-bom:5.11.3'))
+    testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', {
+        exclude group: 'junit', module: 'junit'
+        exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
+    }
+    testImplementation group: 'org.mockito', name: 'mockito-inline', version: '5.2.0'
+    testImplementation group: 'org.springframework.ws', name: 'spring-ws-test', version: '4.0.11'
+    testImplementation group: 'commons-io', name: 'commons-io', version: '2.17.0'// CVE-2021-29425
+    testImplementation group: 'commons-collections', name: 'commons-collections', version: '3.2.2'
+    testImplementation 'org.xmlunit:xmlunit-core:2.10.0'
+    testImplementation 'org.xmlunit:xmlunit-matchers:2.10.0'
+    testImplementation 'org.testcontainers:testcontainers:1.20.3'
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-contract-stub-runner', version: '4.1.4'
+
+    testImplementation group: 'org.testcontainers', name: 'junit-jupiter', version: '1.20.3'
+    testImplementation 'it.ozimov:embedded-redis:0.7.3'
+    testImplementation 'io.github.hakky54:logcaptor:2.9.3'
+    testImplementation group: 'org.apache.jmeter', name: 'ApacheJMeter_core', version: '5.6.3', {
+        exclude group: 'org.codehaus.groovy', module: 'groovy-json'
+        exclude group: 'org.codehaus.groovy', module: 'groovy-xml'
+        exclude group: 'org.codehaus.groovy', module: 'groovy-jso'
+        exclude group: 'org.codehaus.groovy', module: 'groovy'
+    }
+
+    testImplementation group: 'org.apache.jmeter', name: 'ApacheJMeter_http', version: '5.6.3'
 
 
-  openapispec 'com.github.hmcts:darts-api:master-SNAPSHOT:openapi'
+    openapispec 'com.github.hmcts:darts-api:master-SNAPSHOT:openapi'
 }
 
 mainClassName = 'uk.gov.hmcts.darts.Application'
 
 bootJar {
-  archiveFileName = "darts-gateway.jar"
+    archiveFileName = "darts-gateway.jar"
 
-  manifest {
-    attributes('Implementation-Version': project.version.toString())
-  }
+    manifest {
+        attributes('Implementation-Version': project.version.toString())
+    }
 
 }
 
 // Gradle 7.x issue, workaround from: https://github.com/gradle/gradle/issues/17236#issuecomment-894768083
 rootProject.tasks.named("processSmokeTestResources") {
-  duplicatesStrategy = 'include'
+    duplicatesStrategy = 'include'
 }
 
 rootProject.tasks.named("processIntegrationTestResources") {
-  duplicatesStrategy = 'include'
+    duplicatesStrategy = 'include'
 }
 
 rootProject.tasks.named("processFunctionalTestResources") {
-  duplicatesStrategy = 'include'
+    duplicatesStrategy = 'include'
 }
 
 wrapper {
-  distributionType = Wrapper.DistributionType.ALL
+    distributionType = Wrapper.DistributionType.ALL
 }
 
 tasks.withType(Checkstyle) {
-  exclude 'com/service/mojdarts/synapps/com/**'
-  exclude 'com/synapps/moj/dfs/response/*.java'
-  exclude 'com/emc/**/*.java'
-  exclude 'uk/gov/courtservice/**/*.java'
-  exclude 'uk/gov/addcase/**/*.java'
-  exclude 'com/viqsoultions/**/*.java'
-  exclude 'com/service/viq/event/**/*.java'
+    exclude 'com/service/mojdarts/synapps/com/**'
+    exclude 'com/synapps/moj/dfs/response/*.java'
+    exclude 'com/emc/**/*.java'
+    exclude 'uk/gov/courtservice/**/*.java'
+    exclude 'uk/gov/addcase/**/*.java'
+    exclude 'com/viqsoultions/**/*.java'
+    exclude 'com/service/viq/event/**/*.java'
 }
 
 tasks.withType(Pmd) {
-  exclude 'com/service/mojdarts/synapps/com/**'
-  exclude 'com/synapps/moj/dfs/response/**'
-  exclude 'com/emc/**/*.java'
-  exclude 'uk/gov/courtservice/**/*.java'
-  exclude 'uk/gov/addcase/**/*.java'
-  exclude 'com/viqsoultions/**/*.java'
-  exclude 'com/service/viq/event/**/*.java'
+    exclude 'com/service/mojdarts/synapps/com/**'
+    exclude 'com/synapps/moj/dfs/response/**'
+    exclude 'com/emc/**/*.java'
+    exclude 'uk/gov/courtservice/**/*.java'
+    exclude 'uk/gov/addcase/**/*.java'
+    exclude 'com/viqsoultions/**/*.java'
+    exclude 'com/service/viq/event/**/*.java'
 }
 
 sourceSets {
-  main {
-    java {
-      srcDir 'src/main/java'
-      srcDir 'src/main/java/generated'
-      srcDir 'build/generated-sources/jaxb'
-      srcDir 'build/generated-sources/jaxbViqEvent'
-      srcDir 'build/generated-sources/jaxbRegisterNode'
-      srcDir 'build/generated-sources/jaxbAddCase'
-      srcDir 'build/generated-sources/jaxbAddAudio'
-      srcDir 'build/generated-sources/jaxbViqEvent'
+    main {
+        java {
+            srcDir 'src/main/java'
+            srcDir 'src/main/java/generated'
+            srcDir 'build/generated-sources/jaxb'
+            srcDir 'build/generated-sources/jaxbViqEvent'
+            srcDir 'build/generated-sources/jaxbRegisterNode'
+            srcDir 'build/generated-sources/jaxbAddCase'
+            srcDir 'build/generated-sources/jaxbAddAudio'
+            srcDir 'build/generated-sources/jaxbViqEvent'
+        }
     }
-  }
 }
 
 tasks.named('processTestResources', Copy) {
-  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
 task genJaxb {
-  ext.sourcesDir = "${buildDir}/generated-sources/jaxb"
-  ext.schema = "src/main/resources/schemas/dar-notify-event.xsd"
+    ext.sourcesDir = "${buildDir}/generated-sources/jaxb"
+    ext.schema = "src/main/resources/schemas/dar-notify-event.xsd"
 
-  outputs.dir sourcesDir
+    outputs.dir sourcesDir
 
-  doLast() {
-    project.ant {
-      taskdef name: "xjc", classname: "com.sun.tools.xjc.XJCTask", classpath: configurations.jaxb.asPath
-      mkdir(dir: sourcesDir)
+    doLast() {
+        project.ant {
+            taskdef name: "xjc", classname: "com.sun.tools.xjc.XJCTask", classpath: configurations.jaxb.asPath
+            mkdir(dir: sourcesDir)
 
-      xjc(destdir: sourcesDir, schema: schema) {
-        arg(value: "-wsdl")
-        produces(dir: sourcesDir, includes: "**/*.java")
-      }
+            xjc(destdir: sourcesDir, schema: schema) {
+                arg(value: "-wsdl")
+                produces(dir: sourcesDir, includes: "**/*.java")
+            }
+        }
     }
-  }
 }
 
 task genJaxbViqEvent {
-  ext.sourcesDir = "${buildDir}/generated-sources/jaxbViqEvent"
-  ext.schema = "src/main/resources/schemas/event.xsd"
+    ext.sourcesDir = "${buildDir}/generated-sources/jaxbViqEvent"
+    ext.schema = "src/main/resources/schemas/event.xsd"
 
-  outputs.dir sourcesDir
+    outputs.dir sourcesDir
 
-  doLast() {
-    project.ant {
-      taskdef name: "xjc", classname: "com.sun.tools.xjc.XJCTask", classpath: configurations.jaxb.asPath
-      mkdir(dir: sourcesDir)
+    doLast() {
+        project.ant {
+            taskdef name: "xjc", classname: "com.sun.tools.xjc.XJCTask", classpath: configurations.jaxb.asPath
+            mkdir(dir: sourcesDir)
 
-      xjc(destdir: sourcesDir, package: "com.service.viq.event",  schema: schema) {
-        arg(value: "-wsdl")
-        produces(dir: sourcesDir, includes: "**/*.java")
-      }
+            xjc(destdir: sourcesDir, package: "com.service.viq.event", schema: schema) {
+                arg(value: "-wsdl")
+                produces(dir: sourcesDir, includes: "**/*.java")
+            }
+        }
     }
-  }
 }
 
 task genJaxbRegisterNode {
-  ext.sourcesDir = "${buildDir}/generated-sources/jaxbRegisterNode"
-  ext.schema = "src/main/resources/schemas/darts-register-node.xsd"
+    ext.sourcesDir = "${buildDir}/generated-sources/jaxbRegisterNode"
+    ext.schema = "src/main/resources/schemas/darts-register-node.xsd"
 
-  outputs.dir sourcesDir
+    outputs.dir sourcesDir
 
-  doLast() {
-    project.ant {
-      taskdef name: "xjc", classname: "com.sun.tools.xjc.XJCTask", classpath: configurations.jaxb.asPath
-      mkdir(dir: sourcesDir)
+    doLast() {
+        project.ant {
+            taskdef name: "xjc", classname: "com.sun.tools.xjc.XJCTask", classpath: configurations.jaxb.asPath
+            mkdir(dir: sourcesDir)
 
-      xjc(destdir: sourcesDir, package: "com.service.mojdarts.synapps.com.registernode",  schema: schema) {
-        arg(value: "-wsdl")
+            xjc(destdir: sourcesDir, package: "com.service.mojdarts.synapps.com.registernode", schema: schema) {
+                arg(value: "-wsdl")
 
-        produces(dir: sourcesDir, includes: "**/*.java")
-      }
+                produces(dir: sourcesDir, includes: "**/*.java")
+            }
+        }
     }
-  }
 }
 
 task genJaxbAddCase {
-  ext.sourcesDir = "${buildDir}/generated-sources/jaxbAddCase"
-  ext.schema = "src/main/resources/schemas/darts-add-case.xsd"
+    ext.sourcesDir = "${buildDir}/generated-sources/jaxbAddCase"
+    ext.schema = "src/main/resources/schemas/darts-add-case.xsd"
 
-  outputs.dir sourcesDir
+    outputs.dir sourcesDir
 
-  doLast() {
-    project.ant {
-      taskdef name: "xjc", classname: "com.sun.tools.xjc.XJCTask", classpath: configurations.jaxb.asPath
-      mkdir(dir: sourcesDir)
+    doLast() {
+        project.ant {
+            taskdef name: "xjc", classname: "com.sun.tools.xjc.XJCTask", classpath: configurations.jaxb.asPath
+            mkdir(dir: sourcesDir)
 
-      xjc(destdir: sourcesDir, package: "com.service.mojdarts.synapps.com.addcase",  schema: schema) {
-        arg(value: "-wsdl")
+            xjc(destdir: sourcesDir, package: "com.service.mojdarts.synapps.com.addcase", schema: schema) {
+                arg(value: "-wsdl")
 
-        produces(dir: sourcesDir, includes: "**/*.java")
-      }
+                produces(dir: sourcesDir, includes: "**/*.java")
+            }
+        }
     }
-  }
 }
 
 task genJaxbAddAudio {
-  ext.sourcesDir = "${buildDir}/generated-sources/jaxbAddAudio"
-  ext.schema = "src/main/resources/schemas/addAudio.xsd"
+    ext.sourcesDir = "${buildDir}/generated-sources/jaxbAddAudio"
+    ext.schema = "src/main/resources/schemas/addAudio.xsd"
 
-  outputs.dir sourcesDir
+    outputs.dir sourcesDir
 
-  doLast() {
-    project.ant {
-      taskdef name: "xjc", classname: "com.sun.tools.xjc.XJCTask", classpath: configurations.jaxb.asPath
-      mkdir(dir: sourcesDir)
+    doLast() {
+        project.ant {
+            taskdef name: "xjc", classname: "com.sun.tools.xjc.XJCTask", classpath: configurations.jaxb.asPath
+            mkdir(dir: sourcesDir)
 
-      xjc(destdir: sourcesDir, package: "com.service.mojdarts.synapps.com.addaudio",  schema: schema) {
-        arg(value: "-wsdl")
+            xjc(destdir: sourcesDir, package: "com.service.mojdarts.synapps.com.addaudio", schema: schema) {
+                arg(value: "-wsdl")
 
-        produces(dir: sourcesDir, includes: "**/*.java")
-      }
+                produces(dir: sourcesDir, includes: "**/*.java")
+            }
+        }
     }
-  }
 }
 
 wsdl2java {
     wsdlDir.set(layout.projectDirectory.dir("src/main/resources/ws/dartsService"))
     includes = [
-        "**/*.wsdl"
-      ]
+            "**/*.wsdl"
+    ]
 }
 
 compileJava.dependsOn genJaxb
 
 task extractOpenSpecification() {
-  doFirst {
-    configurations.openapispec.getFiles()
-      .each {
-        def zip = new java.util.zip.ZipFile(it)
-        for (def entry : zip.entries()) {
-          if (entry == null) return
+    doFirst {
+        configurations.openapispec.getFiles()
+                .each {
+                    def zip = new java.util.zip.ZipFile(it)
+                    for (def entry : zip.entries()) {
+                        if (entry == null) return
 
-          String contents = zip.getInputStream(entry).text
+                        String contents = zip.getInputStream(entry).text
 
-          String name = entry.name
+                        String name = entry.name
 
-          if (name.endsWith(".yaml")) {
-            //  Finally, we write the contents to a file
-            new File(layout.buildDirectory.dir("extractedSpecs").get().asFile.absolutePath).mkdirs()
-            String newFileName = "${layout.buildDirectory.dir("extractedSpecs").get().asFile.absolutePath}/$name"
+                        if (name.endsWith(".yaml")) {
+                            //  Finally, we write the contents to a file
+                            new File(layout.buildDirectory.dir("extractedSpecs").get().asFile.absolutePath).mkdirs()
+                            String newFileName = "${layout.buildDirectory.dir("extractedSpecs").get().asFile.absolutePath}/$name"
 
-            def newFile = new File(newFileName)
-            newFile.createNewFile()
-            newFile.text = contents
-          }
-        }
-      }
-  }
+                            def newFile = new File(newFileName)
+                            newFile.createNewFile()
+                            newFile.text = contents
+                        }
+                    }
+                }
+    }
 }
 
 /**
  * Run the custom task with the defaults to process the legacy darts service
  */
 tasks.register('processDartsServiceWSDL', CreateAPIMWSDLFile)
-{
-  wsdlFile = new File("src/main/resources/ws/dartsService/DARTSService.wsdl")
-  urlToReplace = "http://test"
-  outputFile = new File("src/main/resources/ws/dartsService.wsdl")
-}
+        {
+            wsdlFile = new File("src/main/resources/ws/dartsService/DARTSService.wsdl")
+            urlToReplace = "http://test"
+            outputFile = new File("src/main/resources/ws/dartsService.wsdl")
+        }
 
 project.tasks.processResources.dependsOn processDartsServiceWSDL
 project.tasks.wsdl2java.dependsOn processDartsServiceWSDL
@@ -683,9 +684,25 @@ generateCodeFromSpecification.dependsOn extractOpenSpecification
 compileJava.dependsOn genJaxbAddCase, genJaxbRegisterNode, genJaxbAddAudio, genJaxbViqEvent
 
 tasks.named { it == "generateEffectiveLombokConfig" }.configureEach {
-  dependsOn(genJaxb)
-  dependsOn(genJaxbAddAudio)
-  dependsOn(genJaxbAddCase)
-  dependsOn(genJaxbRegisterNode)
-  dependsOn(genJaxbViqEvent)
+    dependsOn(genJaxb)
+    dependsOn(genJaxbAddAudio)
+    dependsOn(genJaxbAddCase)
+    dependsOn(genJaxbRegisterNode)
+    dependsOn(genJaxbViqEvent)
+}
+
+task runAllStyleChecks {
+    dependsOn 'checkstyleMain'
+    dependsOn 'checkstyleTest'
+    dependsOn 'checkstyleIntegrationTest'
+    dependsOn 'checkstyleSmokeTest'
+    dependsOn 'checkstyleFunctionalTest'
+    dependsOn 'checkstyleTestCommon'
+
+    dependsOn 'pmdMain'
+    dependsOn 'pmdTest'
+    dependsOn 'pmdIntegrationTest'
+    dependsOn 'pmdSmokeTest'
+    dependsOn 'pmdFunctionalTest'
+    dependsOn 'pmdTestCommon'
 }

--- a/charts/darts-gateway/Chart.yaml
+++ b/charts/darts-gateway/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for darts-gateway App
 name: darts-gateway
 home: https://github.com/hmcts/darts-gateway
-version: 0.0.38
+version: 0.0.39
 maintainers:
   - name: HMCTS darts team
 dependencies:

--- a/charts/darts-gateway/values.yaml
+++ b/charts/darts-gateway/values.yaml
@@ -6,6 +6,8 @@ java:
   keyVaults:
     "darts":
       secrets:
+        - name: AzureStorageConnectionString
+          alias: AZURE_STORAGE_CONNECTION_STRING
         - name: AzureAdB2CFuncTestROPCClientId
           alias: AAD_B2C_ROPC_CLIENT_ID
         - name: AzureAdB2CClientId

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -47,6 +47,8 @@ services:
       - ARM_USERNAME
       - ARM_PASSWORD
       - ARM_URL=http://darts-stub-services:4551
+      - AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;
+
     build:
       context: .
     image: darts-api:latest

--- a/src/functionalTest/java/uk/gov/hmcts/darts/common/client/FunctionalTestClient.java
+++ b/src/functionalTest/java/uk/gov/hmcts/darts/common/client/FunctionalTestClient.java
@@ -24,19 +24,20 @@ public class FunctionalTestClient {
     private final FunctionalProperties functionalProperties;
 
     public void clear() throws IOException, InterruptedException {
-        HttpClient httpClient = HttpClient.newHttpClient();
+        try (HttpClient httpClient = HttpClient.newHttpClient()) {
 
-        log.debug("Clearing down on url " + functionalProperties.getDeployedApplicationUri() + "/functional-tests/clean");
-        HttpRequest httpRequest = HttpRequest
-            .newBuilder()
-            .DELETE().uri(URI.create(functionalProperties.getDeployedApplicationUri().toString() + "/functional-tests/clean"))
-            .build();
+            log.debug("Clearing down on url {}/functional-tests/clean", functionalProperties.getDeployedApplicationUri());
+            HttpRequest httpRequest = HttpRequest
+                .newBuilder()
+                .DELETE().uri(URI.create(functionalProperties.getDeployedApplicationUri().toString() + "/functional-tests/clean"))
+                .build();
 
-        HttpResponse<String> httpResponses = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
-        log.debug("Clearing down response is " + httpResponses.statusCode());
-        Assertions.assertEquals(200, httpResponses.statusCode(),
-                                "Expected a 200 when communicating with "
-                                    + functionalProperties.getDeployedApplicationUri().toString() + "/functional-tests/clean. " +
-                                "Response Status: " + httpResponses.statusCode() + "Response Body: " + httpResponses.body());
+            HttpResponse<String> httpResponses = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+            log.debug("Clearing down response is {}", httpResponses.statusCode());
+            Assertions.assertEquals(200, httpResponses.statusCode(),
+                                    "Expected a 200 when communicating with "
+                                        + functionalProperties.getDeployedApplicationUri().toString() + "/functional-tests/clean. " +
+                                        "Response Status: " + httpResponses.statusCode() + " Response Body: " + httpResponses.body());
+        }
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/workflow/AddAudioMtomMidTierWorkflowTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/workflow/AddAudioMtomMidTierWorkflowTest.java
@@ -71,7 +71,8 @@ class AddAudioMtomMidTierWorkflowTest extends AbstractWorkflowCommand {
             WireMock.matching(
                 "\\{\"started_at\":1698048000.000000000,\"ended_at\":1698051600.000000000,\"channel\":0,\"total_channels\":3,\"format\":\"mp2\"," +
                     "\"filename\":\"sample6.mp2\",\"courthouse\":\"CARDIFF\",\"courtroom\":\"1\",\"media_file\":\"sample6.mp2\",\"file_size\":5854354," +
-                    "\"checksum\":null,\"cases\":\\[\"123456789\"],\"storage_guid\":\"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\"}")));
+                    "\"checksum\":\"81ef8524d69c7ae6605baf37e425b574\",\"cases\":\\[\"123456789\"]," +
+                    "\"storage_guid\":\"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\"}")));
 
         Mockito.verify(validator, times(2)).test(Mockito.eq(Token.TokenExpiryEnum.DO_NOT_APPLY_EARLY_TOKEN_EXPIRY), Mockito.anyString());
         Mockito.verify(validator, times(3)).test(Mockito.eq(Token.TokenExpiryEnum.APPLY_EARLY_TOKEN_EXPIRY), Mockito.anyString());

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/AddAudioWebServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/AddAudioWebServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.darts.ws;
 
+import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.matching.RegexPattern;
 import com.service.mojdarts.synapps.com.AddAudioResponse;
 import org.junit.jupiter.api.Assertions;
@@ -25,19 +26,16 @@ import uk.gov.hmcts.darts.common.utils.TestUtils;
 import uk.gov.hmcts.darts.common.utils.client.SoapAssertionUtil;
 import uk.gov.hmcts.darts.common.utils.client.darts.DartsClientProvider;
 import uk.gov.hmcts.darts.common.utils.client.darts.DartsGatewayClient;
-import uk.gov.hmcts.darts.common.utils.matcher.MultipartDartsProxyContentPattern;
+import uk.gov.hmcts.darts.datastore.DataManagementService;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
 import uk.gov.hmcts.darts.testutils.request.DummyXmlWithFileMultiPartRequest;
 import uk.gov.hmcts.darts.workflow.command.AddAudioMidTierCommand;
 
-import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.time.Duration;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.Optional;
+import java.util.UUID;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
@@ -46,6 +44,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -63,15 +62,13 @@ class AddAudioWebServiceTest extends IntegrationBase {
 
     @MockBean
     private TokenValidator validator;
+    @MockBean
+    private DataManagementService dataManagementService;
 
     @Value("${darts-gateway.add-audio.fileSizeInMegaBytes}")
     private DataSize maxByteSize;
 
-    @Value("${darts-gateway.add-audio.maxFileDuration}")
-    private Duration maxFileDuration;
-
-    private static final OffsetDateTime STARTED_AT = OffsetDateTime.of(2024, 10, 10, 10, 0, 0, 0, ZoneOffset.UTC);
-    private static final URI ENDPOINT = URI.create("/audios");
+    private final UUID uuid = UUID.randomUUID();
 
     @BeforeEach
     public void before() {
@@ -82,6 +79,7 @@ class AddAudioWebServiceTest extends IntegrationBase {
 
         when(mockOauthTokenGenerator.acquireNewToken(ContextRegistryParent.SERVICE_CONTEXT_USER, ContextRegistryParent.SERVICE_CONTEXT_USER))
             .thenReturn("test");
+        when(dataManagementService.saveBlobData(any(), any(), any())).thenReturn(uuid);
     }
 
     @ParameterizedTest
@@ -98,7 +96,7 @@ class AddAudioWebServiceTest extends IntegrationBase {
             String dartsApiResponseStr = TestUtils.getContentsFromFile(
                 "payloads/addAudio/register/dartsApiResponse.json");
 
-            stubFor(post(urlPathEqualTo("/audios"))
+            stubFor(post(urlPathEqualTo("/audios/metadata"))
                         .willReturn(ok(dartsApiResponseStr).withHeader("Content-Type", "application/json")));
 
             XmlWithFileMultiPartRequest request = new DummyXmlWithFileMultiPartRequest(AddAudioMidTierCommand.SAMPLE_FILE);
@@ -122,7 +120,7 @@ class AddAudioWebServiceTest extends IntegrationBase {
             String dartsApiResponseStr = TestUtils.getContentsFromFile(
                 "payloads/addAudio/register/dartsApiResponse.json");
 
-            stubFor(post(urlPathEqualTo("/audios"))
+            stubFor(post(urlPathEqualTo("/audios/metadata"))
                         .willReturn(ok(dartsApiResponseStr).withHeader("Content-Type", "application/json")));
 
             XmlWithFileMultiPartRequest request = new DummyXmlWithFileMultiPartRequest(AddAudioMidTierCommand.SAMPLE_FILE);
@@ -146,7 +144,7 @@ class AddAudioWebServiceTest extends IntegrationBase {
             String dartsApiResponseStr = TestUtils.getContentsFromFile(
                 "payloads/addAudio/register/dartsApiResponse.json");
 
-            stubFor(post(urlPathEqualTo("/audios"))
+            stubFor(post(urlPathEqualTo("/audios/metadata"))
                         .willReturn(ok(dartsApiResponseStr).withHeader("Content-Type", "application/json")));
 
             XmlWithFileMultiPartRequest request = new DummyXmlWithFileMultiPartRequest(AddAudioMidTierCommand.SAMPLE_FILE);
@@ -167,7 +165,7 @@ class AddAudioWebServiceTest extends IntegrationBase {
             String dartsApiResponseStr = TestUtils.getContentsFromFile(
                 "payloads/addAudio/register/dartsApiResponse.json");
 
-            stubFor(post(urlPathEqualTo("/audios"))
+            stubFor(post(urlPathEqualTo("/audios/metadata"))
                         .willReturn(ok(dartsApiResponseStr).withHeader("Content-Type", "application/json")));
 
             String expectedResponseStr = TestUtils.getContentsFromFile(
@@ -182,8 +180,12 @@ class AddAudioWebServiceTest extends IntegrationBase {
             SoapAssertionUtil<AddAudioResponse> response = client.addAudio(getGatewayUri(), soapRequestStr);
             response.assertIdenticalResponse(client.convertData(expectedResponseStr, AddAudioResponse.class).getValue());
 
-            verify(postRequestedFor(urlPathEqualTo("/audios"))
-                       .withRequestBody(new MultipartDartsProxyContentPattern()));
+            verify(postRequestedFor(urlPathEqualTo("/audios/metadata")).withRequestBody(
+                WireMock.matching(
+                    "\\{\"started_at\":1694082411.000000000,\"ended_at\":1694082589.000000000,\"channel\":1,\"total_channels\":4,\"format\":\"mpeg2\"," +
+                        "\"filename\":\"0001.a00\",\"courthouse\":\"SWANSEA\",\"courtroom\":\"32\",\"media_file\":\"0001.a00\",\"file_size\":5854354," +
+                        "\"checksum\":null,\"cases\":\\[\"T20230294\",\"U20230907-112949\"]," +
+                        "\"storage_guid\":\"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\"}")));
 
         }, getContextClient(), getGatewayUri(), DEFAULT_HEADER_USERNAME, DEFAULT_HEADER_PASSWORD);
     }
@@ -192,8 +194,7 @@ class AddAudioWebServiceTest extends IntegrationBase {
     @ArgumentsSource(DartsClientProvider.class)
     void testHandlesAddAudioWithAuthenticationTokenWithRefresh(DartsGatewayClient client) throws Exception {
 
-        when(validator.test(Mockito.any(),
-                                     Mockito.eq("downstreamtoken"))).thenReturn(true);
+        when(validator.test(any(), Mockito.eq("downstreamtoken"))).thenReturn(true);
 
         when(mockOauthTokenGenerator.acquireNewToken(DEFAULT_HEADER_USERNAME, DEFAULT_HEADER_PASSWORD))
             .thenReturn("downstreamtoken", "test", "downstreamrefresh", "downstreamrefreshoutsidecache");
@@ -205,7 +206,7 @@ class AddAudioWebServiceTest extends IntegrationBase {
             String dartsApiResponseStr = TestUtils.getContentsFromFile(
                 "payloads/addAudio/register/dartsApiResponse.json");
 
-            stubFor(post(urlPathEqualTo("/audios"))
+            stubFor(post(urlPathEqualTo("/audios/metadata"))
                         .willReturn(ok(dartsApiResponseStr).withHeader("Content-Type", "application/json")));
 
             String expectedResponseStr = TestUtils.getContentsFromFile(
@@ -214,18 +215,21 @@ class AddAudioWebServiceTest extends IntegrationBase {
             XmlWithFileMultiPartRequest request = new DummyXmlWithFileMultiPartRequest(AddAudioMidTierCommand.SAMPLE_FILE);
             when(requestHolder.getRequest()).thenReturn(Optional.of(request));
 
-            when(validator.test(Mockito.any(),
-                                         Mockito.eq("downstreamtoken"))).thenReturn(false);
+            when(validator.test(any(), Mockito.eq("downstreamtoken"))).thenReturn(false);
 
             SoapAssertionUtil<AddAudioResponse> response = client.addAudio(getGatewayUri(), soapRequestStr);
             response.assertIdenticalResponse(client.convertData(expectedResponseStr, AddAudioResponse.class).getValue());
 
-            verify(postRequestedFor(urlPathEqualTo("/audios"))
-                       .withRequestBody(new MultipartDartsProxyContentPattern()));
+            verify(postRequestedFor(urlPathEqualTo("/audios/metadata")).withRequestBody(
+                WireMock.matching(
+                    "\\{\"started_at\":1694082411.000000000,\"ended_at\":1694082589.000000000,\"channel\":1,\"total_channels\":4,\"format\":\"mpeg2\"," +
+                        "\"filename\":\"0001.a00\",\"courthouse\":\"SWANSEA\",\"courtroom\":\"32\",\"media_file\":\"0001.a00\",\"file_size\":5854354," +
+                        "\"checksum\":null,\"cases\":\\[\"T20230294\",\"U20230907-112949\"]," +
+                        "\"storage_guid\":\"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\"}")));
         }, getContextClient(), getGatewayUri(), DEFAULT_HEADER_USERNAME, DEFAULT_HEADER_PASSWORD);
 
-        verify(postRequestedFor(urlPathEqualTo("/audios"))
-                            .withHeader("Authorization", new RegexPattern("Bearer downstreamrefreshoutsidecache")));
+        verify(postRequestedFor(urlPathEqualTo("/audios/metadata"))
+                   .withHeader("Authorization", new RegexPattern("Bearer downstreamrefreshoutsidecache")));
         Mockito.verify(mockOauthTokenGenerator, times(4)).acquireNewToken(DEFAULT_HEADER_USERNAME, DEFAULT_HEADER_PASSWORD);
     }
 
@@ -240,7 +244,7 @@ class AddAudioWebServiceTest extends IntegrationBase {
             String dartsApiResponseStr = TestUtils.getContentsFromFile(
                 "payloads/addAudio/register/dartsApiResponse.json");
 
-            stubFor(post(urlPathEqualTo("/audios"))
+            stubFor(post(urlPathEqualTo("/audios/metadata"))
                         .willReturn(ok(dartsApiResponseStr).withHeader("Content-Type", "application/json")));
 
             String expectedResponseStr = TestUtils.getContentsFromFile(
@@ -252,8 +256,12 @@ class AddAudioWebServiceTest extends IntegrationBase {
             SoapAssertionUtil<AddAudioResponse> response = client.addAudio(getGatewayUri(), soapRequestStr);
             response.assertIdenticalResponse(client.convertData(expectedResponseStr, AddAudioResponse.class).getValue());
 
-            verify(postRequestedFor(urlPathEqualTo("/audios"))
-                       .withRequestBody(new MultipartDartsProxyContentPattern()));
+            verify(postRequestedFor(urlPathEqualTo("/audios/metadata")).withRequestBody(
+                WireMock.matching(
+                    "\\{\"started_at\":1694082411.000000000,\"ended_at\":1694082589.000000000,\"channel\":1,\"total_channels\":4,\"format\":\"mpeg2\"," +
+                        "\"filename\":\"0001.a00\",\"courthouse\":\"SWANSEA\",\"courtroom\":\"32\",\"media_file\":\"0001.a00\",\"file_size\":5854354," +
+                        "\"checksum\":null,\"cases\":\\[\"T20230294\",\"U20230907-112949\"]," +
+                        "\"storage_guid\":\"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\"}")));
 
             // ensure that the payload logging is turned off for this api call
             Assertions.assertFalse(logAppender.searchLogs(SoapRequestInterceptor.REQUEST_PAYLOAD_PREFIX, null, null).isEmpty());
@@ -301,7 +309,7 @@ class AddAudioWebServiceTest extends IntegrationBase {
             String soapRequestStr = TestUtils.getContentsFromFile(
                 "payloads/addAudio/register/soapRequest.xml");
 
-            stubFor(post(urlPathEqualTo("/audios"))
+            stubFor(post(urlPathEqualTo("/audios/metadata"))
                         .willReturn(aResponse().withStatus(404).withBody("this is not a valid error format")));
 
             XmlWithFileMultiPartRequest request = new DummyXmlWithFileMultiPartRequest(AddAudioMidTierCommand.SAMPLE_FILE);
@@ -311,8 +319,12 @@ class AddAudioWebServiceTest extends IntegrationBase {
             SoapAssertionUtil<AddAudioResponse> response = client.addAudio(getGatewayUri(), soapRequestStr);
             Assertions.assertEquals(responseCode.getCode(), response.getResponse().getValue().getReturn().getCode());
         }, DEFAULT_HEADER_USERNAME, DEFAULT_HEADER_PASSWORD);
-        verify(postRequestedFor(urlPathEqualTo("/audios"))
-                   .withRequestBody(new MultipartDartsProxyContentPattern()));
+        verify(postRequestedFor(urlPathEqualTo("/audios/metadata")).withRequestBody(
+            WireMock.matching(
+                "\\{\"started_at\":1694082411.000000000,\"ended_at\":1694082589.000000000,\"channel\":1,\"total_channels\":4,\"format\":\"mpeg2\"," +
+                    "\"filename\":\"0001.a00\",\"courthouse\":\"SWANSEA\",\"courtroom\":\"32\",\"media_file\":\"0001.a00\",\"file_size\":5854354," +
+                    "\"checksum\":null,\"cases\":\\[\"T20230294\",\"U20230907-112949\"]," +
+                    "\"storage_guid\":\"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\"}")));
     }
 
     @ParameterizedTest
@@ -343,7 +355,7 @@ class AddAudioWebServiceTest extends IntegrationBase {
             String dartsApiResponseStr = TestUtils.getContentsFromFile(
                 "payloads/addAudio/register/problemResponse.json");
 
-            stubFor(post(urlPathEqualTo("/audios"))
+            stubFor(post(urlPathEqualTo("/audios/metadata"))
                         .willReturn(aResponse().withStatus(404)
                                         .withBody(dartsApiResponseStr)));
 
@@ -356,8 +368,12 @@ class AddAudioWebServiceTest extends IntegrationBase {
             SoapAssertionUtil<AddAudioResponse> response = client.addAudio(getGatewayUri(), soapRequestStr);
             response.assertIdenticalResponse(client.convertData(expectedResponseStr, AddAudioResponse.class).getValue());
 
-            verify(postRequestedFor(urlPathEqualTo("/audios"))
-                       .withRequestBody(new MultipartDartsProxyContentPattern()));
+            verify(postRequestedFor(urlPathEqualTo("/audios/metadata")).withRequestBody(
+                WireMock.matching(
+                    "\\{\"started_at\":1694082411.000000000,\"ended_at\":1694082589.000000000,\"channel\":1,\"total_channels\":4,\"format\":\"mpeg2\"," +
+                        "\"filename\":\"0001.a00\",\"courthouse\":\"theunknowncourthouse\",\"courtroom\":\"32\",\"media_file\":\"0001.a00\"" +
+                        ",\"file_size\":5854354,\"checksum\":null,\"cases\":\\[\"T20230294\",\"U20230907-112949\"]," +
+                        "\"storage_guid\":\"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\"}")));
         }, DEFAULT_HEADER_USERNAME, DEFAULT_HEADER_PASSWORD);
     }
 
@@ -453,7 +469,7 @@ class AddAudioWebServiceTest extends IntegrationBase {
             String dartsApiResponseStr = TestUtils.getContentsFromFile(
                 "payloads/addAudio/register/problemResponse500.json");
 
-            stubFor(post(urlPathEqualTo("/audios"))
+            stubFor(post(urlPathEqualTo("/audios/metadata"))
                         .willReturn(aResponse().withStatus(500)
                                         .withBody(dartsApiResponseStr)));
 
@@ -478,7 +494,7 @@ class AddAudioWebServiceTest extends IntegrationBase {
             String dartsApiResponseStr = TestUtils.getContentsFromFile(
                 "payloads/addAudio/register/problemResponse500.json");
 
-            stubFor(post(urlPathEqualTo("/audios"))
+            stubFor(post(urlPathEqualTo("/audios/metadata"))
                         .willReturn(aResponse().withStatus(500)
                                         .withBody(dartsApiResponseStr)));
 
@@ -504,7 +520,7 @@ class AddAudioWebServiceTest extends IntegrationBase {
             String dartsApiResponseStr = TestUtils.getContentsFromFile(
                 "payloads/addAudio/register/dartsApiResponse.json");
 
-            stubFor(post(urlPathEqualTo("/audios"))
+            stubFor(post(urlPathEqualTo("/audios/metadata"))
                         .willReturn(ok(dartsApiResponseStr).withStatus(500)));
 
             XmlWithFileMultiPartRequest request = new DummyXmlWithFileMultiPartRequest(AddAudioMidTierCommand.SAMPLE_FILE);
@@ -515,11 +531,15 @@ class AddAudioWebServiceTest extends IntegrationBase {
             Assertions.assertFalse(logAppender
                                        .searchLogs(
                                            AbstractClientProblemDecoder.RESPONSE_PREFIX +
-                                                       "500 Server Error: \"{<EOL>" +
+                                               "500 Server Error: \"{<EOL>" +
                                                "  \"code\": \"200\",<EOL>  \"message\": \"OK\"<EOL>}<EOL>\"", null, null).isEmpty());
 
-            verify(postRequestedFor(urlPathEqualTo("/audios"))
-                       .withRequestBody(new MultipartDartsProxyContentPattern()));
+            verify(postRequestedFor(urlPathEqualTo("/audios/metadata")).withRequestBody(
+                WireMock.matching(
+                    "\\{\"started_at\":1694082411.000000000,\"ended_at\":1694082589.000000000,\"channel\":1,\"total_channels\":4,\"format\":\"mpeg2\"," +
+                        "\"filename\":\"0001.a00\",\"courthouse\":\"SWANSEA\",\"courtroom\":\"32\",\"media_file\":\"0001.a00\",\"file_size\":5854354," +
+                        "\"checksum\":null,\"cases\":\\[\"T20230294\",\"U20230907-112949\"]," +
+                        "\"storage_guid\":\"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\"}")));
 
             // ensure that the payload logging is turned off for this api call
             Assertions.assertFalse(logAppender.searchLogs(SoapRequestInterceptor.REQUEST_PAYLOAD_PREFIX, null, null).isEmpty());
@@ -537,7 +557,7 @@ class AddAudioWebServiceTest extends IntegrationBase {
             String dartsApiResponseStr = TestUtils.getContentsFromFile(
                 "payloads/addAudio/register/dartsApiResponse.json");
 
-            stubFor(post(urlPathEqualTo("/audios"))
+            stubFor(post(urlPathEqualTo("/audios/metadata"))
                         .willReturn(ok(dartsApiResponseStr).withStatus(500).withBody("<html><body>Internal Server Error</body></html>")));
 
             XmlWithFileMultiPartRequest request = new DummyXmlWithFileMultiPartRequest(AddAudioMidTierCommand.SAMPLE_FILE);
@@ -547,8 +567,12 @@ class AddAudioWebServiceTest extends IntegrationBase {
             Assertions.assertEquals("500", response.getResponse().getValue().getReturn().getCode());
             Assertions.assertFalse(logAppender.searchLogs(AbstractClientProblemDecoder.RESPONSE_PREFIX
                                                               + "500 Server Error: \"<html><body>Internal Server Error</body></html>\"", null, null).isEmpty());
-            verify(postRequestedFor(urlPathEqualTo("/audios"))
-                       .withRequestBody(new MultipartDartsProxyContentPattern()));
+            verify(postRequestedFor(urlPathEqualTo("/audios/metadata")).withRequestBody(
+                WireMock.matching(
+                    "\\{\"started_at\":1694082411.000000000,\"ended_at\":1694082589.000000000,\"channel\":1,\"total_channels\":4,\"format\":\"mpeg2\"," +
+                        "\"filename\":\"0001.a00\",\"courthouse\":\"SWANSEA\",\"courtroom\":\"32\",\"media_file\":\"0001.a00\",\"file_size\":5854354," +
+                        "\"checksum\":null,\"cases\":\\[\"T20230294\",\"U20230907-112949\"]," +
+                        "\"storage_guid\":\"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\"}")));
 
             // ensure that the payload logging is turned off for this api call
             Assertions.assertFalse(logAppender.searchLogs(SoapRequestInterceptor.REQUEST_PAYLOAD_PREFIX, null, null).isEmpty());

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/AddAudioWebServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/AddAudioWebServiceTest.java
@@ -184,7 +184,7 @@ class AddAudioWebServiceTest extends IntegrationBase {
                 WireMock.matching(
                     "\\{\"started_at\":1694082411.000000000,\"ended_at\":1694082589.000000000,\"channel\":1,\"total_channels\":4,\"format\":\"mpeg2\"," +
                         "\"filename\":\"0001.a00\",\"courthouse\":\"SWANSEA\",\"courtroom\":\"32\",\"media_file\":\"0001.a00\",\"file_size\":5854354," +
-                        "\"checksum\":null,\"cases\":\\[\"T20230294\",\"U20230907-112949\"]," +
+                        "\"checksum\":\"81ef8524d69c7ae6605baf37e425b574\",\"cases\":\\[\"T20230294\",\"U20230907-112949\"]," +
                         "\"storage_guid\":\"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\"}")));
 
         }, getContextClient(), getGatewayUri(), DEFAULT_HEADER_USERNAME, DEFAULT_HEADER_PASSWORD);
@@ -224,7 +224,7 @@ class AddAudioWebServiceTest extends IntegrationBase {
                 WireMock.matching(
                     "\\{\"started_at\":1694082411.000000000,\"ended_at\":1694082589.000000000,\"channel\":1,\"total_channels\":4,\"format\":\"mpeg2\"," +
                         "\"filename\":\"0001.a00\",\"courthouse\":\"SWANSEA\",\"courtroom\":\"32\",\"media_file\":\"0001.a00\",\"file_size\":5854354," +
-                        "\"checksum\":null,\"cases\":\\[\"T20230294\",\"U20230907-112949\"]," +
+                        "\"checksum\":\"81ef8524d69c7ae6605baf37e425b574\",\"cases\":\\[\"T20230294\",\"U20230907-112949\"]," +
                         "\"storage_guid\":\"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\"}")));
         }, getContextClient(), getGatewayUri(), DEFAULT_HEADER_USERNAME, DEFAULT_HEADER_PASSWORD);
 
@@ -260,7 +260,7 @@ class AddAudioWebServiceTest extends IntegrationBase {
                 WireMock.matching(
                     "\\{\"started_at\":1694082411.000000000,\"ended_at\":1694082589.000000000,\"channel\":1,\"total_channels\":4,\"format\":\"mpeg2\"," +
                         "\"filename\":\"0001.a00\",\"courthouse\":\"SWANSEA\",\"courtroom\":\"32\",\"media_file\":\"0001.a00\",\"file_size\":5854354," +
-                        "\"checksum\":null,\"cases\":\\[\"T20230294\",\"U20230907-112949\"]," +
+                        "\"checksum\":\"81ef8524d69c7ae6605baf37e425b574\",\"cases\":\\[\"T20230294\",\"U20230907-112949\"]," +
                         "\"storage_guid\":\"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\"}")));
 
             // ensure that the payload logging is turned off for this api call
@@ -323,7 +323,7 @@ class AddAudioWebServiceTest extends IntegrationBase {
             WireMock.matching(
                 "\\{\"started_at\":1694082411.000000000,\"ended_at\":1694082589.000000000,\"channel\":1,\"total_channels\":4,\"format\":\"mpeg2\"," +
                     "\"filename\":\"0001.a00\",\"courthouse\":\"SWANSEA\",\"courtroom\":\"32\",\"media_file\":\"0001.a00\",\"file_size\":5854354," +
-                    "\"checksum\":null,\"cases\":\\[\"T20230294\",\"U20230907-112949\"]," +
+                    "\"checksum\":\"81ef8524d69c7ae6605baf37e425b574\",\"cases\":\\[\"T20230294\",\"U20230907-112949\"]," +
                     "\"storage_guid\":\"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\"}")));
     }
 
@@ -372,7 +372,7 @@ class AddAudioWebServiceTest extends IntegrationBase {
                 WireMock.matching(
                     "\\{\"started_at\":1694082411.000000000,\"ended_at\":1694082589.000000000,\"channel\":1,\"total_channels\":4,\"format\":\"mpeg2\"," +
                         "\"filename\":\"0001.a00\",\"courthouse\":\"theunknowncourthouse\",\"courtroom\":\"32\",\"media_file\":\"0001.a00\"" +
-                        ",\"file_size\":5854354,\"checksum\":null,\"cases\":\\[\"T20230294\",\"U20230907-112949\"]," +
+                        ",\"file_size\":5854354,\"checksum\":\"81ef8524d69c7ae6605baf37e425b574\",\"cases\":\\[\"T20230294\",\"U20230907-112949\"]," +
                         "\"storage_guid\":\"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\"}")));
         }, DEFAULT_HEADER_USERNAME, DEFAULT_HEADER_PASSWORD);
     }
@@ -538,7 +538,7 @@ class AddAudioWebServiceTest extends IntegrationBase {
                 WireMock.matching(
                     "\\{\"started_at\":1694082411.000000000,\"ended_at\":1694082589.000000000,\"channel\":1,\"total_channels\":4,\"format\":\"mpeg2\"," +
                         "\"filename\":\"0001.a00\",\"courthouse\":\"SWANSEA\",\"courtroom\":\"32\",\"media_file\":\"0001.a00\",\"file_size\":5854354," +
-                        "\"checksum\":null,\"cases\":\\[\"T20230294\",\"U20230907-112949\"]," +
+                        "\"checksum\":\"81ef8524d69c7ae6605baf37e425b574\",\"cases\":\\[\"T20230294\",\"U20230907-112949\"]," +
                         "\"storage_guid\":\"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\"}")));
 
             // ensure that the payload logging is turned off for this api call
@@ -571,7 +571,7 @@ class AddAudioWebServiceTest extends IntegrationBase {
                 WireMock.matching(
                     "\\{\"started_at\":1694082411.000000000,\"ended_at\":1694082589.000000000,\"channel\":1,\"total_channels\":4,\"format\":\"mpeg2\"," +
                         "\"filename\":\"0001.a00\",\"courthouse\":\"SWANSEA\",\"courtroom\":\"32\",\"media_file\":\"0001.a00\",\"file_size\":5854354," +
-                        "\"checksum\":null,\"cases\":\\[\"T20230294\",\"U20230907-112949\"]," +
+                        "\"checksum\":\"81ef8524d69c7ae6605baf37e425b574\",\"cases\":\\[\"T20230294\",\"U20230907-112949\"]," +
                         "\"storage_guid\":\"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\"}")));
 
             // ensure that the payload logging is turned off for this api call

--- a/src/integrationTest/resources/application-int-test-jwt-token-error-log-level.yaml
+++ b/src/integrationTest/resources/application-int-test-jwt-token-error-log-level.yaml
@@ -10,6 +10,10 @@ logging:
     root: ERROR
 
 darts-gateway:
+  storage:
+    blob:
+      client:
+        disable-upload: true
   cache:
     token-generate: jwt
     map-token-to-session: false

--- a/src/integrationTest/resources/application-int-test-jwt-token-shared.yaml
+++ b/src/integrationTest/resources/application-int-test-jwt-token-shared.yaml
@@ -10,6 +10,10 @@ logging:
     root: ERROR
 
 darts-gateway:
+#  storage:
+#    blob:
+#      client:
+#        disable-upload: true
   cache:
     token-generate: jwt
     map-token-to-session: false

--- a/src/integrationTest/resources/application-int-test-jwt-token-shared.yaml
+++ b/src/integrationTest/resources/application-int-test-jwt-token-shared.yaml
@@ -10,10 +10,6 @@ logging:
     root: ERROR
 
 darts-gateway:
-#  storage:
-#    blob:
-#      client:
-#        disable-upload: true
   cache:
     token-generate: jwt
     map-token-to-session: false

--- a/src/main/java/uk/gov/hmcts/darts/common/client/AbstractRestTemplateClient.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/AbstractRestTemplateClient.java
@@ -34,10 +34,11 @@ public abstract class AbstractRestTemplateClient {
     /**
      * Uploads a file by streaming NOTE: This mechanism does not use feign for the reason that feign loads files into memory (see
      * https://github.com/OpenFeign/feign-form/issues/88)
+     *
      * @param multipartFile The multipart file to transfer. A default one that disables in memory loading
      *                      can be found {@link uk.gov.hmcts.darts.common.client.multipart.StreamingMultipart}
-     * @param metadata The meta data
-     * @param url The url to use
+     * @param metadata      The meta data
+     * @param url           The url to use
      */
     public <T> void streamFileWithMetaData(MultipartFile multipartFile, T metadata, String url) {
         MultiValueMap<String, Object> map = new LinkedMultiValueMap<>();
@@ -68,12 +69,15 @@ public abstract class AbstractRestTemplateClient {
         }
     }
 
-    private <T> void processHttpHeaderInterceptors(HttpHeaders headers) {
+
+
+    protected <T> void processHttpHeaderInterceptors(HttpHeaders headers) {
         interceptors.forEach(intercept -> intercept.accept(headers));
     }
 
     /**
      * The template to send the request.
+     *
      * @return The template
      */
     protected abstract RestTemplate getTemplate();
@@ -81,6 +85,7 @@ public abstract class AbstractRestTemplateClient {
 
     /**
      * handles the error. This is the feign {@link feign.codec.ErrorDecoder} equivalent
+     *
      * @return The decoder
      */
     protected abstract DartsClientProblemDecoder getProblemDecoder();

--- a/src/main/java/uk/gov/hmcts/darts/common/client/AudiosClient.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/AudiosClient.java
@@ -2,15 +2,20 @@ package uk.gov.hmcts.darts.common.client;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
 import uk.gov.hmcts.darts.api.audio.AudiosApi;
 import uk.gov.hmcts.darts.common.client.component.HttpHeadersInterceptor;
 import uk.gov.hmcts.darts.common.client.exeption.DartsClientProblemDecoder;
 import uk.gov.hmcts.darts.model.audio.AddAudioMetadataRequest;
+import uk.gov.hmcts.darts.model.audio.AddAudioMetadataRequestWithStorageGUID;
 
 import java.util.List;
 
@@ -33,9 +38,10 @@ public class AudiosClient extends AbstractRestTemplateClient implements AudiosAp
 
     /**
      * Add an audio using streaming.
+     *
      * @param multipartFile The multipart audio file to transfer. A default one that disableS in memory loading
      *                      can be found {@link uk.gov.hmcts.darts.common.client.multipart.StreamingMultipart}
-     * @param audio The audio meta data
+     * @param audio         The audio meta data
      */
     public void streamAudio(MultipartFile multipartFile, AddAudioMetadataRequest audio) {
         streamFileWithMetaData(multipartFile, audio, baseUrl + "/audios");
@@ -55,5 +61,20 @@ public class AudiosClient extends AbstractRestTemplateClient implements AudiosAp
     public ResponseEntity<Void> addAudio(MultipartFile file, AddAudioMetadataRequest metadata) {
         streamAudio(file, metadata);
         return new ResponseEntity<>(HttpStatusCode.valueOf(200));
+    }
+
+    @Override
+    @SuppressWarnings("PMD.LooseCoupling")
+    public ResponseEntity<Void> addAudioMetaData(AddAudioMetadataRequestWithStorageGUID addAudioMetadataRequestWithStorageGuid) {
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            HttpEntity<AddAudioMetadataRequestWithStorageGUID> requestEntity = new HttpEntity<>(addAudioMetadataRequestWithStorageGuid, headers);
+            processHttpHeaderInterceptors(headers);
+            return getTemplate().postForEntity(baseUrl + "/audios/metadata", requestEntity, Void.class);
+        } catch (HttpStatusCodeException e) {
+            log.error("Darts api client exception", e);
+            throw getProblemDecoder().decode(e);
+        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/client/AudiosClient.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/AudiosClient.java
@@ -69,6 +69,7 @@ public class AudiosClient extends AbstractRestTemplateClient implements AudiosAp
         try {
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.setAccept(List.of());
             HttpEntity<AddAudioMetadataRequestWithStorageGUID> requestEntity = new HttpEntity<>(addAudioMetadataRequestWithStorageGuid, headers);
             processHttpHeaderInterceptors(headers);
             return getTemplate().postForEntity(baseUrl + "/audios/metadata", requestEntity, Void.class);

--- a/src/main/java/uk/gov/hmcts/darts/datastore/DataManagementConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/darts/datastore/DataManagementConfiguration.java
@@ -1,0 +1,35 @@
+package uk.gov.hmcts.darts.datastore;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Slf4j
+@Component
+@Getter
+public final class DataManagementConfiguration {
+
+    @Value("${darts-gateway.storage.blob.client.connection-string}")
+    private String blobStorageAccountConnectionString;
+
+    @Value("${darts-gateway.storage.blob.client.block-size-bytes}")
+    private long blobClientBlockSizeBytes;
+
+    @Value("${darts-gateway.storage.blob.client.max-single-upload-size-bytes}")
+    private long blobClientMaxSingleUploadSizeBytes;
+
+    @Value("${darts-gateway.storage.blob.client.max-concurrency}")
+    private int blobClientMaxConcurrency;
+
+    @Value("${darts-gateway.storage.blob.client.disable-upload}")
+    private boolean disableUpload;
+
+    @Value("${darts-gateway.storage.blob.client.timeout}")
+    private Duration blobClientTimeout;
+
+    @Value("${darts-gateway.storage.blob.container-name.inbound}")
+    private String inboundContainerName;
+}

--- a/src/main/java/uk/gov/hmcts/darts/datastore/DataManagementService.java
+++ b/src/main/java/uk/gov/hmcts/darts/datastore/DataManagementService.java
@@ -1,0 +1,10 @@
+package uk.gov.hmcts.darts.datastore;
+
+import java.io.InputStream;
+import java.util.Map;
+import java.util.UUID;
+
+public interface DataManagementService {
+
+    UUID saveBlobData(String containerName, InputStream inputStream, Map<String, String> metadata);
+}

--- a/src/main/java/uk/gov/hmcts/darts/datastore/DataManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/datastore/DataManagementServiceImpl.java
@@ -1,0 +1,51 @@
+package uk.gov.hmcts.darts.datastore;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.models.ParallelTransferOptions;
+import com.azure.storage.blob.options.BlobParallelUploadOptions;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.darts.datastore.azure.DataManagementAzureClientFactory;
+
+import java.io.InputStream;
+import java.util.Map;
+import java.util.UUID;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class DataManagementServiceImpl implements DataManagementService {
+
+    private final DataManagementAzureClientFactory blobServiceFactory;
+    private final DataManagementConfiguration dataManagementConfiguration;
+
+    @Override
+    public UUID saveBlobData(String containerName, InputStream inputStream, Map<String, String> metadata) {
+        UUID uniqueBlobId = UUID.randomUUID();
+        if (dataManagementConfiguration.isDisableUpload()) {
+            log.info("Azure upload is disabled in properties. Skipping file upload");
+            return uniqueBlobId;
+        }
+        BlobServiceClient serviceClient = blobServiceFactory.getBlobServiceClient(dataManagementConfiguration.getBlobStorageAccountConnectionString());
+        BlobContainerClient containerClient = blobServiceFactory.getBlobContainerClient(containerName, serviceClient);
+
+        BlobClient client = blobServiceFactory.getBlobClient(containerClient, uniqueBlobId);
+
+        var uploadOptions = new BlobParallelUploadOptions(inputStream);
+        uploadOptions.setMetadata(metadata);
+        uploadOptions.setParallelTransferOptions(createCommonTransferOptions());
+        client.uploadWithResponse(uploadOptions, dataManagementConfiguration.getBlobClientTimeout(), null);
+
+        return uniqueBlobId;
+    }
+
+    private ParallelTransferOptions createCommonTransferOptions() {
+        return new ParallelTransferOptions()
+            .setBlockSizeLong(dataManagementConfiguration.getBlobClientBlockSizeBytes())
+            .setMaxSingleUploadSizeLong(dataManagementConfiguration.getBlobClientMaxSingleUploadSizeBytes())
+            .setMaxConcurrency(dataManagementConfiguration.getBlobClientMaxConcurrency());
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/datastore/azure/DataManagementAzureClientFactory.java
+++ b/src/main/java/uk/gov/hmcts/darts/datastore/azure/DataManagementAzureClientFactory.java
@@ -1,0 +1,15 @@
+package uk.gov.hmcts.darts.datastore.azure;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+
+import java.util.UUID;
+
+public interface DataManagementAzureClientFactory {
+    BlobContainerClient getBlobContainerClient(String containerName, BlobServiceClient serviceClient);
+
+    BlobClient getBlobClient(BlobContainerClient containerClient, UUID blobName);
+
+    BlobServiceClient getBlobServiceClient(String containerString);
+}

--- a/src/main/java/uk/gov/hmcts/darts/datastore/azure/DataManagementAzureClientFactoryImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/datastore/azure/DataManagementAzureClientFactoryImpl.java
@@ -1,0 +1,39 @@
+package uk.gov.hmcts.darts.datastore.azure;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class DataManagementAzureClientFactoryImpl implements DataManagementAzureClientFactory {
+
+    private final Map<String, BlobContainerClient> blobContainerClientMap = new ConcurrentHashMap<>();
+    private final Map<String, BlobServiceClient> blobServiceClientMap = new ConcurrentHashMap<>();
+
+    @Override
+    public BlobContainerClient getBlobContainerClient(String containerName, BlobServiceClient serviceClient) {
+        String id = serviceClient.getAccountUrl() + ":" + containerName;
+        return blobContainerClientMap.computeIfAbsent(id, k -> serviceClient.getBlobContainerClient(containerName));
+    }
+
+    @Override
+    public BlobClient getBlobClient(BlobContainerClient containerClient, UUID blobId) {
+        return containerClient.getBlobClient(String.valueOf(blobId));
+    }
+
+    @Override
+    public BlobServiceClient getBlobServiceClient(String containerString) {
+        return blobServiceClientMap.computeIfAbsent(containerString, k -> new BlobServiceClientBuilder()
+            .connectionString(containerString).buildClient());
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/test/TestSupportController.java
+++ b/src/main/java/uk/gov/hmcts/darts/test/TestSupportController.java
@@ -20,17 +20,15 @@ public class TestSupportController {
 
     private final RedisTemplate<String, Object> template;
 
-    @SuppressWarnings({"unchecked", "PMD.CloseResource"})
     @DeleteMapping(value = "/functional-tests/clean")
     public void cleanUpDataAfterFunctionalTests() {
         deleteKeyByPattern(TokenRegisterable.CACHE_PREFIX + "*");
     }
 
-    public boolean deleteKeyByPattern(String pattern) {
+    public void deleteKeyByPattern(String pattern) {
         Set<byte[]> patternResultConf = template.getConnectionFactory().getConnection().keys(pattern.getBytes());
         if (Objects.nonNull(patternResultConf) && !patternResultConf.isEmpty()) {
             template.getConnectionFactory().getConnection().del(patternResultConf.toArray(new byte[0][]));
         }
-        return true;
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/utilities/DataUtil.java
+++ b/src/main/java/uk/gov/hmcts/darts/utilities/DataUtil.java
@@ -1,0 +1,52 @@
+package uk.gov.hmcts.darts.utilities;
+
+import uk.gov.hmcts.darts.model.audio.AddAudioMetadataRequest;
+import uk.gov.hmcts.darts.model.audio.AddAudioMetadataRequestWithStorageGUID;
+
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public final class DataUtil {
+
+    private DataUtil() {
+
+    }
+
+    public static Map<String, String> toMap(AddAudioMetadataRequest addAudioMetadataRequest) {
+        DateTimeFormatter dataTimeFormatter = DateTimeFormatter.ISO_DATE_TIME;
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("startedAt", addAudioMetadataRequest.getStartedAt().format(dataTimeFormatter));
+        metadata.put("endedAt", addAudioMetadataRequest.getEndedAt().format(dataTimeFormatter));
+        metadata.put("channel", String.valueOf(addAudioMetadataRequest.getChannel()));
+        metadata.put("totalChannels", String.valueOf(addAudioMetadataRequest.getTotalChannels()));
+        metadata.put("format", addAudioMetadataRequest.getFormat());
+        metadata.put("filename", addAudioMetadataRequest.getFilename());
+        metadata.put("courthouse", addAudioMetadataRequest.getCourthouse());
+        metadata.put("courtroom", addAudioMetadataRequest.getCourtroom());
+        metadata.put("mediaFile", addAudioMetadataRequest.getMediaFile());
+        metadata.put("fileSize", String.valueOf(addAudioMetadataRequest.getFileSize()));
+        metadata.put("checksum", addAudioMetadataRequest.getChecksum());
+        metadata.put("cases", String.join(",", addAudioMetadataRequest.getCases()));
+        return metadata;
+    }
+
+    public static AddAudioMetadataRequestWithStorageGUID convertToStorageGuid(AddAudioMetadataRequest metadata, UUID blobStoreUuid) {
+        AddAudioMetadataRequestWithStorageGUID addAudioMetadataRequestWithStorageGuid = new AddAudioMetadataRequestWithStorageGUID();
+        addAudioMetadataRequestWithStorageGuid.setStartedAt(metadata.getStartedAt());
+        addAudioMetadataRequestWithStorageGuid.setEndedAt(metadata.getEndedAt());
+        addAudioMetadataRequestWithStorageGuid.setChannel(metadata.getChannel());
+        addAudioMetadataRequestWithStorageGuid.setTotalChannels(metadata.getTotalChannels());
+        addAudioMetadataRequestWithStorageGuid.setFormat(metadata.getFormat());
+        addAudioMetadataRequestWithStorageGuid.setFilename(metadata.getFilename());
+        addAudioMetadataRequestWithStorageGuid.setCourthouse(metadata.getCourthouse());
+        addAudioMetadataRequestWithStorageGuid.setCourtroom(metadata.getCourtroom());
+        addAudioMetadataRequestWithStorageGuid.setMediaFile(metadata.getMediaFile());
+        addAudioMetadataRequestWithStorageGuid.setFileSize(metadata.getFileSize());
+        addAudioMetadataRequestWithStorageGuid.setChecksum(metadata.getChecksum());
+        addAudioMetadataRequestWithStorageGuid.setCases(metadata.getCases());
+        addAudioMetadataRequestWithStorageGuid.setStorageGuid(blobStoreUuid);
+        return addAudioMetadataRequestWithStorageGuid;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/utilities/DataUtil.java
+++ b/src/main/java/uk/gov/hmcts/darts/utilities/DataUtil.java
@@ -1,38 +1,43 @@
 package uk.gov.hmcts.darts.utilities;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import uk.gov.hmcts.darts.model.audio.AddAudioMetadataRequest;
 import uk.gov.hmcts.darts.model.audio.AddAudioMetadataRequestWithStorageGUID;
 
+import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 public final class DataUtil {
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
 
     private DataUtil() {
 
     }
 
-    public static Map<String, String> toMap(AddAudioMetadataRequest addAudioMetadataRequest) {
-        DateTimeFormatter dataTimeFormatter = DateTimeFormatter.ISO_DATE_TIME;
+    public static Map<String, String> toMap(@NotNull @Valid AddAudioMetadataRequest addAudioMetadataRequest) {
         Map<String, String> metadata = new HashMap<>();
-        metadata.put("startedAt", addAudioMetadataRequest.getStartedAt().format(dataTimeFormatter));
-        metadata.put("endedAt", addAudioMetadataRequest.getEndedAt().format(dataTimeFormatter));
-        metadata.put("channel", String.valueOf(addAudioMetadataRequest.getChannel()));
-        metadata.put("totalChannels", String.valueOf(addAudioMetadataRequest.getTotalChannels()));
+        metadata.put("startedAt", formatDateTime(addAudioMetadataRequest.getStartedAt()));
+        metadata.put("endedAt", formatDateTime(addAudioMetadataRequest.getEndedAt()));
+        metadata.put("channel", toString(addAudioMetadataRequest.getChannel()));
+        metadata.put("totalChannels", toString(addAudioMetadataRequest.getTotalChannels()));
         metadata.put("format", addAudioMetadataRequest.getFormat());
         metadata.put("filename", addAudioMetadataRequest.getFilename());
         metadata.put("courthouse", addAudioMetadataRequest.getCourthouse());
         metadata.put("courtroom", addAudioMetadataRequest.getCourtroom());
         metadata.put("mediaFile", addAudioMetadataRequest.getMediaFile());
-        metadata.put("fileSize", String.valueOf(addAudioMetadataRequest.getFileSize()));
+        metadata.put("fileSize", toString(addAudioMetadataRequest.getFileSize()));
         metadata.put("checksum", addAudioMetadataRequest.getChecksum());
         metadata.put("cases", String.join(",", addAudioMetadataRequest.getCases()));
         return metadata;
     }
 
-    public static AddAudioMetadataRequestWithStorageGUID convertToStorageGuid(AddAudioMetadataRequest metadata, UUID blobStoreUuid) {
+    public static AddAudioMetadataRequestWithStorageGUID convertToStorageGuid(@NotNull @Valid AddAudioMetadataRequest metadata,
+                                                                              @NotNull @Valid UUID blobStoreUuid) {
         AddAudioMetadataRequestWithStorageGUID addAudioMetadataRequestWithStorageGuid = new AddAudioMetadataRequestWithStorageGUID();
         addAudioMetadataRequestWithStorageGuid.setStartedAt(metadata.getStartedAt());
         addAudioMetadataRequestWithStorageGuid.setEndedAt(metadata.getEndedAt());
@@ -48,5 +53,23 @@ public final class DataUtil {
         addAudioMetadataRequestWithStorageGuid.setCases(metadata.getCases());
         addAudioMetadataRequestWithStorageGuid.setStorageGuid(blobStoreUuid);
         return addAudioMetadataRequestWithStorageGuid;
+    }
+
+    private static String formatDateTime(@NotNull @Valid OffsetDateTime date) {
+        return Optional.ofNullable(date)
+            .map(DATE_TIME_FORMATTER::format)
+            .orElse(null);
+    }
+
+    private static String toString(Long longValue) {
+        return Optional.ofNullable(longValue)
+            .map(String::valueOf)
+            .orElse(null);
+    }
+
+    private static String toString(Integer intValue) {
+        return Optional.ofNullable(intValue)
+            .map(String::valueOf)
+            .orElse(null);
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/utilities/FileContentChecksum.java
+++ b/src/main/java/uk/gov/hmcts/darts/utilities/FileContentChecksum.java
@@ -1,0 +1,36 @@
+package uk.gov.hmcts.darts.utilities;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.apache.commons.codec.digest.DigestUtils.md5;
+
+/**
+ * Calculates the file checksum equivalent to "md5 filename" on the command line.
+ * <p>
+ * This is not the same as the Azure Blob Storage CONTENT-MD5 tag value as a base64 encoded
+ * representation of the binary MD5 hash value. This could be done in Bash e.g. openssl md5 -binary "Test
+ * Document.doc" | base64
+ * </p>
+ */
+@Component
+@Slf4j
+public class FileContentChecksum {
+
+    public static String calculate(InputStream inputStream) throws IOException {
+        return encodeToString(md5(inputStream));
+    }
+
+    public static String encodeToString(byte[] bytes) {
+        StringBuilder result = new StringBuilder();
+        for (byte b : bytes) {
+            result.append(String.format("%02x", b));
+        }
+
+        return result.toString();
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/utilities/FileContentChecksum.java
+++ b/src/main/java/uk/gov/hmcts/darts/utilities/FileContentChecksum.java
@@ -18,7 +18,11 @@ import static org.apache.commons.codec.digest.DigestUtils.md5;
  */
 @Component
 @Slf4j
-public class FileContentChecksum {
+public final class FileContentChecksum {
+
+    private FileContentChecksum() {
+
+    }
 
     public static String calculate(InputStream inputStream) throws IOException {
         return encodeToString(md5(inputStream));

--- a/src/main/java/uk/gov/hmcts/darts/utilities/FileContentChecksum.java
+++ b/src/main/java/uk/gov/hmcts/darts/utilities/FileContentChecksum.java
@@ -24,6 +24,7 @@ public final class FileContentChecksum {
 
     }
 
+    @SuppressWarnings("java:S4790")
     public static String calculate(InputStream inputStream) throws IOException {
         return encodeToString(md5(inputStream));
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -44,6 +44,18 @@ spring:
 
 azure:
 darts-gateway:
+  storage:
+    blob:
+      client:
+        connection-string: ${AZURE_STORAGE_CONNECTION_STRING:}
+        ## See https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blobs-tune-upload-download-java
+        block-size-bytes: 10_000_000
+        max-single-upload-size-bytes: 10_000_000
+        max-concurrency: 5
+        timeout: 15m
+        disable-upload: false
+      container-name:
+        inbound: darts-inbound-container
   testing-support-endpoints:
     enabled: ${TESTING_SUPPORT_ENDPOINTS_ENABLED:false}
   cache:

--- a/src/test/java/uk/gov/hmcts/darts/datastore/DataManagementServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/datastore/DataManagementServiceImplTest.java
@@ -1,0 +1,70 @@
+package uk.gov.hmcts.darts.datastore;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.darts.datastore.azure.DataManagementAzureClientFactory;
+
+import java.io.ByteArrayInputStream;
+import java.time.Duration;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DataManagementServiceImplTest {
+    public static final String BLOB_CONTAINER_NAME = "dummy_container";
+    private static final String TEST_BINARY_STRING = "Test String to be converted to binary!";
+    @Mock
+    private DataManagementAzureClientFactory dataManagementFactory;
+    @Mock
+    private BlobClient blobClient;
+    @Mock
+    private BlobServiceClient serviceClient;
+    @Mock
+    private BlobContainerClient blobContainerClient;
+    @Mock
+    private DataManagementConfiguration dataManagementConfiguration;
+    @InjectMocks
+    private DataManagementServiceImpl dataManagementService;
+
+    @BeforeEach
+    void beforeEach() {
+        when(dataManagementFactory.getBlobContainerClient(Mockito.anyString(), Mockito.notNull())).thenReturn(blobContainerClient);
+        when(dataManagementFactory.getBlobServiceClient(Mockito.notNull())).thenReturn(serviceClient);
+        when(dataManagementConfiguration.getBlobStorageAccountConnectionString()).thenReturn("connection");
+    }
+
+    @Test
+    void testSaveBlobDataViaInputStream() {
+        // Given
+        when(dataManagementConfiguration.getBlobClientBlockSizeBytes()).thenReturn(1L);
+        when(dataManagementConfiguration.getBlobClientMaxSingleUploadSizeBytes()).thenReturn(1L);
+        when(dataManagementConfiguration.getBlobClientMaxConcurrency()).thenReturn(1);
+        when(dataManagementConfiguration.getBlobClientTimeout()).thenReturn(Duration.ofMinutes(1));
+
+        when(dataManagementFactory.getBlobClient(any(), any())).thenReturn(blobClient);
+
+        // When
+        UUID uuid = dataManagementService.saveBlobData(BLOB_CONTAINER_NAME, new ByteArrayInputStream(TEST_BINARY_STRING.getBytes()), Map.of("key", "value"));
+
+        // Then
+        assertNotNull(uuid);
+        verify(dataManagementFactory, times(1)).getBlobServiceClient("connection");
+        verify(dataManagementFactory, times(1)).getBlobContainerClient(BLOB_CONTAINER_NAME, serviceClient);
+        verify(dataManagementFactory, times(1)).getBlobClient(eq(blobContainerClient), any(UUID.class));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/darts/datastore/azure/DataManagementAzureClientFactoryImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/datastore/azure/DataManagementAzureClientFactoryImplTest.java
@@ -1,0 +1,75 @@
+package uk.gov.hmcts.darts.datastore.azure;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DataManagementAzureClientFactoryImplTest {
+    @InjectMocks
+    private DataManagementAzureClientFactoryImpl dataManagementFactoryImpl;
+
+    public static final String BLOB_CONTAINER_NAME = "dummy_container";
+    public static final UUID BLOB_ID = UUID.randomUUID();
+    private static final String CONNECTION_STRING = "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;" +
+        "AccountKey=KBHBeksoGMGw;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;";
+
+    private static final String ALTERNATE_CONNECTION_STRING = "DefaultEndpointsProtocol=http;AccountName=devstoreaccount2;" +
+        "AccountKey=KBHBeksoGMGw;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;";
+    private BlobContainerClient blobContainerClient;
+    private BlobClient blobClient;
+
+    @BeforeEach
+    void beforeEach() {
+        blobContainerClient = Mockito.mock(BlobContainerClient.class);
+        blobClient = Mockito.mock(BlobClient.class);
+    }
+
+    @Test
+    void testGetBlobContainerClient() {
+        BlobContainerClient blobContainerClient = dataManagementFactoryImpl.getBlobContainerClient(
+            BLOB_CONTAINER_NAME, dataManagementFactoryImpl.getBlobServiceClient(CONNECTION_STRING));
+        assertNotNull(blobContainerClient);
+
+        Assertions.assertSame(blobContainerClient,
+                              dataManagementFactoryImpl.getBlobContainerClient(BLOB_CONTAINER_NAME,
+                                                                               dataManagementFactoryImpl.getBlobServiceClient(CONNECTION_STRING)));
+    }
+
+    @Test
+    void testGetServiceClientCaching() {
+        BlobServiceClient serviceClient = dataManagementFactoryImpl.getBlobServiceClient(CONNECTION_STRING);
+        BlobServiceClient serviceClient1 = dataManagementFactoryImpl.getBlobServiceClient(CONNECTION_STRING);
+        BlobServiceClient serviceClient2 = dataManagementFactoryImpl.getBlobServiceClient(ALTERNATE_CONNECTION_STRING);
+
+        Assertions.assertSame(serviceClient, serviceClient1);
+        Assertions.assertNotSame(serviceClient, serviceClient2);
+    }
+
+    @Test
+    void testGetServiceClientSasCaching() {
+        BlobServiceClient serviceClient = dataManagementFactoryImpl.getBlobServiceClient(CONNECTION_STRING);
+        BlobServiceClient serviceClient1 = dataManagementFactoryImpl.getBlobServiceClient(CONNECTION_STRING);
+
+        Assertions.assertSame(serviceClient, serviceClient1);
+    }
+
+    @Test
+    void testGetBlobClient() {
+        when(blobContainerClient.getBlobClient(String.valueOf(BLOB_ID))).thenReturn(blobClient);
+        BlobClient blobClient = dataManagementFactoryImpl.getBlobClient(blobContainerClient, BLOB_ID);
+        assertNotNull(blobClient);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/darts/utilities/DataUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/utilities/DataUtilTest.java
@@ -1,0 +1,78 @@
+package uk.gov.hmcts.darts.utilities;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.darts.model.audio.AddAudioMetadataRequest;
+import uk.gov.hmcts.darts.model.audio.AddAudioMetadataRequestWithStorageGUID;
+
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+class DataUtilTest {
+
+
+    private AddAudioMetadataRequest getAddAudioMetadataRequest() {
+        AddAudioMetadataRequest addAudioMetadataRequest = new AddAudioMetadataRequest();
+        addAudioMetadataRequest.setStartedAt(OffsetDateTime.parse("2021-01-01T00:00:00Z"));
+        addAudioMetadataRequest.setEndedAt(OffsetDateTime.parse("2022-01-01T00:00:00Z"));
+        addAudioMetadataRequest.setChannel(1);
+        addAudioMetadataRequest.setTotalChannels(2);
+        addAudioMetadataRequest.setFormat("format");
+        addAudioMetadataRequest.setFilename("filename");
+        addAudioMetadataRequest.setCourthouse("courthouse");
+        addAudioMetadataRequest.setCourtroom("courtroom");
+        addAudioMetadataRequest.setMediaFile("mediaFile");
+        addAudioMetadataRequest.setFileSize(100L);
+        addAudioMetadataRequest.setChecksum("checksum");
+        addAudioMetadataRequest.setCases(List.of("case1", "case2"));
+        return addAudioMetadataRequest;
+    }
+
+    @Test
+    void positiveToMap() {
+        AddAudioMetadataRequest addAudioMetadataRequest = getAddAudioMetadataRequest();
+
+        Map<String, String> expectedMap = new HashMap<>();
+        expectedMap.put("startedAt", "2021-01-01T00:00:00Z");
+        expectedMap.put("endedAt", "2022-01-01T00:00:00Z");
+        expectedMap.put("channel", "1");
+        expectedMap.put("totalChannels", "2");
+        expectedMap.put("format", "format");
+        expectedMap.put("filename", "filename");
+        expectedMap.put("courthouse", "courthouse");
+        expectedMap.put("courtroom", "courtroom");
+        expectedMap.put("mediaFile", "mediaFile");
+        expectedMap.put("fileSize", "100");
+        expectedMap.put("checksum", "checksum");
+        expectedMap.put("cases", "case1,case2");
+
+        Map<String, String> actualMap = DataUtil.toMap(addAudioMetadataRequest);
+        Assertions.assertEquals(expectedMap, actualMap);
+    }
+
+    @Test
+    void positiveConvertToStorageGuid() {
+        AddAudioMetadataRequest addAudioMetadataRequest = getAddAudioMetadataRequest();
+        UUID uuid = UUID.randomUUID();
+        AddAudioMetadataRequestWithStorageGUID expected = new AddAudioMetadataRequestWithStorageGUID();
+        expected.setStartedAt(OffsetDateTime.parse("2021-01-01T00:00:00Z"));
+        expected.setEndedAt(OffsetDateTime.parse("2022-01-01T00:00:00Z"));
+        expected.setChannel(1);
+        expected.setTotalChannels(2);
+        expected.setFormat("format");
+        expected.setFilename("filename");
+        expected.setCourthouse("courthouse");
+        expected.setCourtroom("courtroom");
+        expected.setMediaFile("mediaFile");
+        expected.setFileSize(100L);
+        expected.setChecksum("checksum");
+        expected.setCases(List.of("case1", "case2"));
+        expected.setStorageGuid(uuid);
+
+        AddAudioMetadataRequestWithStorageGUID actual = DataUtil.convertToStorageGuid(addAudioMetadataRequest, uuid);
+        Assertions.assertEquals(expected, actual);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/darts/utilities/DataUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/utilities/DataUtilTest.java
@@ -54,6 +54,27 @@ class DataUtilTest {
     }
 
     @Test
+    void positiveToMapBlankRequest() {
+        AddAudioMetadataRequest addAudioMetadataRequest = new AddAudioMetadataRequest();
+
+        Map<String, String> expectedMap = new HashMap<>();
+        expectedMap.put("startedAt", null);
+        expectedMap.put("endedAt", null);
+        expectedMap.put("channel", null);
+        expectedMap.put("totalChannels", null);
+        expectedMap.put("format", null);
+        expectedMap.put("filename", null);
+        expectedMap.put("courthouse", null);
+        expectedMap.put("courtroom", null);
+        expectedMap.put("mediaFile", null);
+        expectedMap.put("fileSize", null);
+        expectedMap.put("checksum", null);
+        expectedMap.put("cases", "");
+
+        Map<String, String> actualMap = DataUtil.toMap(addAudioMetadataRequest);
+        Assertions.assertEquals(expectedMap, actualMap);
+    }
+    @Test
     void positiveConvertToStorageGuid() {
         AddAudioMetadataRequest addAudioMetadataRequest = getAddAudioMetadataRequest();
         UUID uuid = UUID.randomUUID();
@@ -75,4 +96,16 @@ class DataUtilTest {
         AddAudioMetadataRequestWithStorageGUID actual = DataUtil.convertToStorageGuid(addAudioMetadataRequest, uuid);
         Assertions.assertEquals(expected, actual);
     }
+
+    @Test
+    void positiveConvertToStorageGuidBlankRequest() {
+        AddAudioMetadataRequest addAudioMetadataRequest = new AddAudioMetadataRequest();
+        AddAudioMetadataRequestWithStorageGUID expected = new AddAudioMetadataRequestWithStorageGUID();
+        UUID uuid = UUID.randomUUID();
+        expected.setStorageGuid(uuid);
+
+        AddAudioMetadataRequestWithStorageGUID actual = DataUtil.convertToStorageGuid(addAudioMetadataRequest, uuid);
+        Assertions.assertEquals(expected, actual);
+    }
+
 }

--- a/src/test/java/uk/gov/hmcts/darts/utilities/DataUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/utilities/DataUtilTest.java
@@ -74,6 +74,7 @@ class DataUtilTest {
         Map<String, String> actualMap = DataUtil.toMap(addAudioMetadataRequest);
         Assertions.assertEquals(expectedMap, actualMap);
     }
+
     @Test
     void positiveConvertToStorageGuid() {
         AddAudioMetadataRequest addAudioMetadataRequest = getAddAudioMetadataRequest();

--- a/src/test/java/uk/gov/hmcts/darts/utilities/FileContentChecksumTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/utilities/FileContentChecksumTest.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.darts.utilities;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+class FileContentChecksumTest {
+
+    private static final byte[] TEST_DATA = "test".getBytes(StandardCharsets.UTF_8);
+    private static final String EXPECTED_STRING_MD5_CHECKSUM = "098f6bcd4621d373cade4e832627b4f6";
+
+    @Test
+    void calculateFromInputStream() throws IOException {
+        ByteArrayInputStream testDataInputStream = new ByteArrayInputStream(TEST_DATA);
+        String calculatedChecksum = FileContentChecksum.calculate(testDataInputStream);
+        assertThat(calculatedChecksum).isEqualTo(EXPECTED_STRING_MD5_CHECKSUM);
+    }
+}

--- a/src/testCommon/java/uk.gov.hmcts.darts.common.utils/client/AbstractSoapTestClient.java
+++ b/src/testCommon/java/uk.gov.hmcts.darts.common.utils/client/AbstractSoapTestClient.java
@@ -67,19 +67,15 @@ public abstract class AbstractSoapTestClient extends WebServiceGatewaySupport
             Object obj = getWebServiceTemplate().marshalSendAndReceive(
                 uri.toString(),
                 ijaxbElement,
-                new WebServiceMessageCallback() {
-
-                    @Override
-                    public void doWithMessage(WebServiceMessage message) {
-                        try {
-                            SoapMessage soapMessage = (SoapMessage) message;
-                            SoapHeader header = soapMessage.getSoapHeader();
-                            StringSource headerSource = new StringSource(headerContents);
-                            Transformer transformer = TransformerFactory.newInstance().newTransformer();
-                            transformer.transform(headerSource, header.getResult());
-                        } catch (Exception e) {
-                            // exception handling
-                        }
+                message -> {
+                    try {
+                        SoapMessage soapMessage = (SoapMessage) message;
+                        SoapHeader header = soapMessage.getSoapHeader();
+                        StringSource headerSource = new StringSource(headerContents);
+                        Transformer transformer = TransformerFactory.newInstance().newTransformer();
+                        transformer.transform(headerSource, header.getResult());
+                    } catch (Exception e) {
+                        // exception handling
                     }
                 }
             );


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-2402)


### Change description ###
Transferring audio files between the Proxy and the API for upload to Azure was observed to be slow during performance testing. To address, the proxy should upload the audio file to Azure blob store directly, instead of sending over to the API. In case of failure, the metadata will be stored in Azure blob store, associated to the audio file. Then, the new /audio/metadata endpoint (DMP-4115) in DARTS API should be invoked from the Proxy to save the metadata of the audio file to the database. 

This change should also be applied to the Gateway. If this is not trivial to just copy the code across please raise a new ticket to track. 
h3. Acceptance criteria

*AC1: Send audio and metadata into DARTS Proxy*

GIVEN an audio file is sent

WHEN it is received into the Proxy

THEN the audio file and metadata is uploaded to Azure Blob store

AND the metadata is sent to the DARTS API and associated with the correct case

 

*AC2: Send audio and metadata into DARTS Gateway*

GIVEN an audio file is sent

WHEN it is received into the Gateway

THEN the audio file and metadata is uploaded to Azure Blob store

AND the metadata is sent to the DARTS API and associated with the correct case

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
