### PR TITLE
DMP-2402: Upload audio to azure directly from DARTS Proxy

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/addaudio/AddAudioRoute.java
+++ b/src/main/java/uk/gov/hmcts/darts/addaudio/AddAudioRoute.java
@@ -68,6 +68,7 @@ public class AddAudioRoute {
                     );
                     AddAudioMetadataRequest metaData = addAudioMapper.mapToDartsApi(addAudioLegacy);
                     metaData.setFileSize(request.get().getBinarySize());
+                    metaData.setChecksum(checksum.get());
                     multipartFileValidator.validate(multipartFile);
 
                     UUID blobStoreUuid = dataManagementService.saveBlobData(
@@ -75,7 +76,6 @@ public class AddAudioRoute {
                         multipartFile.getInputStream(),
                         DataUtil.toMap(metaData));
                     log.info("Audio file uploaded successfully to the inbound blob store. BlobStoreUuid: {}", blobStoreUuid);
-                    metaData.setChecksum(checksum.get());
                     audiosClient.addAudioMetaData(DataUtil.convertToStorageGuid(metaData, blobStoreUuid));
                 });
             } else {


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-2402)


### Change description ###
**Added checksum to azure metadata upload**

Transferring audio files between the Proxy and the API for upload to Azure was observed to be slow during performance testing. To address, the proxy should upload the audio file to Azure blob store directly, instead of sending over to the API. In case of failure, the metadata will be stored in Azure blob store, associated to the audio file. Then, the new /audio/metadata endpoint (DMP-4115) in DARTS API should be invoked from the Proxy to save the metadata of the audio file to the database. 

This change should also be applied to the Gateway. If this is not trivial to just copy the code across please raise a new ticket to track. 
h3. Acceptance criteria

*AC1: Send audio and metadata into DARTS Proxy*

GIVEN

an audio file is sent

WHEN 

it is received into the Proxy

THEN

the audio file and metadata is uploaded to Azure Blob store

AND

the metadata is sent to the DARTS API and associated with the correct case

 

*AC2: Send audio and metadata into DARTS Gateway*

GIVEN

an audio file is sent

WHEN 

it is received into the Gateway

THEN

the audio file and metadata is uploaded to Azure Blob store

AND

the metadata is sent to the DARTS API and associated with the correct case

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
