### PR TITLE
DMP-4031: Capture DAR PC time in Notify response

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/GetWelcomeTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/GetWelcomeTest.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.darts.cache.token.component.impl.TokenValidatorImpl;
 import uk.gov.hmcts.darts.cache.token.config.impl.CachePropertiesImpl;
 import uk.gov.hmcts.darts.cache.token.config.impl.SecurityPropertiesImpl;
 import uk.gov.hmcts.darts.common.controllers.RootController;
+import uk.gov.hmcts.darts.conf.ServiceTestConfiguration;
 import uk.gov.hmcts.darts.config.CacheConfig;
 import uk.gov.hmcts.darts.event.client.DarNotifyEventClient;
 import uk.gov.hmcts.darts.event.config.DarNotifyEventConfiguration;
@@ -25,7 +26,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(RootController.class)
 @Import({DarNotifyEventConfiguration.class, DarNotifyEventClient.class,
     DarNotifyEventServiceImpl.class, CachePropertiesImpl.class, CacheConfig.class,
-    SecurityPropertiesImpl.class, TokenValidatorImpl.class, OauthTokenGenerator.class, RestTemplate.class})
+    SecurityPropertiesImpl.class, TokenValidatorImpl.class, OauthTokenGenerator.class, RestTemplate.class,
+    ServiceTestConfiguration.class
+})
 class GetWelcomeTest {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/conf/ServiceTestConfiguration.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/conf/ServiceTestConfiguration.java
@@ -1,0 +1,17 @@
+package uk.gov.hmcts.darts.conf;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+import java.time.Clock;
+import java.time.Instant;
+
+@TestConfiguration
+public class ServiceTestConfiguration {
+    @Bean
+    @Primary
+    public Clock clock() {
+        return Clock.fixed(Instant.now(), Clock.systemUTC().getZone());
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/DarNotifyControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/DarNotifyControllerTest.java
@@ -99,7 +99,7 @@ class DarNotifyControllerTest {
     @Test
     @ExtendWith(OutputCaptureExtension.class)
     void shouldSendDarNotifyEventSoapActionDarPcDateOutSide2MinRangeAhead(CapturedOutput capturedOutput) throws Exception {
-        OffsetDateTime responseDateTime = OffsetDateTime.now().plusMinutes(2).truncatedTo(ChronoUnit.SECONDS);
+        OffsetDateTime responseDateTime = OffsetDateTime.now(clock).plusMinutes(2).truncatedTo(ChronoUnit.SECONDS);
         darPcStub.respondWithSuccessResponse(responseDateTime);
 
         mockMvc.perform(post("/events/dar-notify")

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/DarNotifyControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/DarNotifyControllerTest.java
@@ -80,8 +80,8 @@ class DarNotifyControllerTest {
 
     @Test
     @ExtendWith(OutputCaptureExtension.class)
-    void shouldSendDarNotifyEventSoapActionDarPcDateOutSide2MinRangeBehind(CapturedOutput capturedOutput) throws Exception {
-        OffsetDateTime responseDateTime = OffsetDateTime.now(clock).minusMinutes(2).truncatedTo(ChronoUnit.SECONDS);
+    void shouldSendDarNotifyEventSoapActionDarPcDateOutSideDriftLimitsRangeBehind(CapturedOutput capturedOutput) throws Exception {
+        OffsetDateTime responseDateTime = OffsetDateTime.now(clock).minusSeconds(90).truncatedTo(ChronoUnit.SECONDS);
         darPcStub.respondWithSuccessResponse(responseDateTime);
 
         mockMvc.perform(post("/events/dar-notify")
@@ -91,14 +91,14 @@ class DarNotifyControllerTest {
 
         darPcStub.verifyNotificationReceivedWithBody(EXPECTED_DAR_PC_NOTIFICATION);
         assertThat(capturedOutput)
-            .containsPattern("Response time from DAR PC is not within 2 minutes of current time. DarPC Response time: "
+            .containsPattern("Response time from DAR PC is outside max drift limits of PT1M30S. DAR PC Response time: "
                                  + responseDateTime.format(DateTimeFormatter.ISO_DATE_TIME)
-                                 + ", Current time: [0-9\\-.T:]+Z for url: http://localhost:8090/VIQDARNotifyEvent/DARNotifyEvent.asmx");
+                                 + ", Current time: [0-9\\-.T:]+Z for courthouse: York in courtroom: 1");
     }
 
     @Test
     @ExtendWith(OutputCaptureExtension.class)
-    void shouldSendDarNotifyEventSoapActionDarPcDateOutSide2MinRangeAhead(CapturedOutput capturedOutput) throws Exception {
+    void shouldSendDarNotifyEventSoapActionDarPcDateOutSideDriftLimitsRangeAhead(CapturedOutput capturedOutput) throws Exception {
         OffsetDateTime responseDateTime = OffsetDateTime.now(clock).plusMinutes(2).truncatedTo(ChronoUnit.SECONDS);
         darPcStub.respondWithSuccessResponse(responseDateTime);
 
@@ -109,9 +109,9 @@ class DarNotifyControllerTest {
 
         darPcStub.verifyNotificationReceivedWithBody(EXPECTED_DAR_PC_NOTIFICATION);
         assertThat(capturedOutput)
-            .containsPattern("Response time from DAR PC is not within 2 minutes of current time. DarPC Response time: "
+            .containsPattern("Response time from DAR PC is outside max drift limits of PT1M30S. DAR PC Response time: "
                                  + responseDateTime.format(DateTimeFormatter.ISO_DATE_TIME)
-                                 + ", Current time: [0-9\\-.T:]+Z for url: http://localhost:8090/VIQDARNotifyEvent/DARNotifyEvent.asmx");
+                                 + ", Current time: [0-9\\-.T:]+Z for courthouse: York in courtroom: 1");
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/DarNotifyControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/DarNotifyControllerTest.java
@@ -11,8 +11,10 @@ import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.hmcts.darts.conf.ServiceTestConfiguration;
 import uk.gov.hmcts.darts.testutils.stub.DarPcStub;
 
+import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
@@ -23,7 +25,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureWireMock(port = 8090)
-@SpringBootTest
+@SpringBootTest(classes = ServiceTestConfiguration.class)
 @ActiveProfiles({"int-test"})
 @AutoConfigureMockMvc
 class DarNotifyControllerTest {
@@ -56,6 +58,8 @@ class DarNotifyControllerTest {
 
     @Autowired
     private DarPcStub darPcStub;
+    @Autowired
+    private Clock clock;
 
     @BeforeEach
     void setup() {
@@ -64,7 +68,7 @@ class DarNotifyControllerTest {
 
     @Test
     void shouldSendDarNotifyEventSoapAction() throws Exception {
-        darPcStub.respondWithSuccessResponse(OffsetDateTime.now());
+        darPcStub.respondWithSuccessResponse(OffsetDateTime.now(clock));
 
         mockMvc.perform(post("/events/dar-notify")
                             .contentType(APPLICATION_JSON_VALUE)
@@ -77,7 +81,7 @@ class DarNotifyControllerTest {
     @Test
     @ExtendWith(OutputCaptureExtension.class)
     void shouldSendDarNotifyEventSoapActionDarPcDateOutSide2MinRangeBehind(CapturedOutput capturedOutput) throws Exception {
-        OffsetDateTime responseDateTime = OffsetDateTime.now().minusMinutes(2).truncatedTo(ChronoUnit.SECONDS);
+        OffsetDateTime responseDateTime = OffsetDateTime.now(clock).minusMinutes(2).truncatedTo(ChronoUnit.SECONDS);
         darPcStub.respondWithSuccessResponse(responseDateTime);
 
         mockMvc.perform(post("/events/dar-notify")

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/DarNotifyControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/DarNotifyControllerTest.java
@@ -67,7 +67,8 @@ class DarNotifyControllerTest {
     }
 
     @Test
-    void shouldSendDarNotifyEventSoapAction() throws Exception {
+    @ExtendWith(OutputCaptureExtension.class)
+    void shouldSendDarNotifyEventSoapAction(CapturedOutput capturedOutput) throws Exception {
         darPcStub.respondWithSuccessResponse(OffsetDateTime.now(clock));
 
         mockMvc.perform(post("/events/dar-notify")
@@ -76,6 +77,8 @@ class DarNotifyControllerTest {
             .andExpect(status().is2xxSuccessful());
 
         darPcStub.verifyNotificationReceivedWithBody(EXPECTED_DAR_PC_NOTIFICATION);
+        assertThat(capturedOutput)
+            .doesNotContain("Response time from DAR PC is outside max drift limits of");
     }
 
     @Test
@@ -91,7 +94,7 @@ class DarNotifyControllerTest {
 
         darPcStub.verifyNotificationReceivedWithBody(EXPECTED_DAR_PC_NOTIFICATION);
         assertThat(capturedOutput)
-            .containsPattern("Response time from DAR PC is outside max drift limits of PT1M30S. DAR PC Response time: "
+            .containsPattern("Response time from DAR PC is outside max drift limits of 1 minute 30 seconds. DAR PC Response time: "
                                  + responseDateTime.format(DateTimeFormatter.ISO_DATE_TIME)
                                  + ", Current time: [0-9\\-.T:]+Z for courthouse: York in courtroom: 1");
     }
@@ -109,7 +112,7 @@ class DarNotifyControllerTest {
 
         darPcStub.verifyNotificationReceivedWithBody(EXPECTED_DAR_PC_NOTIFICATION);
         assertThat(capturedOutput)
-            .containsPattern("Response time from DAR PC is outside max drift limits of PT1M30S. DAR PC Response time: "
+            .containsPattern("Response time from DAR PC is outside max drift limits of 1 minute 30 seconds. DAR PC Response time: "
                                  + responseDateTime.format(DateTimeFormatter.ISO_DATE_TIME)
                                  + ", Current time: [0-9\\-.T:]+Z for courthouse: York in courtroom: 1");
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/IntegrationBase.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/IntegrationBase.java
@@ -28,7 +28,6 @@ import uk.gov.hmcts.darts.testutils.stub.GetCasesApiStub;
 import uk.gov.hmcts.darts.testutils.stub.GetCourtLogsApiStub;
 import uk.gov.hmcts.darts.testutils.stub.PostCourtLogsApiStub;
 import uk.gov.hmcts.darts.testutils.stub.TokenStub;
-import uk.gov.hmcts.darts.utilities.XmlParser;
 import uk.gov.hmcts.darts.workflow.command.Command;
 import uk.gov.hmcts.darts.workflow.command.CommandHolder;
 import uk.gov.hmcts.darts.workflow.command.DeployRedisCommand;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/IntegrationBase.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/IntegrationBase.java
@@ -77,9 +77,6 @@ public class IntegrationBase implements CommandHolder {
     @Autowired
     private Map<String, ContextRegistryClient> contextClients;
 
-    @Autowired
-    protected XmlParser parser;
-
     private static String localhost;
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stub/DarPcStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stub/DarPcStub.java
@@ -3,6 +3,9 @@ package uk.gov.hmcts.darts.testutils.stub;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import org.springframework.stereotype.Component;
 
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToXml;
 import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
@@ -23,9 +26,10 @@ public class DarPcStub {
         <?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><DARNotifyEventResponse xmlns="http://www.VIQSoultions.com"><DARNotifyEventResult>1</DARNotifyEventResult></DARNotifyEventResponse></soap:Body></soap:Envelope>""";
 
 
-    public void respondWithSuccessResponse() {
+    public void respondWithSuccessResponse(OffsetDateTime responseDateTime) {
         stubFor(post(urlEqualTo(BASE_API_URL)).willReturn(
             aResponse().withHeader("Content-Type", "text/xml")
+                .withHeader("Date", responseDateTime.format(DateTimeFormatter.RFC_1123_DATE_TIME))
                 .withBody(DAR_PC_SUCCESS_RESPONSE)));
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/addaudio/AddAudioRoute.java
+++ b/src/main/java/uk/gov/hmcts/darts/addaudio/AddAudioRoute.java
@@ -30,7 +30,6 @@ import java.util.concurrent.atomic.AtomicReference;
 @RequiredArgsConstructor
 @Slf4j
 public class AddAudioRoute {
-    private final XmlParser xmlParser;
     private final AudiosApi audiosClient;
     private final AddAudioMapper addAudioMapper;
     private final XmlWithFileMultiPartRequestHolder multiPartRequestHolder;
@@ -48,7 +47,7 @@ public class AddAudioRoute {
         Audio addAudioLegacy;
 
         try {
-            addAudioLegacy = xmlParser.unmarshal(audioXml, Audio.class);
+            addAudioLegacy = XmlParser.unmarshal(audioXml, Audio.class);
 
             addAudioValidator.validate(addAudioLegacy);
 

--- a/src/main/java/uk/gov/hmcts/darts/cases/impl/CasesRouteImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/impl/CasesRouteImpl.java
@@ -32,7 +32,6 @@ public class CasesRouteImpl implements CasesRoute {
     @Value("${darts-gateway.addcase.validate}")
     private boolean validateAddCase;
     private final XmlValidator xmlValidator;
-    private final XmlParser xmlParser;
     private final AddCaseMapper addCaseMapper;
 
     private final CasesClient casesClient;
@@ -57,7 +56,7 @@ public class CasesRouteImpl implements CasesRoute {
             xmlValidator.validate(caseDocumentXmlStr, addCaseSchemaPath);
         }
 
-        Case caseDocument = xmlParser.unmarshal(caseDocumentXmlStr, Case.class);
+        Case caseDocument = XmlParser.unmarshal(caseDocumentXmlStr, Case.class);
         AddCaseRequest addCaseRequest = addCaseMapper.mapToDartsApi(caseDocument);
 
         casesClient.casesPost(addCaseRequest);

--- a/src/main/java/uk/gov/hmcts/darts/config/ServiceConfig.java
+++ b/src/main/java/uk/gov/hmcts/darts/config/ServiceConfig.java
@@ -37,6 +37,7 @@ import uk.gov.hmcts.darts.utilities.serializer.LocalDateTimeTypeSerializer;
 import uk.gov.hmcts.darts.utilities.serializer.LocalDateTypeSerializer;
 import uk.gov.hmcts.darts.utilities.serializer.OffsetDateTimeTypeSerializer;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
@@ -70,15 +71,20 @@ public class ServiceConfig {
         JavaTimeModule module = new JavaTimeModule();
 
         module.addSerializer(LocalDateTime.class, new LocalDateTimeTypeSerializer())
-                .addSerializer(LocalDate.class, new LocalDateTypeSerializer())
-                .addSerializer(OffsetDateTime.class, new OffsetDateTimeTypeSerializer())
-                .addDeserializer(LocalDateTime.class, new LocalDateTimeTypeDeserializer())
-                .addDeserializer(LocalDate.class, new LocalDateTypeDeserializer())
-                .addDeserializer(OffsetDateTime.class, new OffsetDateTimeTypeDeserializer());
+            .addSerializer(LocalDate.class, new LocalDateTypeSerializer())
+            .addSerializer(OffsetDateTime.class, new OffsetDateTimeTypeSerializer())
+            .addDeserializer(LocalDateTime.class, new LocalDateTimeTypeDeserializer())
+            .addDeserializer(LocalDate.class, new LocalDateTypeDeserializer())
+            .addDeserializer(OffsetDateTime.class, new OffsetDateTimeTypeDeserializer());
 
         return new ObjectMapper()
-                .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-                .registerModule(module);
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            .registerModule(module);
+    }
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
     }
 
     @Bean

--- a/src/main/java/uk/gov/hmcts/darts/courtlogs/AddCourtLogsRoute.java
+++ b/src/main/java/uk/gov/hmcts/darts/courtlogs/AddCourtLogsRoute.java
@@ -17,8 +17,6 @@ import uk.gov.hmcts.darts.utilities.XmlParser;
 @Service
 @Slf4j
 public class AddCourtLogsRoute {
-
-    private final XmlParser xmlParser;
     private final AddCourtLogsMapper mapper;
     private final CourtLogsClient courtLogsClient;
 
@@ -26,7 +24,7 @@ public class AddCourtLogsRoute {
 
         ResponseEntity<EventsResponse> response;
 
-        LogEntry logEntry = xmlParser.unmarshal(document, LogEntry.class);
+        LogEntry logEntry = XmlParser.unmarshal(document, LogEntry.class);
         CourtLogsPostRequestBody postRequestBody = mapper.mapToApi(logEntry);
 
         try {

--- a/src/main/java/uk/gov/hmcts/darts/dailylist/DailyListRoute.java
+++ b/src/main/java/uk/gov/hmcts/darts/dailylist/DailyListRoute.java
@@ -32,7 +32,6 @@ import java.util.Optional;
 public class DailyListRoute {
 
     private final DailyListsClient dailyListsClient;
-    private final XmlParser xmlParser;
     private final DailyListRequestMapper dailyListRequestMapper;
     private final XmlValidator xmlValidator;
 
@@ -58,15 +57,15 @@ public class DailyListRoute {
             }
         }
 
-        DailyListStructure legacyDailyListObject = xmlParser.unmarshal(document.trim(), DailyListStructure.class);
+        DailyListStructure legacyDailyListObject = XmlParser.unmarshal(document.trim(), DailyListStructure.class);
 
         DailyListJsonObject modernisedDailyList = dailyListRequestMapper.mapToEntity(legacyDailyListObject);
 
         PostDailyListRequest postDailyListRequest = DailyListXmlRequestMapper.mapToPostDailyListRequest(
-                legacyDailyListObject,
-                document,
-                systemType.get().getModernisedSystemType(),
-                addDocument.getMessageId()
+            legacyDailyListObject,
+            document,
+            systemType.get().getModernisedSystemType(),
+            addDocument.getMessageId()
         );
 
         ResponseEntity<PostDailyListResponse> postDailyListResponse = dailyListsClient.dailylistsPost(

--- a/src/main/java/uk/gov/hmcts/darts/event/client/DarNotifyEventClient.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/client/DarNotifyEventClient.java
@@ -3,8 +3,6 @@ package uk.gov.hmcts.darts.event.client;
 import com.service.viq.event.Event;
 import com.viqsoultions.DARNotifyEvent;
 import com.viqsoultions.DARNotifyEventResponse;
-import jakarta.xml.bind.JAXBContext;
-import jakarta.xml.bind.Unmarshaller;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.Header;
@@ -23,19 +21,14 @@ import uk.gov.hmcts.darts.event.enums.DarNotifyEventResult;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.utilities.XmlParser;
 
-import java.io.StringWriter;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import javax.annotation.PostConstruct;
-import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Source;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
 
 import static java.lang.Integer.parseInt;
 import static org.slf4j.event.Level.ERROR;

--- a/src/main/java/uk/gov/hmcts/darts/event/client/DarNotifyEventClient.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/client/DarNotifyEventClient.java
@@ -8,7 +8,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.http.Header;
 import org.springframework.stereotype.Component;
 import org.springframework.ws.WebServiceException;
-import org.springframework.ws.client.WebServiceClientException;
 import org.springframework.ws.client.core.WebServiceTemplate;
 import org.springframework.ws.client.support.interceptor.ClientInterceptor;
 import org.springframework.ws.context.MessageContext;
@@ -112,22 +111,22 @@ public class DarNotifyEventClient {
     static class DarPcTimeLogInterceptor implements ClientInterceptor {
 
         @Override
-        public boolean handleRequest(MessageContext messageContext) throws WebServiceClientException {
+        public boolean handleRequest(MessageContext messageContext) {
             return true;
         }
 
         @Override
-        public boolean handleResponse(MessageContext messageContext) throws WebServiceClientException {
+        public boolean handleResponse(MessageContext messageContext) {
             return true;
         }
 
         @Override
-        public boolean handleFault(MessageContext messageContext) throws WebServiceClientException {
+        public boolean handleFault(MessageContext messageContext) {
             return true;
         }
 
         @Override
-        public void afterCompletion(MessageContext messageContext, Exception ex) throws WebServiceClientException {
+        public void afterCompletion(MessageContext messageContext, Exception ex) {
             try {
                 HttpComponentsConnection connection = (HttpComponentsConnection) TransportContextHolder.getTransportContext().getConnection();
 

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventRoute.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventRoute.java
@@ -22,7 +22,6 @@ public class EventRoute {
     private boolean validateEvent;
     private final XmlValidator xmlValidator;
     private final EventsClient eventsClient;
-    private final XmlParser xmlParser;
     private final EventRequestMapper dartsXmlMapper;
 
     @SuppressWarnings("PMD.UseObjectForClearerAPI")
@@ -31,7 +30,7 @@ public class EventRoute {
             xmlValidator.validate(document, schemaPath);
         }
 
-        DartsEvent dartsEvent = xmlParser.unmarshal(document, DartsEvent.class);
+        DartsEvent dartsEvent = XmlParser.unmarshal(document, DartsEvent.class);
         uk.gov.hmcts.darts.model.event.DartsEvent eventRequest = dartsXmlMapper.toNewApi(dartsEvent, messageId, type, subType);
 
         ResponseEntity<EventsResponse> eventResponse = eventsClient.eventsPost(eventRequest);

--- a/src/main/java/uk/gov/hmcts/darts/noderegistration/RegisterNodeRoute.java
+++ b/src/main/java/uk/gov/hmcts/darts/noderegistration/RegisterNodeRoute.java
@@ -22,7 +22,6 @@ public class RegisterNodeRoute {
     private boolean validateAddCase;
 
     private final XmlValidator xmlValidator;
-    private final XmlParser xmlParser;
 
     private final RegisterNodeClient registerNodeClient;
     private final RegisterNodeMapper registerNodeMapper;
@@ -33,12 +32,12 @@ public class RegisterNodeRoute {
             xmlValidator.validate(caseDocumentXmlStr, addCaseSchemaPath);
         }
 
-        Node registerNodeObj = xmlParser.unmarshal(caseDocumentXmlStr, Node.class);
+        Node registerNodeObj = XmlParser.unmarshal(caseDocumentXmlStr, Node.class);
 
         ResponseEntity<PostNodeRegistrationResponse> registerNodeResponse =
             registerNodeClient.registerDevicesPost(registerNodeObj.getType(), registerNodeObj.getCourthouse(),
-                                                                           registerNodeObj.getCourtroom(), registerNodeObj.getHostname(),
-                                                                           registerNodeObj.getIpAddress(), registerNodeObj.getMacAddress());
+                                                   registerNodeObj.getCourtroom(), registerNodeObj.getHostname(),
+                                                   registerNodeObj.getIpAddress(), registerNodeObj.getMacAddress());
 
         return registerNodeMapper.mapToDfsResponse(registerNodeResponse.getBody());
     }

--- a/src/main/java/uk/gov/hmcts/darts/utilities/XmlParser.java
+++ b/src/main/java/uk/gov/hmcts/darts/utilities/XmlParser.java
@@ -7,11 +7,12 @@ import uk.gov.hmcts.darts.common.exceptions.DartsException;
 import uk.gov.hmcts.darts.ws.CodeAndMessage;
 
 import java.io.StringReader;
+import javax.xml.transform.Source;
 
 @Service
 public class XmlParser {
 
-    public <T> T unmarshal(String xml, Class<T> clazz) {
+    public static <T> T unmarshal(String xml, Class<T> clazz) {
         JAXBContext context;
         Object clazzInstance;
         try {
@@ -19,6 +20,21 @@ public class XmlParser {
             clazzInstance = context
                 .createUnmarshaller()
                 .unmarshal(new StringReader(xml));
+        } catch (JAXBException jaxbException) {
+            throw new DartsException(jaxbException, CodeAndMessage.INVALID_XML);
+        }
+
+        return clazz.cast(clazzInstance);
+    }
+
+    public static <T> T unmarshal(Source source, Class<T> clazz) {
+        JAXBContext context;
+        Object clazzInstance;
+        try {
+            context = JAXBContext.newInstance(clazz);
+            clazzInstance = context
+                .createUnmarshaller()
+                .unmarshal(source);
         } catch (JAXBException jaxbException) {
             throw new DartsException(jaxbException, CodeAndMessage.INVALID_XML);
         }

--- a/src/main/java/uk/gov/hmcts/darts/utilities/XmlParser.java
+++ b/src/main/java/uk/gov/hmcts/darts/utilities/XmlParser.java
@@ -2,15 +2,17 @@ package uk.gov.hmcts.darts.utilities;
 
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
-import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.common.exceptions.DartsException;
 import uk.gov.hmcts.darts.ws.CodeAndMessage;
 
 import java.io.StringReader;
 import javax.xml.transform.Source;
 
-@Service
-public class XmlParser {
+public final class XmlParser {
+
+    private XmlParser() {
+
+    }
 
     public static <T> T unmarshal(String xml, Class<T> clazz) {
         JAXBContext context;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -44,6 +44,7 @@ spring:
 
 azure:
 darts-gateway:
+  dar-pc-max-time-draft: 90s
   storage:
     blob:
       client:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -44,7 +44,7 @@ spring:
 
 azure:
 darts-gateway:
-  dar-pc-max-time-draft: 90s
+  dar-pc-max-time-drift: 90s
   storage:
     blob:
       client:

--- a/src/test/java/uk/gov/hmcts/darts/dailylist/mapper/DailyListRequestMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/dailylist/mapper/DailyListRequestMapperTest.java
@@ -27,8 +27,6 @@ import java.time.OffsetDateTime;
 @SuppressWarnings({"PMD.UnitTestShouldIncludeAssert"})
 class DailyListRequestMapperTest {
 
-    final XmlParser xmlParser = new XmlParser();
-
     @Autowired
     DailyListRequestMapper dailyListRequestMapper;
 
@@ -36,7 +34,7 @@ class DailyListRequestMapperTest {
     void test1() throws IOException, JSONException {
         String requestXml = TestUtils.getContentsFromFile(
             "tests/dailylist/DailyListRequestMapperTest/test1/request.xml");
-        DailyListStructure legacyDailyList = xmlParser.unmarshal(requestXml, DailyListStructure.class);
+        DailyListStructure legacyDailyList = XmlParser.unmarshal(requestXml, DailyListStructure.class);
         DailyListJsonObject modernisedDailyList = dailyListRequestMapper.mapToEntity(legacyDailyList);
 
         JavaTimeModule module = new JavaTimeModule();
@@ -46,7 +44,7 @@ class DailyListRequestMapperTest {
             .addDeserializer(LocalDateTime.class, new LocalDateTimeTypeDeserializer())
             .addDeserializer(LocalDate.class, new LocalDateTypeDeserializer())
             .addDeserializer(OffsetDateTime.class, new OffsetDateTimeTypeDeserializer());
-        ObjectMapper mapper =  new ObjectMapper()
+        ObjectMapper mapper = new ObjectMapper()
             .setSerializationInclusion(JsonInclude.Include.NON_NULL)
             .registerModule(module);
 
@@ -61,7 +59,7 @@ class DailyListRequestMapperTest {
     void test2() throws IOException, JSONException {
         String requestXml = TestUtils.getContentsFromFile(
             "tests/dailylist/DailyListRequestMapperTest/test2/request.xml");
-        DailyListStructure legacyDailyList = xmlParser.unmarshal(requestXml, DailyListStructure.class);
+        DailyListStructure legacyDailyList = XmlParser.unmarshal(requestXml, DailyListStructure.class);
         DailyListJsonObject modernisedDailyList = dailyListRequestMapper.mapToEntity(legacyDailyList);
 
         JavaTimeModule module = new JavaTimeModule();
@@ -71,7 +69,7 @@ class DailyListRequestMapperTest {
             .addDeserializer(LocalDateTime.class, new LocalDateTimeTypeDeserializer())
             .addDeserializer(LocalDate.class, new LocalDateTypeDeserializer())
             .addDeserializer(OffsetDateTime.class, new OffsetDateTimeTypeDeserializer());
-        ObjectMapper mapper =  new ObjectMapper()
+        ObjectMapper mapper = new ObjectMapper()
             .setSerializationInclusion(JsonInclude.Include.NON_NULL)
             .registerModule(module);
 

--- a/src/test/java/uk/gov/hmcts/darts/dailylist/mapper/DailyListXmlRequestMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/dailylist/mapper/DailyListXmlRequestMapperTest.java
@@ -13,13 +13,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class DailyListXmlRequestMapperTest {
 
-    private final XmlParser xmlParser = new XmlParser();
-
     @Test
     void testPublishedTimeBstWithTimeZone() throws IOException {
         String requestXml = TestUtils.getContentsFromFile(
             "tests/dailylist/DailyListXmlRequestMapperTest/publishedDateBstWithTimeZone.xml");
-        DailyListStructure dailyList = xmlParser.unmarshal(requestXml, DailyListStructure.class);
+        DailyListStructure dailyList = XmlParser.unmarshal(requestXml, DailyListStructure.class);
         PostDailyListRequest postDailyListRequest = DailyListXmlRequestMapper.mapToPostDailyListRequest(dailyList, requestXml, "XHB", "12345");
 
         OffsetDateTime publishedTime = postDailyListRequest.getPublishedTs();
@@ -30,7 +28,7 @@ class DailyListXmlRequestMapperTest {
     void testPublishedTimeBstWithoutTimeZone() throws IOException {
         String requestXml = TestUtils.getContentsFromFile(
             "tests/dailylist/DailyListXmlRequestMapperTest/publishedDateBstWithoutTimeZone.xml");
-        DailyListStructure dailyList = xmlParser.unmarshal(requestXml, DailyListStructure.class);
+        DailyListStructure dailyList = XmlParser.unmarshal(requestXml, DailyListStructure.class);
         PostDailyListRequest postDailyListRequest = DailyListXmlRequestMapper.mapToPostDailyListRequest(dailyList, requestXml, "XHB", "12345");
 
         OffsetDateTime publishedTime = postDailyListRequest.getPublishedTs();
@@ -41,7 +39,7 @@ class DailyListXmlRequestMapperTest {
     void testPublishedTimeGmtWithTimeZone() throws IOException {
         String requestXml = TestUtils.getContentsFromFile(
             "tests/dailylist/DailyListXmlRequestMapperTest/publishedDateGmtWithTimeZone.xml");
-        DailyListStructure dailyList = xmlParser.unmarshal(requestXml, DailyListStructure.class);
+        DailyListStructure dailyList = XmlParser.unmarshal(requestXml, DailyListStructure.class);
         PostDailyListRequest postDailyListRequest = DailyListXmlRequestMapper.mapToPostDailyListRequest(dailyList, requestXml, "XHB", "12345");
 
         OffsetDateTime publishedTime = postDailyListRequest.getPublishedTs();
@@ -52,7 +50,7 @@ class DailyListXmlRequestMapperTest {
     void testPublishedTimeGmtWithoutTimeZone() throws IOException {
         String requestXml = TestUtils.getContentsFromFile(
             "tests/dailylist/DailyListXmlRequestMapperTest/publishedDateGmtWithoutTimeZone.xml");
-        DailyListStructure dailyList = xmlParser.unmarshal(requestXml, DailyListStructure.class);
+        DailyListStructure dailyList = XmlParser.unmarshal(requestXml, DailyListStructure.class);
         PostDailyListRequest postDailyListRequest = DailyListXmlRequestMapper.mapToPostDailyListRequest(dailyList, requestXml, "XHB", "12345");
 
         OffsetDateTime publishedTime = postDailyListRequest.getPublishedTs();

--- a/src/test/java/uk/gov/hmcts/darts/document/XmlParserTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/document/XmlParserTest.java
@@ -44,11 +44,9 @@ class XmlParserTest {
             <be:EventText>test</be:EventText>
         </be:xxx>""";
 
-    final XmlParser xmlParser = new XmlParser();
-
     @Test
     void unmarshalEvent() {
-        DartsEvent dartsEvent = xmlParser.unmarshal(eventXML, DartsEvent.class);
+        DartsEvent dartsEvent = XmlParser.unmarshal(eventXML, DartsEvent.class);
 
         assertThat(dartsEvent.getID()).isEqualTo(0);
         assertThat(dartsEvent.getY()).isEqualTo(2019);
@@ -64,7 +62,7 @@ class XmlParserTest {
 
     @Test
     void throwsWhenXmlNotParsable() {
-        assertThatThrownBy(() -> xmlParser.unmarshal(notParsableXML, DartsEvent.class))
+        assertThatThrownBy(() -> XmlParser.unmarshal(notParsableXML, DartsEvent.class))
             .isInstanceOf(DartsException.class);
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/event/client/DarNotifyEventClientTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/event/client/DarNotifyEventClientTest.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.darts.event.model.DarNotifyEvent;
 import uk.gov.hmcts.darts.log.api.impl.LogApiImpl;
 import uk.gov.hmcts.darts.log.service.impl.DarNotificationLoggerServiceImpl;
 
+import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.List;
@@ -67,7 +68,8 @@ class DarNotifyEventClientTest {
         darNotifyEventClient = new DarNotifyEventClient(
             "http://www.viqsoultions.com/DARNotifyEvent",
             mockWebServiceTemplate,
-            logApi);
+            logApi,
+            new DarNotifyEventClient.DarPcTimeLogInterceptor(Clock.systemDefaultZone()));
     }
 
     @Test


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4031)


### Change description ###
When darts-gateway sends a DarNotify request to the DAR Pc, the message will be ignored by the DAr PC if the timestamp is more than 2 minutes out.
This should be fine, but the clocks on the DAR Pc's can drift, and may drift outwith of the 2 minute window. 
When we sent a request to the DAR Pc, the response headers includes the time that the DAR PC thinks it is, so we should be able to read this and log if the time is more than 2 minutes out, and therefore we think the DAR PC may have dropped the message.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
