### PR TITLE
DMP-4574: Darts gateway: Remove addAudio request payload validation

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/config/DartsPayloadValidatingInterceptor.java
+++ b/src/main/java/uk/gov/hmcts/darts/config/DartsPayloadValidatingInterceptor.java
@@ -1,0 +1,85 @@
+package uk.gov.hmcts.darts.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Component;
+import org.springframework.ws.context.MessageContext;
+import org.springframework.ws.soap.server.endpoint.interceptor.PayloadValidatingInterceptor;
+import org.springframework.xml.validation.XmlValidator;
+import org.springframework.xml.validation.XmlValidatorFactory;
+import org.springframework.xml.xsd.XsdSchema;
+import org.springframework.xml.xsd.XsdSchemaCollection;
+import org.xml.sax.SAXException;
+import uk.gov.hmcts.darts.metadata.EndpointMetaData;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.PostConstruct;
+import javax.xml.transform.TransformerException;
+
+@Component
+@RequiredArgsConstructor
+public class DartsPayloadValidatingInterceptor extends PayloadValidatingInterceptor {
+
+    @Value("${darts-gateway.ws.request-validation}")
+    private boolean requestValidation;
+
+    @Value("${darts-gateway.ws.response-validation}")
+    private boolean responseValidation;
+
+    @Value("${darts-gateway.addcase.validate}")
+    private boolean validateAddCase;
+
+    private final List<EndpointMetaData> endpointMetaDataList;
+
+    @PostConstruct
+    void postConstruct() {
+        this.setValidateRequest(requestValidation);
+        this.setValidateResponse(responseValidation);
+
+
+        XsdSchemaCollection schemaCollection = new XsdSchemaCollection() {
+            @Override
+            public XsdSchema[] getXsdSchemas() {
+                List<XsdSchema> schemas = new ArrayList<>();
+
+                for (EndpointMetaData metaData : endpointMetaDataList) {
+                    schemas.addAll(Arrays.asList(metaData.getSchemas()));
+                }
+
+                return schemas.toArray(new XsdSchema[0]);
+            }
+
+            @SneakyThrows
+            @Override
+            public XmlValidator createValidator() {
+                return XmlValidatorFactory.createValidator(getXmlSchemas(), "http://www.w3.org/2001/XMLSchema");
+
+            }
+        };
+        this.setXsdSchemaCollection(schemaCollection);
+    }
+
+    public Resource[] getXmlSchemas() {
+        List<Resource> schemaResources = new ArrayList<>();
+        for (EndpointMetaData metaData : endpointMetaDataList) {
+            schemaResources.addAll(Arrays.asList(metaData.getResources()));
+        }
+
+        return schemaResources.toArray(new Resource[0]);
+    }
+
+    @Override
+    public boolean handleRequest(MessageContext messageContext, Object endpoint)
+        throws IOException, SAXException, TransformerException {
+        String request = messageContext.getRequest().toString();
+        if (request.endsWith("addAudio") && !validateAddCase) {
+            return true;
+        }
+        return super.handleRequest(messageContext, endpoint);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/config/ServiceConfig.java
+++ b/src/main/java/uk/gov/hmcts/darts/config/ServiceConfig.java
@@ -30,6 +30,9 @@ import uk.gov.hmcts.darts.common.client.mapper.APIProblemResponseMapper;
 import uk.gov.hmcts.darts.common.client.mapper.CommonApiProblemResponseMapper;
 import uk.gov.hmcts.darts.common.client.mapper.DailyListAPIProblemResponseMapper;
 import uk.gov.hmcts.darts.common.client.mapper.EventAPIProblemResponseMapper;
+import uk.gov.hmcts.darts.metadata.ContextRegistryEndpointMetaData;
+import uk.gov.hmcts.darts.metadata.DartsEndpointMetaData;
+import uk.gov.hmcts.darts.metadata.EndpointMetaData;
 import uk.gov.hmcts.darts.utilities.deserializer.LocalDateTimeTypeDeserializer;
 import uk.gov.hmcts.darts.utilities.deserializer.LocalDateTypeDeserializer;
 import uk.gov.hmcts.darts.utilities.deserializer.OffsetDateTimeTypeDeserializer;
@@ -41,6 +44,7 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -135,5 +139,13 @@ public class ServiceConfig {
     @Bean
     public RestTemplate getTemplate() {
         return new RestTemplate();
+    }
+
+    @Bean
+    List<EndpointMetaData> getEndpointMetaData() {
+        List<EndpointMetaData> endpointMetaData = new ArrayList<>();
+        endpointMetaData.add(new DartsEndpointMetaData(SoapWebServiceConfig.BASE_WEB_CONTEXT));
+        endpointMetaData.add(new ContextRegistryEndpointMetaData(SoapWebServiceConfig.BASE_WEB_CONTEXT));
+        return endpointMetaData;
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/config/SoapWebServiceConfig.java
+++ b/src/main/java/uk/gov/hmcts/darts/config/SoapWebServiceConfig.java
@@ -1,32 +1,20 @@
 package uk.gov.hmcts.darts.config;
 
 import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.Resource;
 import org.springframework.ws.config.annotation.EnableWs;
 import org.springframework.ws.config.annotation.WsConfigurerAdapter;
 import org.springframework.ws.server.EndpointInterceptor;
-import org.springframework.ws.soap.server.endpoint.interceptor.PayloadValidatingInterceptor;
 import org.springframework.ws.transport.http.MessageDispatcherServlet;
 import org.springframework.ws.wsdl.wsdl11.Wsdl11Definition;
-import org.springframework.xml.validation.XmlValidator;
-import org.springframework.xml.validation.XmlValidatorFactory;
-import org.springframework.xml.xsd.XsdSchema;
-import org.springframework.xml.xsd.XsdSchemaCollection;
 import uk.gov.hmcts.darts.authentication.component.SoapRequestInterceptor;
 import uk.gov.hmcts.darts.common.multipart.JavaMailXmlWithFileMultiPartRequestFactory;
-import uk.gov.hmcts.darts.metadata.ContextRegistryEndpointMetaData;
-import uk.gov.hmcts.darts.metadata.DartsEndpointMetaData;
 import uk.gov.hmcts.darts.metadata.EndpointMetaData;
 import uk.gov.hmcts.darts.ws.DartsMessageDispatcherServlet;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -35,53 +23,18 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class SoapWebServiceConfig extends WsConfigurerAdapter {
 
-    @Value("${darts-gateway.ws.request-validation}")
-    private boolean requestValidation;
 
-    @Value("${darts-gateway.ws.response-validation}")
-    private boolean responseValidation;
 
     public static final String BASE_WEB_CONTEXT = "/service/darts/";
 
     private final SoapRequestInterceptor soapRequestInterceptor;
 
+    private final DartsPayloadValidatingInterceptor validatingInterceptor;
+
     @Override
     public void addInterceptors(List<EndpointInterceptor> interceptors) {
         interceptors.add(soapRequestInterceptor);
-
-        var validatingInterceptor = new PayloadValidatingInterceptor();
-        validatingInterceptor.setValidateRequest(requestValidation);
-        validatingInterceptor.setValidateResponse(responseValidation);
-        XsdSchemaCollection schemaCollection = new XsdSchemaCollection() {
-            @Override
-            public XsdSchema[] getXsdSchemas() {
-                List<XsdSchema> schemas = new ArrayList<>();
-
-                for (EndpointMetaData metaData : getEndpointMetaData()) {
-                    schemas.addAll(Arrays.asList(metaData.getSchemas()));
-                }
-
-                return schemas.toArray(new XsdSchema[0]);
-            }
-
-            @SneakyThrows
-            @Override
-            public XmlValidator createValidator() {
-                return XmlValidatorFactory.createValidator(getSchemas(), "http://www.w3.org/2001/XMLSchema");
-
-            }
-        };
-        validatingInterceptor.setXsdSchemaCollection(schemaCollection);
         interceptors.add(validatingInterceptor);
-    }
-
-    public Resource[] getSchemas() {
-        List<Resource> schemaResources = new ArrayList<>();
-        for (EndpointMetaData metaData : getEndpointMetaData()) {
-            schemaResources.addAll(Arrays.asList(metaData.getResources()));
-        }
-
-        return schemaResources.toArray(new Resource[0]);
     }
 
     @Bean
@@ -95,13 +48,5 @@ public class SoapWebServiceConfig extends WsConfigurerAdapter {
     @Bean
     public List<Wsdl11Definition> dartsWsdl11Definition(List<EndpointMetaData> metaData) {
         return metaData.stream().map(EndpointMetaData::getWsdlDefinition).collect(Collectors.toList());
-    }
-
-    @Bean
-    List<EndpointMetaData> getEndpointMetaData() {
-        List<EndpointMetaData> endpointMetaData = new ArrayList<>();
-        endpointMetaData.add(new DartsEndpointMetaData(BASE_WEB_CONTEXT));
-        endpointMetaData.add(new ContextRegistryEndpointMetaData(BASE_WEB_CONTEXT));
-        return endpointMetaData;
     }
 }


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4574)


### Change description ###
# Summary of Git Diff

This diff introduces a new class `DartsPayloadValidatingInterceptor`, which extends the existing `PayloadValidatingInterceptor` from Spring. It integrates request and response validation for SOAP messages, allowing for more granular control over the validation process based on configuration properties. Additionally, it modifies the `ServiceConfig` and `SoapWebServiceConfig` classes to integrate this new interceptor into the application's configuration.

## Highlights

- **New Class Added**: 
  - `DartsPayloadValidatingInterceptor` was introduced to handle payload validation for SOAP requests and responses.
  

- **Adjustments in SoapWebServiceConfig**:
  - The configuration now injects the new `DartsPayloadValidatingInterceptor` instead of creating its own validation logic, simplifying the interceptor registration process.

- **Conditionally Skips Validation**:
  - The `handleRequest` method in `DartsPayloadValidatingInterceptor` allows requests to bypass validation based on specific conditions (e.g., if the request ends with "addAudio" and validation is disabled).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
