### PR TITLE
DMP-4673: Audio failed to link to case log entry for Dynatrace

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/addaudio/AddAudioRoute.java
+++ b/src/main/java/uk/gov/hmcts/darts/addaudio/AddAudioRoute.java
@@ -88,7 +88,7 @@ public class AddAudioRoute {
                             metaData.getChecksum(),
                             null
                         );
-                        throw new DartsException(CodeAndMessage.ERROR);
+                        throw new DartsException(e, CodeAndMessage.ERROR);
                     }
                     log.info("Audio file uploaded successfully to the inbound blob store. BlobStoreUuid: {}", blobStoreUuid);
                     audiosClient.addAudioMetaData(DataUtil.convertToStorageGuid(metaData, blobStoreUuid));

--- a/src/main/java/uk/gov/hmcts/darts/addaudio/AddAudioRoute.java
+++ b/src/main/java/uk/gov/hmcts/darts/addaudio/AddAudioRoute.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.darts.common.multipart.XmlWithFileMultiPartRequest;
 import uk.gov.hmcts.darts.common.multipart.XmlWithFileMultiPartRequestHolder;
 import uk.gov.hmcts.darts.datastore.DataManagementConfiguration;
 import uk.gov.hmcts.darts.datastore.DataManagementService;
+import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.model.audio.AddAudioMetadataRequest;
 import uk.gov.hmcts.darts.utilities.DataUtil;
 import uk.gov.hmcts.darts.utilities.FileContentChecksum;
@@ -37,6 +38,7 @@ public class AddAudioRoute {
     private final AddAudioFileValidator multipartFileValidator;
     private final DataManagementService dataManagementService;
     private final DataManagementConfiguration dataManagementConfiguration;
+    private final LogApi logApi;
 
     public DARTSResponse route(AddAudio addAudio) {
 
@@ -69,11 +71,25 @@ public class AddAudioRoute {
                     metaData.setFileSize(request.get().getBinarySize());
                     metaData.setChecksum(checksum.get());
                     multipartFileValidator.validate(multipartFile);
-
-                    UUID blobStoreUuid = dataManagementService.saveBlobData(
-                        dataManagementConfiguration.getInboundContainerName(),
-                        multipartFile.getInputStream(),
-                        DataUtil.toMap(metaData));
+                    UUID blobStoreUuid;
+                    try {
+                        blobStoreUuid = dataManagementService.saveBlobData(
+                            dataManagementConfiguration.getInboundContainerName(),
+                            multipartFile.getInputStream(),
+                            DataUtil.toMap(metaData));
+                    } catch (Exception e) {
+                        log.error("Failed to upload audio file to the inbound blob store", e);
+                        logApi.failedToLinkAudioToCases(
+                            metaData.getCourthouse(),
+                            metaData.getCourtroom(),
+                            metaData.getStartedAt(),
+                            metaData.getEndedAt(),
+                            metaData.getCases(),
+                            metaData.getChecksum(),
+                            null
+                        );
+                        throw new DartsException(CodeAndMessage.ERROR);
+                    }
                     log.info("Audio file uploaded successfully to the inbound blob store. BlobStoreUuid: {}", blobStoreUuid);
                     audiosClient.addAudioMetaData(DataUtil.convertToStorageGuid(metaData, blobStoreUuid));
                 });

--- a/src/main/java/uk/gov/hmcts/darts/config/DartsPayloadValidatingInterceptor.java
+++ b/src/main/java/uk/gov/hmcts/darts/config/DartsPayloadValidatingInterceptor.java
@@ -77,9 +77,6 @@ public class DartsPayloadValidatingInterceptor extends PayloadValidatingIntercep
     public boolean handleRequest(MessageContext messageContext, Object endpoint)
         throws IOException, SAXException, TransformerException {
         String request = messageContext.getRequest().toString();
-        if (request.endsWith("addAudio") && !validateAddCase) {
-            return true;
-        }
-        return super.handleRequest(messageContext, endpoint);
+        return (request.endsWith("addAudio") && !validateAddCase) || super.handleRequest(messageContext, endpoint);
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/log/api/LogApi.java
+++ b/src/main/java/uk/gov/hmcts/darts/log/api/LogApi.java
@@ -1,8 +1,5 @@
 package uk.gov.hmcts.darts.log.api;
 
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import org.slf4j.event.Level;
 
 import java.time.OffsetDateTime;

--- a/src/main/java/uk/gov/hmcts/darts/log/api/LogApi.java
+++ b/src/main/java/uk/gov/hmcts/darts/log/api/LogApi.java
@@ -1,38 +1,46 @@
 package uk.gov.hmcts.darts.log.api;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import org.slf4j.event.Level;
 
 import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
 
 @SuppressWarnings("PMD.UseObjectForClearerAPI")
 public interface LogApi {
 
     void notificationSucceeded(
-            String uri,
-            String courthouse,
-            String courtroom,
-            String caseNumber,
-            OffsetDateTime offsetDateTime,
-            int responseCode);
+        String uri,
+        String courthouse,
+        String courtroom,
+        String caseNumber,
+        OffsetDateTime offsetDateTime,
+        int responseCode);
 
     void notificationFailed(
-            String uri,
-            String courthouse,
-            String courtroom,
-            String caseNumber,
-            OffsetDateTime offsetDateTime,
-            String status,
-            String message,
-            Level logLevel);
+        String uri,
+        String courthouse,
+        String courtroom,
+        String caseNumber,
+        OffsetDateTime offsetDateTime,
+        String status,
+        String message,
+        Level logLevel);
 
     void notificationFailedWithCode(
-            String uri,
-            String courthouse,
-            String courtroom,
-            String caseNumber,
-            OffsetDateTime offsetDateTime,
-            String status,
-            String message,
-            int code,
-            Level logLevel);
+        String uri,
+        String courthouse,
+        String courtroom,
+        String caseNumber,
+        OffsetDateTime offsetDateTime,
+        String status,
+        String message,
+        int code,
+        Level logLevel);
+
+    void failedToLinkAudioToCases(String courthouse, String courtroom, OffsetDateTime startedAt, OffsetDateTime endedAt, List<String> cases,
+                                  String checksum, UUID storageBlobId);
 }

--- a/src/main/java/uk/gov/hmcts/darts/log/api/impl/LogApiImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/log/api/impl/LogApiImpl.java
@@ -1,58 +1,76 @@
 package uk.gov.hmcts.darts.log.api.impl;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.event.Level;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.log.service.DarNotificationLoggerService;
 
 import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 @SuppressWarnings("PMD.UseObjectForClearerAPI")
+@Slf4j
 public class LogApiImpl implements LogApi {
 
     private final DarNotificationLoggerService darNotificationLogger;
 
     @Override
     public void notificationSucceeded(
-            String uri,
-            String courthouse,
-            String courtroom,
-            String caseNumber,
-            OffsetDateTime offsetDateTime,
-            int responseCode) {
+        String uri,
+        String courthouse,
+        String courtroom,
+        String caseNumber,
+        OffsetDateTime offsetDateTime,
+        int responseCode) {
 
         darNotificationLogger.notificationSucceeded(uri, courthouse, courtroom, caseNumber, offsetDateTime, responseCode);
     }
 
     @Override
     public void notificationFailed(
-            String uri,
-            String courthouse,
-            String courtroom,
-            String caseNumber,
-            OffsetDateTime offsetDateTime,
-            String status,
-            String message,
-            Level logLevel) {
+        String uri,
+        String courthouse,
+        String courtroom,
+        String caseNumber,
+        OffsetDateTime offsetDateTime,
+        String status,
+        String message,
+        Level logLevel) {
 
         darNotificationLogger.notificationFailed(uri, courthouse, courtroom, caseNumber, offsetDateTime, status, message, logLevel);
     }
 
     @Override
     public void notificationFailedWithCode(
-            String uri,
-            String courthouse,
-            String courtroom,
-            String caseNumber,
-            OffsetDateTime offsetDateTime,
-            String status,
-            String message,
-            int responseCode,
-            Level logLevel) {
+        String uri,
+        String courthouse,
+        String courtroom,
+        String caseNumber,
+        OffsetDateTime offsetDateTime,
+        String status,
+        String message,
+        int responseCode,
+        Level logLevel) {
 
         darNotificationLogger.notificationFailedWithCode(uri, courthouse, courtroom, caseNumber, offsetDateTime, status, message, responseCode, logLevel);
+    }
+
+    @Override
+    public void failedToLinkAudioToCases(String courthouse, String courtroom, OffsetDateTime startedAt, OffsetDateTime endedAt, List<String> cases,
+                                         String checksum, UUID storageBlobId) {
+        log.error("Failed to link audio to cases: courthouse={}, courtroom={}, startedAt={}, endedAt={}, cases={}, checksum={}, blob_store_id={}",
+                  courthouse,
+                  courtroom,
+                  startedAt.format(DateTimeFormatter.ISO_DATE_TIME),
+                  endedAt.format(DateTimeFormatter.ISO_DATE_TIME),
+                  cases,
+                  checksum,
+                  storageBlobId);
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/addaudio/AddAudioRouteTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/addaudio/AddAudioRouteTest.java
@@ -1,0 +1,118 @@
+package uk.gov.hmcts.darts.addaudio;
+
+import com.service.mojdarts.synapps.com.AddAudio;
+import com.service.mojdarts.synapps.com.addaudio.Audio;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.darts.addaudio.validator.AddAudioFileValidator;
+import uk.gov.hmcts.darts.addaudio.validator.AddAudioValidator;
+import uk.gov.hmcts.darts.api.audio.AudiosApi;
+import uk.gov.hmcts.darts.common.function.ConsumerWithIoException;
+import uk.gov.hmcts.darts.common.multipart.SizeableInputSource;
+import uk.gov.hmcts.darts.common.multipart.XmlWithFileMultiPartRequest;
+import uk.gov.hmcts.darts.common.multipart.XmlWithFileMultiPartRequestHolder;
+import uk.gov.hmcts.darts.datastore.DataManagementConfiguration;
+import uk.gov.hmcts.darts.datastore.DataManagementService;
+import uk.gov.hmcts.darts.log.api.LogApi;
+import uk.gov.hmcts.darts.model.audio.AddAudioMetadataRequest;
+import uk.gov.hmcts.darts.utilities.XmlParser;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AddAudioRouteTest {
+
+    @Mock
+    private AudiosApi audiosClient;
+    @Mock
+    private AddAudioMapper addAudioMapper;
+    @Mock
+    private XmlWithFileMultiPartRequestHolder multiPartRequestHolder;
+    @Mock
+    private AddAudioValidator addAudioValidator;
+    @Mock
+    private AddAudioFileValidator multipartFileValidator;
+    @Mock
+    private DataManagementService dataManagementService;
+    @Mock
+    private DataManagementConfiguration dataManagementConfiguration;
+    @Mock
+    private LogApi logApi;
+
+    @InjectMocks
+    private AddAudioRoute addAudioRoute;
+
+
+    @Test
+    void route_onBlobStoreUploadFailure_shouldLogError() throws Exception {
+        XmlWithFileMultiPartRequest request = mock(XmlWithFileMultiPartRequest.class);
+        when(multiPartRequestHolder.getRequest()).thenReturn(Optional.of(request));
+        AtomicBoolean firstCall = new AtomicBoolean(false);
+
+        when(request.consumeFileBinaryStream(any())).thenAnswer(invocation -> {
+            if (firstCall.get()) {
+                ConsumerWithIoException<SizeableInputSource> consumer = invocation.getArgument(0);
+                consumer.accept(mock(SizeableInputSource.class));
+            } else {
+                firstCall.set(true);
+            }
+            return true;
+        });
+        AddAudioMetadataRequest addAudioMetadataRequest = mock(AddAudioMetadataRequest.class);
+
+        OffsetDateTime startAt = OffsetDateTime.parse("2025-01-29T10:44:25.028498Z");
+        OffsetDateTime endAt = OffsetDateTime.parse("2025-01-31T10:44:25.028526Z");
+
+        when(addAudioMetadataRequest.getCourthouse()).thenReturn("courtHouse");
+        when(addAudioMetadataRequest.getCourtroom()).thenReturn("courtroom");
+        when(addAudioMetadataRequest.getStartedAt()).thenReturn(startAt);
+        when(addAudioMetadataRequest.getEndedAt()).thenReturn(endAt);
+        when(addAudioMetadataRequest.getCases()).thenReturn(List.of("case1", "case2"));
+        when(addAudioMetadataRequest.getChecksum()).thenReturn("checksum");
+
+        when(addAudioMapper.mapToDartsApi(any())).thenReturn(addAudioMetadataRequest);
+
+        RuntimeException exception = new RuntimeException("Some exception");
+        when(dataManagementService.saveBlobData(any(), any(), any()))
+            .thenThrow(exception);
+
+        AddAudio addAudio = mock(AddAudio.class);
+
+        when(addAudio.getDocument()).thenReturn("");
+
+        try (MockedStatic<XmlParser> xmlParserMockedStatic = mockStatic(XmlParser.class)) {
+
+            xmlParserMockedStatic.when(() -> XmlParser.unmarshal(anyString(), any()))
+                .thenReturn(mock(Audio.class));
+
+            assertThrows(RuntimeException.class,
+                         () -> addAudioRoute.route(addAudio));
+        }
+
+        verify(logApi)
+            .failedToLinkAudioToCases(
+                "courtHouse",
+                "courtroom",
+                startAt,
+                endAt,
+                List.of("case1", "case2"),
+                "checksum",
+                null
+            );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/darts/common/client/AudiosClientTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/client/AudiosClientTest.java
@@ -65,6 +65,7 @@ class AudiosClientTest {
     }
 
 
+    @SuppressWarnings("PMD.TestClassWithoutTestCases")//False positive
     public static class TestHttpStatusCodeException extends HttpStatusCodeException {
         protected TestHttpStatusCodeException() {
             super(HttpStatus.BAD_REQUEST);

--- a/src/test/java/uk/gov/hmcts/darts/common/client/AudiosClientTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/client/AudiosClientTest.java
@@ -1,0 +1,73 @@
+package uk.gov.hmcts.darts.common.client;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpStatusCodeException;
+import uk.gov.hmcts.darts.common.client.exeption.DartsClientProblemDecoder;
+import uk.gov.hmcts.darts.log.api.LogApi;
+import uk.gov.hmcts.darts.model.audio.AddAudioMetadataRequestWithStorageGUID;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AudiosClientTest {
+
+    @Mock
+    private LogApi logApi;
+    @Mock
+    private DartsClientProblemDecoder dartsClientProblemDecoder;
+
+    @InjectMocks
+    @Spy
+    private AudiosClient audiosClient;
+
+    @Test
+    void addAudioMetaData_shouldLogFailedToLinkAudioToCasesMessage_onAnyFailure() {
+        doThrow(new TestHttpStatusCodeException()).when(audiosClient)
+            .processHttpHeaderInterceptors(any());
+        OffsetDateTime startAt = OffsetDateTime.now();
+        OffsetDateTime endAt = OffsetDateTime.now().plusDays(2);
+        UUID storageUuid = UUID.randomUUID();
+
+        AddAudioMetadataRequestWithStorageGUID request = new AddAudioMetadataRequestWithStorageGUID();
+        request.setCourthouse("courtHouse");
+        request.setCourtroom("courtroom");
+        request.setStartedAt(startAt);
+        request.setEndedAt(endAt);
+        request.setCases(List.of("case1", "case2"));
+        request.setChecksum("checksum");
+        request.setStorageGuid(storageUuid);
+
+        assertThrows(Exception.class, () -> audiosClient.addAudioMetaData(request));
+
+        verify(logApi)
+            .failedToLinkAudioToCases(
+                "courtHouse",
+                "courtroom",
+                startAt,
+                endAt,
+                List.of("case1", "case2"),
+                "checksum",
+                storageUuid
+            );
+    }
+
+
+    public static class TestHttpStatusCodeException extends HttpStatusCodeException {
+        protected TestHttpStatusCodeException() {
+            super(HttpStatus.BAD_REQUEST);
+        }
+    }
+}

--- a/src/test/java/uk/gov/hmcts/darts/log/service/impl/LogApiImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/log/service/impl/LogApiImplTest.java
@@ -1,0 +1,64 @@
+package uk.gov.hmcts.darts.log.service.impl;
+
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import uk.gov.hmcts.darts.log.api.LogApi;
+import uk.gov.hmcts.darts.log.api.impl.LogApiImpl;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+@ExtendWith(OutputCaptureExtension.class)
+class LogApiImplTest {
+
+
+    @Test
+    void failedToLinkAudioToCases_shouldLogFailedToLinkAudioToCasesMessage(CapturedOutput output) {
+
+        LogApi logApi = new LogApiImpl(null);
+        OffsetDateTime startAt = OffsetDateTime.parse("2025-01-29T10:44:25.028498Z");
+        OffsetDateTime endAt = OffsetDateTime.parse("2025-01-31T10:44:25.028526Z");
+        UUID storageUuid = UUID.fromString("2250b3a7-933f-4358-a770-5f5ebf3c17b9");
+
+        logApi.failedToLinkAudioToCases(
+            "courtHouse",
+            "courtroom",
+            startAt,
+            endAt,
+            List.of("case1", "case2"),
+            "checksum",
+            storageUuid
+        );
+
+        waitUntilMessage(output,
+                         "Failed to link audio to cases: " +
+                             "courthouse=courtHouse, " +
+                             "courtroom=courtroom, " +
+                             "startedAt=2025-01-29T10:44:25.028498Z, " +
+                             "endedAt=2025-01-31T10:44:25.028526Z, " +
+                             "cases=[case1, case2], " +
+                             "checksum=checksum, " +
+                             "blob_store_id=2250b3a7-933f-4358-a770-5f5ebf3c17b9",
+                         5);
+    }
+
+    @SneakyThrows
+    @SuppressWarnings("PMD.DoNotUseThreads")//Required to prevent busy waiting
+    //Used to allow logs to catch up with the test
+    public static void waitUntilMessage(CapturedOutput capturedOutput, String message,
+                                        int timeoutInSeconds) {
+        long startTime = System.currentTimeMillis();
+        while (!capturedOutput.getAll().contains(message)) {
+            if (System.currentTimeMillis() - startTime > timeoutInSeconds * 1000) {
+                fail("Timeout waiting for message: " + message);
+            }
+            Thread.sleep(100);
+        }
+    }
+}


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4673)


### Change description ###
The requirement is as follows, originally specified in APM-2603
{quote}Audio fails to link to a case - uploading audio and linking to a case is a 2 part process in modernised DARTS. Step 1 is when the audio file and metadata is uploaded directly to Azure blob store from DARTS Proxy or Gateway. Step 2 is when the DARTS API attempts to link the metadata from the audio to the correct case. There are several edge case scenarios that could result in failure of the second part of this process e.g. the call to retrieve the metadata from blob store could fail. For a more detailed investigation of this please refer to [https://tools.hmcts.net/confluence/display/DMP/Add+audio+metadata+failures]. In summary, if audio metadata fails to link to a case, the AMS team would need to investigate this as a priority. It would be beneficial to have these issues shown in Dynatrace.
{quote}
To facilitate this Dynatrace tile we need to implement a new log entry with the following message.

{{Audio failed to link to cases: courthouse={}, courtroom={}, started_at={}, ended_at={}, cases={} checksum={}, blob_store_id=}}

*Technical*

This should be checked within the DARTS gateway codebase and the log entry should be created if the DARTS Gateway receives any response other than HTTP 200 from the POST /audios/metadata request, as this would indicate that the audio was not able to be linked to any cases. This includes HTTP 404 and 50X.

Ensure an error log entry is also created so that the cause can be identified when looking through the logs when investigating.

Ensure sufficient testing is added in order to protect against the log entry being changed accidentally.

The blob store id part of the log message will only be populated if the file was successfully uploaded to the blob store, else set to null. 
h3. Acceptance criteria

Note, some of these ACs will need developer intervention to test.

*AC1 - DARTS API down*

GIVEN DARTS is sent an audio file
AND the DARTS API is not running
WHEN it is processed
THEN a log entry is created to identify an issue adding the audio to cases
AND the audio is not linked to any cases/hearings

*AC2 - Failed to save audio file to Azure blob store*

GIVEN DARTS is sent an audio file
WHEN the file is not able to be saved to the inbound blob store 
THEN a log entry is created to identify an issue adding the audio to cases
AND the audio is not linked to any cases/hearings
**

*AC3 - Courthouse not found*

GIVEN DARTS is sent an audio file
AND the courthouse does not exist in DARTS
WHEN it is processed
THEN a log entry is created to identify an issue adding the audio to cases
AND the audio is not linked to any cases/hearings

*AC4 - File size exceeds max allowed (350MB)*

GIVEN DARTS is sent an audio file
AND the file size is greater than the allowed file size (set to 350MB currently)
WHEN it is processed
THEN a log entry is created to identify an issue adding the audio to cases
AND the audio is not linked to any cases/hearings

*AC5 - Mismatching checksum*

GIVEN DARTS is sent an audio file
WHEN it is processed
AND the checksum calculated initially does not match the one stored on the blob store
THEN a log entry is created to identify an issue adding the audio to cases
AND the audio is not linked to any cases/hearings 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
