### PR TITLE
DMP-4689: Delete from Blob Store on addAudio failure from Gateway

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/addaudio/AddAudioRoute.java
+++ b/src/main/java/uk/gov/hmcts/darts/addaudio/AddAudioRoute.java
@@ -44,6 +44,7 @@ public class AddAudioRoute {
     @Value("${temp.force-checksum-failure:false}")
     private boolean tempForceChecksumFailure;
 
+    @SuppressWarnings("PMD.ExceptionAsFlowControl")//Try/Catch used to clean up resources in case of any failure
     public DARTSResponse route(AddAudio addAudio) {
 
         addAudioValidator.validate(addAudio);

--- a/src/main/java/uk/gov/hmcts/darts/addaudio/AddAudioRoute.java
+++ b/src/main/java/uk/gov/hmcts/darts/addaudio/AddAudioRoute.java
@@ -51,6 +51,7 @@ public class AddAudioRoute {
         String audioXml = addAudio.getDocument();
 
         Audio addAudioLegacy;
+        AtomicReference<UUID> blobStoreUuid = new AtomicReference<>();
 
         try {
             addAudioLegacy = XmlParser.unmarshal(audioXml, Audio.class);
@@ -75,12 +76,11 @@ public class AddAudioRoute {
                     metaData.setFileSize(request.get().getBinarySize());
                     metaData.setChecksum(checksum.get());
                     multipartFileValidator.validate(multipartFile);
-                    UUID blobStoreUuid;
                     try {
-                        blobStoreUuid = dataManagementService.saveBlobData(
+                        blobStoreUuid.set(dataManagementService.saveBlobData(
                             dataManagementConfiguration.getInboundContainerName(),
                             multipartFile.getInputStream(),
-                            DataUtil.toMap(metaData));
+                            DataUtil.toMap(metaData)));
                     } catch (Exception e) {
                         log.error("Failed to upload audio file to the inbound blob store", e);
                         logApi.failedToLinkAudioToCases(
@@ -98,7 +98,7 @@ public class AddAudioRoute {
                     if (tempForceChecksumFailure) {
                         metaData.setChecksum(metaData.getChecksum() + "1");
                     }
-                    audiosClient.addAudioMetaData(DataUtil.convertToStorageGuid(metaData, blobStoreUuid));
+                    audiosClient.addAudioMetaData(DataUtil.convertToStorageGuid(metaData, blobStoreUuid.get()));
                 });
             } else {
                 log.error("The add audio endpoint requires a file to be specified. No file was found");
@@ -106,6 +106,11 @@ public class AddAudioRoute {
             }
         } catch (IOException ioe) {
             throw new DartsException(ioe, CodeAndMessage.ERROR);
+        } catch (Exception e) {
+            if (blobStoreUuid.get() != null) {
+                dataManagementService.deleteBlobData(dataManagementConfiguration.getInboundContainerName(), blobStoreUuid.get());
+            }
+            throw e;
         }
 
         CodeAndMessage message = CodeAndMessage.OK;

--- a/src/main/java/uk/gov/hmcts/darts/addaudio/validator/AddAudioValidator.java
+++ b/src/main/java/uk/gov/hmcts/darts/addaudio/validator/AddAudioValidator.java
@@ -75,7 +75,7 @@ public class AddAudioValidator {
 
     private void validateSize() {
         Optional<XmlWithFileMultiPartRequest> request = multiPartRequestHolder.getRequest();
-        if (!request.isPresent()) {
+        if (request.isEmpty()) {
             throw new DartsValidationException(CodeAndMessage.ERROR);
         }
         try {

--- a/src/main/java/uk/gov/hmcts/darts/common/client/AudiosClient.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/AudiosClient.java
@@ -4,18 +4,15 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.multipart.MultipartFile;
 import uk.gov.hmcts.darts.api.audio.AudiosApi;
 import uk.gov.hmcts.darts.common.client.component.HttpHeadersInterceptor;
 import uk.gov.hmcts.darts.common.client.exeption.DartsClientProblemDecoder;
 import uk.gov.hmcts.darts.log.api.LogApi;
-import uk.gov.hmcts.darts.model.audio.AddAudioMetadataRequest;
 import uk.gov.hmcts.darts.model.audio.AddAudioMetadataRequestWithStorageGUID;
 
 import java.util.List;

--- a/src/main/java/uk/gov/hmcts/darts/common/client/AudiosClient.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/client/AudiosClient.java
@@ -40,17 +40,6 @@ public class AudiosClient extends AbstractRestTemplateClient implements AudiosAp
         this.logApi = logApi;
     }
 
-    /**
-     * Add an audio using streaming.
-     *
-     * @param multipartFile The multipart audio file to transfer. A default one that disableS in memory loading
-     *                      can be found {@link uk.gov.hmcts.darts.common.client.multipart.StreamingMultipart}
-     * @param audio         The audio meta data
-     */
-    public void streamAudio(MultipartFile multipartFile, AddAudioMetadataRequest audio) {
-        streamFileWithMetaData(multipartFile, audio, baseUrl + "/audios");
-    }
-
     @Override
     protected RestTemplate getTemplate() {
         return template;
@@ -59,12 +48,6 @@ public class AudiosClient extends AbstractRestTemplateClient implements AudiosAp
     @Override
     protected DartsClientProblemDecoder getProblemDecoder() {
         return decoder;
-    }
-
-    @Override
-    public ResponseEntity<Void> addAudio(MultipartFile file, AddAudioMetadataRequest metadata) {
-        streamAudio(file, metadata);
-        return new ResponseEntity<>(HttpStatusCode.valueOf(200));
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/darts/datastore/DataManagementConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/darts/datastore/DataManagementConfiguration.java
@@ -30,6 +30,11 @@ public final class DataManagementConfiguration {
     @Value("${darts-gateway.storage.blob.client.timeout}")
     private Duration blobClientTimeout;
 
+    @Value("${darts-gateway.storage.blob.client.delete-timeout}")
+    private Duration blobClientDeleteTimeout;
+
+
+
     @Value("${darts-gateway.storage.blob.container-name.inbound}")
     private String inboundContainerName;
 }

--- a/src/main/java/uk/gov/hmcts/darts/datastore/DataManagementService.java
+++ b/src/main/java/uk/gov/hmcts/darts/datastore/DataManagementService.java
@@ -7,4 +7,6 @@ import java.util.UUID;
 public interface DataManagementService {
 
     UUID saveBlobData(String containerName, InputStream inputStream, Map<String, String> metadata);
+
+    void deleteBlobData(String inboundContainerName, UUID uuid);
 }

--- a/src/main/java/uk/gov/hmcts/darts/datastore/DataManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/datastore/DataManagementServiceImpl.java
@@ -14,8 +14,6 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.datastore.azure.DataManagementAzureClientFactory;
 
 import java.io.InputStream;
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.UUID;
 
@@ -54,6 +52,7 @@ public class DataManagementServiceImpl implements DataManagementService {
     public void deleteBlobData(String containerName, UUID blobId) {
         if (dataManagementConfiguration.isDisableUpload()) {
             log.info("Azure upload is disabled in properties. Skipping file deletion");
+            return;
         }
 
         try {
@@ -61,8 +60,9 @@ public class DataManagementServiceImpl implements DataManagementService {
             BlobContainerClient containerClient = blobServiceFactory.getBlobContainerClient(containerName, serviceClient);
 
             BlobClient client = blobServiceFactory.getBlobClient(containerClient, blobId);
-            Response<Boolean> response = client.deleteIfExistsWithResponse(DeleteSnapshotsOptionType.INCLUDE, null,
-                                                                           dataManagementConfiguration.getBlobClientDeleteTimeout(), null
+            Response<Boolean> response = client.deleteIfExistsWithResponse(
+                DeleteSnapshotsOptionType.INCLUDE, null,
+                dataManagementConfiguration.getBlobClientDeleteTimeout(), null
             );
 
             HttpStatus httpStatus = valueOf(response.getStatusCode());

--- a/src/main/java/uk/gov/hmcts/darts/datastore/DataManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/datastore/DataManagementServiceImpl.java
@@ -1,18 +1,26 @@
 package uk.gov.hmcts.darts.datastore;
 
+import com.azure.core.http.rest.Response;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.models.DeleteSnapshotsOptionType;
 import com.azure.storage.blob.models.ParallelTransferOptions;
 import com.azure.storage.blob.options.BlobParallelUploadOptions;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.datastore.azure.DataManagementAzureClientFactory;
 
 import java.io.InputStream;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.UUID;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.valueOf;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -40,6 +48,32 @@ public class DataManagementServiceImpl implements DataManagementService {
         client.uploadWithResponse(uploadOptions, dataManagementConfiguration.getBlobClientTimeout(), null);
 
         return uniqueBlobId;
+    }
+
+    @Override
+    public void deleteBlobData(String containerName, UUID blobId) {
+        if (dataManagementConfiguration.isDisableUpload()) {
+            log.info("Azure upload is disabled in properties. Skipping file deletion");
+        }
+
+        try {
+            BlobServiceClient serviceClient = blobServiceFactory.getBlobServiceClient(dataManagementConfiguration.getBlobStorageAccountConnectionString());
+            BlobContainerClient containerClient = blobServiceFactory.getBlobContainerClient(containerName, serviceClient);
+
+            BlobClient client = blobServiceFactory.getBlobClient(containerClient, blobId);
+            Response<Boolean> response = client.deleteIfExistsWithResponse(DeleteSnapshotsOptionType.INCLUDE, null,
+                                                                           dataManagementConfiguration.getBlobClientDeleteTimeout(), null
+            );
+
+            HttpStatus httpStatus = valueOf(response.getStatusCode());
+            if (httpStatus.is2xxSuccessful() || NOT_FOUND.equals(httpStatus)) {
+                return;
+            }
+            log.error("Failed to delete from storage container={}, blobId={}, httpStatus={}",
+                      containerName, blobId, httpStatus);
+        } catch (RuntimeException e) {
+            log.error("Failed to delete from storage container={}, blobId={}", containerName, blobId, e);
+        }
     }
 
     private ParallelTransferOptions createCommonTransferOptions() {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -54,6 +54,7 @@ darts-gateway:
         max-single-upload-size-bytes: 10_000_000
         max-concurrency: 5
         timeout: 15m
+        delete-timeout: 1m
         disable-upload: false
       container-name:
         inbound: darts-inbound-container

--- a/src/test/java/uk/gov/hmcts/darts/addaudio/AddAudioRouteTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/addaudio/AddAudioRouteTest.java
@@ -24,6 +24,7 @@ import uk.gov.hmcts.darts.utilities.XmlParser;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -31,6 +32,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -114,5 +116,63 @@ class AddAudioRouteTest {
                 "checksum",
                 null
             );
+        verify(dataManagementService, never())
+            .deleteBlobData(any(), any());
+    }
+
+    @Test
+    void route_onApiFailure_shouldDeleteBlobData() throws Exception {
+        final String containerName = "container-name";
+        when(dataManagementConfiguration.getInboundContainerName())
+            .thenReturn(containerName);
+        XmlWithFileMultiPartRequest request = mock(XmlWithFileMultiPartRequest.class);
+        when(multiPartRequestHolder.getRequest()).thenReturn(Optional.of(request));
+        AtomicBoolean firstCall = new AtomicBoolean(false);
+
+        when(request.consumeFileBinaryStream(any())).thenAnswer(invocation -> {
+            if (firstCall.get()) {
+                ConsumerWithIoException<SizeableInputSource> consumer = invocation.getArgument(0);
+                consumer.accept(mock(SizeableInputSource.class));
+            } else {
+                firstCall.set(true);
+            }
+            return true;
+        });
+        AddAudioMetadataRequest addAudioMetadataRequest = mock(AddAudioMetadataRequest.class);
+
+        OffsetDateTime startAt = OffsetDateTime.parse("2025-01-29T10:44:25.028498Z");
+        OffsetDateTime endAt = OffsetDateTime.parse("2025-01-31T10:44:25.028526Z");
+
+        when(addAudioMetadataRequest.getCourthouse()).thenReturn("courtHouse");
+        when(addAudioMetadataRequest.getCourtroom()).thenReturn("courtroom");
+        when(addAudioMetadataRequest.getStartedAt()).thenReturn(startAt);
+        when(addAudioMetadataRequest.getEndedAt()).thenReturn(endAt);
+        when(addAudioMetadataRequest.getCases()).thenReturn(List.of("case1", "case2"));
+        when(addAudioMetadataRequest.getChecksum()).thenReturn("checksum");
+
+        when(addAudioMapper.mapToDartsApi(any())).thenReturn(addAudioMetadataRequest);
+
+        UUID blobUuid = UUID.randomUUID();
+        when(dataManagementService.saveBlobData(any(), any(), any()))
+            .thenReturn(blobUuid);
+
+        RuntimeException exception = new RuntimeException("Some exception");
+        when(audiosClient.addAudioMetaData(any()))
+            .thenThrow(exception);
+
+        AddAudio addAudio = mock(AddAudio.class);
+
+        when(addAudio.getDocument()).thenReturn("");
+
+        try (MockedStatic<XmlParser> xmlParserMockedStatic = mockStatic(XmlParser.class)) {
+
+            xmlParserMockedStatic.when(() -> XmlParser.unmarshal(anyString(), any()))
+                .thenReturn(mock(Audio.class));
+
+            assertThrows(RuntimeException.class,
+                         () -> addAudioRoute.route(addAudio));
+        }
+        verify(dataManagementService)
+            .deleteBlobData(containerName, blobUuid);
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/datastore/DataManagementServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/datastore/DataManagementServiceImplTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -70,6 +71,7 @@ class DataManagementServiceImplTest {
         verify(dataManagementFactory, times(1)).getBlobServiceClient("connection");
         verify(dataManagementFactory, times(1)).getBlobContainerClient(BLOB_CONTAINER_NAME, serviceClient);
         verify(dataManagementFactory, times(1)).getBlobClient(eq(blobContainerClient), any(UUID.class));
+        verify(blobClient, never()).deleteIfExistsWithResponse(any(), any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4689)


### Change description ###
# Summary of Git Diff

This diff includes modifications to multiple Java files in the project, focusing primarily on the handling of audio file uploads and associated metadata. Key changes include the introduction of improved error handling when uploading audio files, the addition of a blob data deletion mechanism, and the removal of unused methods in the `AudiosClient` class. 

## Highlights

- **AddAudioRoute.java**:
  - Introduced an `AtomicReference<UUID> blobStoreUuid` to hold the UUID of the uploaded audio blob.
  - Updated the blob upload logic to set the UUID in the `AtomicReference`.
  - Added error handling to delete the blob if an exception occurs during the API call after a successful upload.

- **AddAudioValidator.java**:
  - Changed the presence check for `Optional` from `isPresent()` to `isEmpty()` for better readability.

- **AudiosClient.java**:
  - Removed the `streamAudio` method and its associated `addAudio` method, streamlining the class.

- **DataManagementConfiguration.java**:
  - Added a configuration property for `blobClientDeleteTimeout`.

- **DataManagementService.java**:
  - Added a method to delete blob data from the storage.

- **DataManagementServiceImpl.java**:
  - Implemented the delete logic for blobs, including logging for success and error cases.

- **application.yaml**:
  - Configured a new `delete-timeout` property for blob deletions.

- **AddAudioRouteTest.java**:
  - Added tests to verify that blob data is deleted on API failure and ensured that the delete logic is not called unnecessarily in other scenarios.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
