### PR TITLE
DMP-4772: log entry is not created to identify an issue adding the audio file size exceeds

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/AddAudioWebServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/AddAudioWebServiceTest.java
@@ -47,6 +47,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -276,7 +277,7 @@ class AddAudioWebServiceTest extends IntegrationBase {
             final String soapRequestStr = TestUtils.getContentsFromFile(
                 "payloads/addAudio/register/soapRequest.xml");
 
-            XmlWithFileMultiPartRequest request = mock(XmlWithFileMultiPartRequest.class);
+            XmlWithFileMultiPartRequest request = spy(new DummyXmlWithFileMultiPartRequest(AddAudioMidTierCommand.SAMPLE_FILE));
             when(request.getBinarySize()).thenReturn(AddAudioValidator.getBytes(maxByteSize.toBytes()) + 1);
             when(requestHolder.getRequest()).thenReturn(Optional.of(request));
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/ws/AddAudioWebServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/ws/AddAudioWebServiceTest.java
@@ -453,7 +453,7 @@ class AddAudioWebServiceTest extends IntegrationBase {
             final String soapRequestStr = TestUtils.getContentsFromFile(
                 "payloads/addAudio/register/soapRequestDurationExceeded.xml");
 
-            XmlWithFileMultiPartRequest request = mock(XmlWithFileMultiPartRequest.class);
+            XmlWithFileMultiPartRequest request = spy(new DummyXmlWithFileMultiPartRequest(AddAudioMidTierCommand.SAMPLE_FILE));
             when(request.getBinarySize()).thenReturn(AddAudioValidator.getBytes(maxByteSize.toBytes()));
             when(requestHolder.getRequest()).thenReturn(Optional.of(request));
 

--- a/src/main/java/uk/gov/hmcts/darts/addaudio/AddAudioRoute.java
+++ b/src/main/java/uk/gov/hmcts/darts/addaudio/AddAudioRoute.java
@@ -56,9 +56,6 @@ public class AddAudioRoute {
 
         try {
             addAudioLegacy = XmlParser.unmarshal(audioXml, Audio.class);
-
-            addAudioValidator.validate(addAudioLegacy);
-
             Optional<XmlWithFileMultiPartRequest> request = multiPartRequestHolder.getRequest();
 
             if (request.isEmpty()) {
@@ -79,7 +76,7 @@ public class AddAudioRoute {
                 multipartFileValidator.validate(multipartFile);
 
                 AddAudioMetadataRequest metaData = addAudioMapper.mapToDartsApi(addAudioLegacy);
-                addAudioValidator.validateSize(metaData, request.get().getBinarySize());
+                addAudioValidator.validate(metaData, request.get().getBinarySize(), addAudioLegacy);
 
                 metaData.setFileSize(request.get().getBinarySize());
                 metaData.setChecksum(checksum.get());
@@ -108,6 +105,7 @@ public class AddAudioRoute {
             throw e;
         } catch (Exception e) {
             if (blobStoreUuid.get() != null) {
+                log.error("Deleting blob {} from the inbound container as an unexpected error has occurred", blobStoreUuid.get(), e);
                 dataManagementService.deleteBlobData(dataManagementConfiguration.getInboundContainerName(), blobStoreUuid.get());
             }
             throw new DartsException(e, CodeAndMessage.ERROR);

--- a/src/main/java/uk/gov/hmcts/darts/addaudio/AddAudioRoute.java
+++ b/src/main/java/uk/gov/hmcts/darts/addaudio/AddAudioRoute.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.darts.addaudio.validator.AddAudioValidator;
 import uk.gov.hmcts.darts.api.audio.AudiosApi;
 import uk.gov.hmcts.darts.common.client.multipart.StreamingMultipart;
 import uk.gov.hmcts.darts.common.exceptions.DartsException;
+import uk.gov.hmcts.darts.common.exceptions.DartsValidationException;
 import uk.gov.hmcts.darts.common.multipart.XmlWithFileMultiPartRequest;
 import uk.gov.hmcts.darts.common.multipart.XmlWithFileMultiPartRequestHolder;
 import uk.gov.hmcts.darts.datastore.DataManagementConfiguration;
@@ -74,6 +75,7 @@ public class AddAudioRoute {
                         uploadedStream
                     );
                     AddAudioMetadataRequest metaData = addAudioMapper.mapToDartsApi(addAudioLegacy);
+                    addAudioValidator.validateSize(metaData, request.get().getBinarySize());
                     metaData.setFileSize(request.get().getBinarySize());
                     metaData.setChecksum(checksum.get());
                     multipartFileValidator.validate(multipartFile);
@@ -105,6 +107,8 @@ public class AddAudioRoute {
                 log.error("The add audio endpoint requires a file to be specified. No file was found");
                 throw new DartsException(CodeAndMessage.ERROR);
             }
+        } catch (DartsValidationException e) {
+            throw e;
         } catch (IOException ioe) {
             throw new DartsException(ioe, CodeAndMessage.ERROR);
         } catch (Exception e) {

--- a/src/main/java/uk/gov/hmcts/darts/addaudio/AddAudioRoute.java
+++ b/src/main/java/uk/gov/hmcts/darts/addaudio/AddAudioRoute.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.addaudio.validator.AddAudioFileValidator;
 import uk.gov.hmcts.darts.addaudio.validator.AddAudioValidator;
 import uk.gov.hmcts.darts.api.audio.AudiosApi;
+import uk.gov.hmcts.darts.common.client.exeption.ClientProblemException;
 import uk.gov.hmcts.darts.common.client.multipart.StreamingMultipart;
 import uk.gov.hmcts.darts.common.exceptions.DartsException;
 import uk.gov.hmcts.darts.common.exceptions.DartsValidationException;
@@ -103,7 +104,7 @@ public class AddAudioRoute {
                 log.info("Audio file uploaded successfully to the inbound blob store. BlobStoreUuid: {}", blobStoreUuid);
                 audiosClient.addAudioMetaData(DataUtil.convertToStorageGuid(metaData, blobStoreUuid.get()));
             });
-        } catch (DartsValidationException e) {
+        } catch (DartsValidationException | ClientProblemException e) {
             throw e;
         } catch (Exception e) {
             if (blobStoreUuid.get() != null) {

--- a/src/main/java/uk/gov/hmcts/darts/addaudio/validator/AddAudioValidator.java
+++ b/src/main/java/uk/gov/hmcts/darts/addaudio/validator/AddAudioValidator.java
@@ -17,7 +17,6 @@ import uk.gov.hmcts.darts.model.audio.AddAudioMetadataRequest;
 import uk.gov.hmcts.darts.utilities.XmlValidator;
 import uk.gov.hmcts.darts.ws.CodeAndMessage;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.Optional;

--- a/src/main/java/uk/gov/hmcts/darts/addaudio/validator/AddAudioValidator.java
+++ b/src/main/java/uk/gov/hmcts/darts/addaudio/validator/AddAudioValidator.java
@@ -95,7 +95,7 @@ public class AddAudioValidator {
         }
     }
 
-     void validateDuration(AddAudioMetadataRequest metaData, Audio audio) {
+    void validateDuration(AddAudioMetadataRequest metaData, Audio audio) {
 
         OffsetDateTime startDate = getAudioStartDateTime(audio);
         OffsetDateTime finishDate = getAudioEndDateTime(audio);

--- a/src/main/java/uk/gov/hmcts/darts/addaudio/validator/AddAudioValidator.java
+++ b/src/main/java/uk/gov/hmcts/darts/addaudio/validator/AddAudioValidator.java
@@ -37,7 +37,7 @@ public class AddAudioValidator {
     @Value("${darts-gateway.add-audio.fileSizeInMegaBytes}")
     long expectedFileSize;
     @Value("${darts-gateway.add-audio.maxFileDuration}")
-    private Duration maxFileDuration;
+    Duration maxFileDuration;
 
     private final XmlWithFileMultiPartRequestHolder multiPartRequestHolder;
     private final XmlValidator xmlValidator;
@@ -47,9 +47,12 @@ public class AddAudioValidator {
         validateXml(addAudio);
     }
 
-    public void validate(Audio audio) {
-        validateDuration(audio);
+
+    public void validate(AddAudioMetadataRequest metaData, long binarySize, Audio audio) {
+        validateDuration(metaData, audio);
+        validateSize(metaData, binarySize);
     }
+
 
     public void validateCourtroom(Audio audio) {
         //check courtroom in populated, if empty throw 500 to match legacy
@@ -92,7 +95,7 @@ public class AddAudioValidator {
         }
     }
 
-    private void validateDuration(Audio audio) {
+     void validateDuration(AddAudioMetadataRequest metaData, Audio audio) {
 
         OffsetDateTime startDate = getAudioStartDateTime(audio);
         OffsetDateTime finishDate = getAudioEndDateTime(audio);
@@ -101,6 +104,15 @@ public class AddAudioValidator {
 
         if (difference.compareTo(maxFileDuration) > 0) {
             log.info("Add Audio failed due to Duration too long");
+            logApi.failedToLinkAudioToCases(
+                metaData.getCourthouse(),
+                metaData.getCourtroom(),
+                metaData.getStartedAt(),
+                metaData.getEndedAt(),
+                metaData.getCases(),
+                metaData.getChecksum(),
+                null
+            );
             throw new DartsValidationException(CodeAndMessage.AUDIO_TOO_LARGE);
         }
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -152,5 +152,3 @@ darts-gateway:
       - namespace: http://com.synapps.mojdarts.service.com
         tag: addDocument
         type: DL
-temp:
-  force-checksum-failure: ${FORCE_CHECKSUM_FAILURE:false}

--- a/src/test/java/uk/gov/hmcts/darts/addaudio/validator/AddAudioValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/addaudio/validator/AddAudioValidatorTest.java
@@ -1,0 +1,61 @@
+package uk.gov.hmcts.darts.addaudio.validator;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.darts.common.exceptions.DartsValidationException;
+import uk.gov.hmcts.darts.log.api.LogApi;
+import uk.gov.hmcts.darts.model.audio.AddAudioMetadataRequest;
+import uk.gov.hmcts.darts.ws.CodeAndMessage;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class AddAudioValidatorTest {
+
+    @Test
+    void validateSize_shouldNotThrowException_whenSizeIsLessThanMaxSize() {
+        LogApi logApi = mock(LogApi.class);
+        AddAudioValidator validator = new AddAudioValidator(null, null, logApi);
+        validator.expectedFileSize = 1000;
+        AddAudioMetadataRequest metaData = mock(AddAudioMetadataRequest.class);
+
+        validator.validateSize(metaData, 900);
+        verifyNoInteractions(logApi);
+    }
+
+    @Test
+    void validateSize_shouldThrowException_whenSizeIsGreaterThanMaxSize() {
+        LogApi logApi = mock(LogApi.class);
+        AddAudioValidator validator = new AddAudioValidator(null, null, logApi);
+        validator.expectedFileSize = 1000;
+        AddAudioMetadataRequest metaData = new AddAudioMetadataRequest();
+        metaData.setCourthouse("courthouse");
+        metaData.setCourtroom("courtroom");
+        OffsetDateTime startedAt = OffsetDateTime.now();
+        metaData.setStartedAt(startedAt);
+        OffsetDateTime endedAt = OffsetDateTime.now().plusDays(1);
+        metaData.setEndedAt(endedAt);
+        metaData.setCases(List.of("case1", "case2"));
+        metaData.setChecksum("checksum");
+
+        DartsValidationException dartsValidationException =
+            assertThrows(DartsValidationException.class,
+                         () -> validator.validateSize(metaData, AddAudioValidator.getBytes(1001)));
+
+        assertThat(dartsValidationException.getCodeAndMessage()).isEqualTo(CodeAndMessage.AUDIO_TOO_LARGE);
+        verify(logApi).failedToLinkAudioToCases(
+            "courthouse",
+            "courtroom",
+            startedAt,
+            endedAt,
+            List.of("case1", "case2"),
+            "checksum",
+            null
+        );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/darts/addaudio/validator/AddAudioValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/addaudio/validator/AddAudioValidatorTest.java
@@ -67,9 +67,7 @@ class AddAudioValidatorTest {
         LogApi logApi = mock(LogApi.class);
         AddAudioValidator validator = new AddAudioValidator(null, null, logApi);
         validator.maxFileDuration = Duration.ofDays(1);
-        AddAudioMetadataRequest metaData = mock(AddAudioMetadataRequest.class);
 
-        Audio audio = new Audio();
         Audio.Start start = new Audio.Start();
         start.setY("2020");
         start.setM("1");
@@ -77,15 +75,19 @@ class AddAudioValidatorTest {
         start.setH("1");
         start.setMIN("1");
         start.setS("1");
-        audio.setStart(start);
+
         Audio.End end = new Audio.End();
         end.setY(new BigInteger("2020"));
-        end.setM(new BigInteger("1"));
-        end.setD(new BigInteger("1"));
+        end.setM(BigInteger.ONE);
+        end.setD(BigInteger.ONE);
         end.setH(new BigInteger("23"));
         end.setMIN(new BigInteger("59"));
         end.setS(new BigInteger("59"));
+
+        Audio audio = new Audio();
+        audio.setStart(start);
         audio.setEnd(end);
+        AddAudioMetadataRequest metaData = mock(AddAudioMetadataRequest.class);
         validator.validateDuration(metaData, audio);
         verifyNoInteractions(logApi);
     }
@@ -105,7 +107,6 @@ class AddAudioValidatorTest {
         metaData.setCases(List.of("case1", "case2"));
         metaData.setChecksum("checksum");
 
-        Audio audio = new Audio();
         Audio.Start start = new Audio.Start();
         start.setY("2020");
         start.setM("1");
@@ -113,14 +114,17 @@ class AddAudioValidatorTest {
         start.setH("1");
         start.setMIN("1");
         start.setS("1");
-        audio.setStart(start);
+
         Audio.End end = new Audio.End();
         end.setY(new BigInteger("2020"));
-        end.setM(new BigInteger("1"));
-        end.setD(new BigInteger("2"));
-        end.setH(new BigInteger("1"));
-        end.setMIN(new BigInteger("1"));
-        end.setS(new BigInteger("2"));
+        end.setM(BigInteger.ONE);
+        end.setD(BigInteger.TWO);
+        end.setH(BigInteger.ONE);
+        end.setMIN(BigInteger.ONE);
+        end.setS(BigInteger.TWO);
+
+        Audio audio = new Audio();
+        audio.setStart(start);
         audio.setEnd(end);
 
         DartsValidationException dartsValidationException =


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4772)


### Change description ###
# Git Diff Summary

This Git Diff introduces enhancements to the `AddAudioRoute` and `AddAudioValidator` classes, improving validation mechanisms for audio uploads and incorporating new exception handling. Additionally, a test suite for the `AddAudioValidator` is added to ensure proper validation functionality.

## Highlights

- **New Exception Handling**: 
  - Added `DartsValidationException` to handle validation errors specifically in the `AddAudioRoute`.

- **Validation Enhancements**:
  - The `AddAudioValidator` now includes a method `validateSize` that checks the size of the uploaded audio file against a maximum limit.
  - Improved logging to provide more context on validation failures.

- **Code Refactoring**:
  - The method `validateSize()` in `AddAudioValidator` has been updated to take `AddAudioMetadataRequest` and binary size as parameters, enhancing its utility.
  
- **New Test Cases**:
  - Introduced `AddAudioValidatorTest` with tests for validating audio file sizes:
    - **Test for Size Validation**: Ensures no exception is thrown when the file size is within limits.
    - **Test for Size Exceedance**: Validates that an exception is thrown and appropriate logging occurs when the file size exceeds the limit. 

These changes aim to ensure that audio uploads meet specified criteria, enhancing the overall robustness of the system.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
