### PR TITLE
DMP-5048: Make DARTS Gateway run on Dev environment

### DIFF
--- a/charts/darts-gateway/values.dev.template.yaml
+++ b/charts/darts-gateway/values.dev.template.yaml
@@ -40,3 +40,4 @@ java:
   environment:
     DARTS_API_URL: https://darts-api.staging.platform.hmcts.net
     TESTING_SUPPORT_ENDPOINTS_ENABLED: true
+


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-5048)


### Change description ###
Fix the DARTS Gateway so that when a DARTS Gateway PR is created, a Dev environment is spun up as per the DARTS API process. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
