### PR TITLE
DMP-5095 Fixing DAR notify log message date time

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/event/client/DarNotifyEventClient.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/client/DarNotifyEventClient.java
@@ -20,12 +20,14 @@ import org.springframework.ws.transport.context.TransportContextHolder;
 import org.springframework.ws.transport.http.HttpComponentsConnection;
 import uk.gov.hmcts.darts.event.enums.DarNotifyEventResult;
 import uk.gov.hmcts.darts.log.api.LogApi;
+import uk.gov.hmcts.darts.utilities.DateUtil;
 import uk.gov.hmcts.darts.utilities.XmlParser;
 
 import java.time.Clock;
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.Month;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import javax.annotation.PostConstruct;
 import javax.xml.transform.Source;
@@ -106,16 +108,15 @@ public class DarNotifyEventClient {
     }
 
     private static OffsetDateTime dateTimeFrom(Event event) {
-        return OffsetDateTime.of(
+        LocalDateTime localDateTime = LocalDateTime.of(
             parseInt(event.getY()),
-            parseInt(event.getM()),
+            Month.of(parseInt(event.getM())),
             parseInt(event.getD()),
             parseInt(event.getH()),
             parseInt(event.getMIN()),
-            parseInt(event.getS()),
-            0,
-            ZoneOffset.UTC
+            parseInt(event.getS())
         );
+        return DateUtil.toOffsetDateTime(localDateTime);
     }
 
     @Component


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-5095

### Change description ###

- the event date time is local time without an offset
- using `DateUtil.toOffsetDateTime` to convert this correctly for the log message
- no changes made to the DAR notification request


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
