### PR TITLE
DMP-5169 Updating HTTP session timeout to match token lifetime

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,7 +5,7 @@ server:
       store-type: redis
       cookie:
         name: JSESSIONID
-      timeout: 245m
+      timeout: 721m # 12 hours 1 minute - to last slightly beyond the 12h token lifetime
 
 management:
   endpoint:


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-5169

### Change description ###

- 12 hours, plus 1 minute to ensure it doesn't expire before the token

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
