### PR TITLE
DMP-5165: Cascade graceful shutdown logic from DMP-5143 to gateway

### DIFF
--- a/charts/darts-gateway/Chart.yaml
+++ b/charts/darts-gateway/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for darts-gateway App
 name: darts-gateway
 home: https://github.com/hmcts/darts-gateway
-version: 0.0.40
+version: 0.0.41
 maintainers:
   - name: HMCTS darts team
 dependencies:

--- a/charts/darts-gateway/values.yaml
+++ b/charts/darts-gateway/values.yaml
@@ -1,5 +1,7 @@
 java:
   applicationPort: 8070
+  readinessPeriod: 5
+  terminationGracePeriodSeconds: 65
   image: 'sdshmctspublic.azurecr.io/darts/gateway:latest'
   ingressHost: darts-gateway.{{ .Values.global.environment }}.platform.hmcts.net
   aadIdentityName: darts
@@ -47,3 +49,4 @@ java:
     ACTIVE_DIRECTORY_B2C_ON_MICROSOFT_URI: https://hmctsstgextid.onmicrosoft.com
     JWKS_REFRESH_PERIOD: 30m
     JWKS_LIFETIME_PERIOD: 60m
+    GRACEFUL_SHUTDOWN_TIMEOUT: '35s'

--- a/src/main/java/uk/gov/hmcts/darts/Application.java
+++ b/src/main/java/uk/gov/hmcts/darts/Application.java
@@ -2,17 +2,28 @@ package uk.gov.hmcts.darts;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import uk.gov.hmcts.darts.cache.token.config.KeyConfiguration;
+import uk.gov.hmcts.darts.shutdown.GracefulShutdownHook;
 
 @SpringBootApplication
 @EnableFeignClients
-@EnableRedisRepositories (keyspaceConfiguration = KeyConfiguration.class)
+@EnableRedisRepositories(keyspaceConfiguration = KeyConfiguration.class)
 @SuppressWarnings("HideUtilityClassConstructor") // Spring needs a constructor, its not a utility class
 public class Application {
 
+    @SuppressWarnings("PMD.DoNotUseThreads")//Required for shutdown hook)
     public static void main(final String[] args) {
-        SpringApplication.run(Application.class, args);
+        final var application = new SpringApplication(Application.class);
+        application.setRegisterShutdownHook(false);
+
+        ConfigurableApplicationContext applicationContext = application.run(args);
+
+        Thread shutdownHookThread = new Thread(new GracefulShutdownHook((ServletWebServerApplicationContext) applicationContext));
+        shutdownHookThread.setName("GracefulShutdownHook");
+        Runtime.getRuntime().addShutdownHook(shutdownHookThread);
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/shutdown/GracefulShutdownHealthCheck.java
+++ b/src/main/java/uk/gov/hmcts/darts/shutdown/GracefulShutdownHealthCheck.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.darts.shutdown;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+@Component("dartsGatewayGracefulShutdownHealthCheck")
+@Slf4j
+public class GracefulShutdownHealthCheck implements HealthIndicator {
+    public static final String HEALTH_KEY = "DartsGracefulShutdown";
+
+    @Getter
+    private Health healthResult;
+
+    @Override
+    public Health health() {
+        return healthResult;
+    }
+
+    public void setReady(boolean ready) {
+        log.info("Updating application graceful shutdown health check state to: {}", ready ? "up" : "down");
+        if (ready) {
+            healthResult = new Health.Builder().withDetail(HEALTH_KEY, "application up").up().build();
+        } else {
+            healthResult = new Health.Builder().withDetail(HEALTH_KEY, "gracefully shutting down").down().build();
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/shutdown/GracefulShutdownHook.java
+++ b/src/main/java/uk/gov/hmcts/darts/shutdown/GracefulShutdownHook.java
@@ -1,0 +1,59 @@
+package uk.gov.hmcts.darts.shutdown;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.convert.DurationStyle;
+import org.springframework.boot.web.server.GracefulShutdownCallback;
+import org.springframework.boot.web.server.GracefulShutdownResult;
+import org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext;
+
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@Slf4j
+//TODO Fix loging so we still get logs even after logging shutdown hook is triggered
+public class GracefulShutdownHook
+    implements Runnable, GracefulShutdownCallback {
+    private final ServletWebServerApplicationContext applicationContext;
+
+    @Override
+    public void run() {
+        setReadinessToFalse();
+        delayShutdown();
+        shutdownApplication();
+    }
+
+    void setReadinessToFalse() {
+        log.info("Setting readiness for application to false, so the application doesn't receive new connections from now on.");
+        GracefulShutdownHealthCheck probeControllers = applicationContext.getBean(
+            "dartsGatewayGracefulShutdownHealthCheck", GracefulShutdownHealthCheck.class);
+        probeControllers.setReady(false);
+    }
+
+    //Required for graceful shutdown. Health check needs to fail for a short time, so the load balancer stops sending new requests.
+    @SuppressWarnings("PMD.DoNotUseThreads")
+    void delayShutdown() {
+        try {
+            String waitTimeString = applicationContext.getBeanFactory().resolveEmbeddedValue("${darts-gateway.shutdown.wait-time:30s}");
+            Duration waitTime = DurationStyle.detectAndParse(waitTimeString);
+            log.info("Waiting for {} before shutdown SpringContext!", waitTime);
+            Thread.sleep(waitTime.toMillis());
+        } catch (InterruptedException e) {
+            log.error("Error while gracefulshutdown Thread.sleep", e);
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    void shutdownApplication() {
+        log.info("Shutting down Application");
+        //First shutdown the web server, so it stops accepting new connections
+        applicationContext.getWebServer().shutDownGracefully(this);
+        //Then shutdown application context in shutdown callback
+    }
+
+    @Override
+    public void shutdownComplete(GracefulShutdownResult result) {
+        applicationContext.close();
+        log.info("Graceful shutdown complete: {}", result);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -44,6 +44,8 @@ spring:
 
 azure:
 darts-gateway:
+  shutdown:
+    wait-time: ${GRACEFUL_SHUTDOWN_TIMEOUT:30s}
   dar-pc-max-time-drift: ${DAR_PC_MAX_TIME_DRIFT:90s}
   storage:
     blob:

--- a/src/test/java/uk/gov/hmcts/darts/shutdown/GracefulShutdownHealthCheckTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/shutdown/GracefulShutdownHealthCheckTest.java
@@ -1,0 +1,27 @@
+package uk.gov.hmcts.darts.shutdown;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.actuate.health.Health;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GracefulShutdownHealthCheckTest {
+
+    @Test
+    void setReadyTrue_shouldSetHealthToUp() {
+        GracefulShutdownHealthCheck healthCheck = new GracefulShutdownHealthCheck();
+        healthCheck.setReady(true);
+        Health health = healthCheck.health();
+        assertEquals("UP", health.getStatus().getCode());
+        assertEquals("application up", health.getDetails().get(GracefulShutdownHealthCheck.HEALTH_KEY));
+    }
+
+    @Test
+    void setReadyFalse_shouldSetHealthToDown() {
+        GracefulShutdownHealthCheck healthCheck = new GracefulShutdownHealthCheck();
+        healthCheck.setReady(false);
+        Health health = healthCheck.health();
+        assertEquals("DOWN", health.getStatus().getCode());
+        assertEquals("gracefully shutting down", health.getDetails().get(GracefulShutdownHealthCheck.HEALTH_KEY));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/darts/shutdown/GracefulShutdownHookTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/shutdown/GracefulShutdownHookTest.java
@@ -1,0 +1,89 @@
+package uk.gov.hmcts.darts.shutdown;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.boot.web.server.GracefulShutdownResult;
+import org.springframework.boot.web.server.WebServer;
+import org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class GracefulShutdownHookTest {
+
+    private GracefulShutdownHook gracefulShutdownHook;
+    private ServletWebServerApplicationContext applicationContext;
+
+    @BeforeEach
+    void beforeEach() {
+        applicationContext = mock(ServletWebServerApplicationContext.class);
+        gracefulShutdownHook = spy(new GracefulShutdownHook(applicationContext));
+    }
+
+    @Test
+    void run_shouldSetReadinessToFalseAndDelayShutDownAndShutdownApplication() {
+        doNothing().when(gracefulShutdownHook).setReadinessToFalse();
+        doNothing().when(gracefulShutdownHook).delayShutdown();
+        doNothing().when(gracefulShutdownHook).shutdownApplication();
+
+        gracefulShutdownHook.run();
+        verify(gracefulShutdownHook).setReadinessToFalse();
+        verify(gracefulShutdownHook).delayShutdown();
+        verify(gracefulShutdownHook).shutdownApplication();
+    }
+
+    @Test
+    void setReadinessToFalse_shouldSetHealthCheckBeanReadyToFalse() {
+        GracefulShutdownHealthCheck gracefulShutdownHealthCheck = mock(GracefulShutdownHealthCheck.class);
+        when(applicationContext.getBean("dartsGatewayGracefulShutdownHealthCheck", GracefulShutdownHealthCheck.class))
+            .thenReturn(gracefulShutdownHealthCheck);
+        gracefulShutdownHook.setReadinessToFalse();
+        verify(gracefulShutdownHealthCheck).setReady(false);
+    }
+
+    @Test
+    void delayShutdown_shouldSleepForConfiguredTime() {
+        String waitTimeString = "2s";
+        ConfigurableListableBeanFactory beanFactory = mock(ConfigurableListableBeanFactory.class);
+        when(applicationContext.getBeanFactory()).thenReturn(beanFactory);
+
+        when(beanFactory.resolveEmbeddedValue(any())).thenReturn(waitTimeString);
+
+        long waitStartTime = System.currentTimeMillis();
+
+        gracefulShutdownHook.delayShutdown();
+        long waitEndTime = System.currentTimeMillis();
+        long waitDuration = waitEndTime - waitStartTime;
+
+        assertTrue(waitDuration >= 2000,
+                   "Wait duration was less than 2000ms actual: " + waitDuration + "ms");
+
+        verify(applicationContext).getBeanFactory();
+        verify(beanFactory).resolveEmbeddedValue("${darts-gateway.shutdown.wait-time:30s}");
+    }
+
+    @Test
+    void shutdownComplete_shouldCloseApplicationContext() {
+        WebServer webServer = mock(WebServer.class);
+        when(applicationContext.getWebServer()).thenReturn(webServer);
+
+        gracefulShutdownHook.shutdownApplication();
+
+        verify(applicationContext).getWebServer();
+        verify(webServer).shutDownGracefully(gracefulShutdownHook);
+    }
+
+    @Test
+    void shutdownComplete_shouldCloseApplicationContextAndLogResult() {
+        GracefulShutdownResult result = mock(GracefulShutdownResult.class);
+        gracefulShutdownHook.shutdownComplete(result);
+
+        verify(applicationContext).close();
+    }
+}


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-5165)


### Change description ###
# Summary of Git Diff

This Git diff presents updates to the `darts-gateway` Helm chart, including changes to the versioning, configuration settings, and the addition of new classes related to graceful shutdown functionality in the application. The updates enhance the application's shutdown process and related health checks.

## Highlights

- **Version Update**: 
  - The version of the `darts-gateway` Helm chart has been incremented from `0.0.40` to `0.0.41`.

- **New Configuration Settings**:
  - Added `readinessPeriod` (5 seconds) and `terminationGracePeriodSeconds` (65 seconds) to the `values.yaml` file.
  - Introduced `GRACEFUL_SHUTDOWN_TIMEOUT` (35 seconds) in the environment variables.

- **Graceful Shutdown Implementation**:
  - New classes `GracefulShutdownHook` and `GracefulShutdownHealthCheck` were added to manage the graceful shutdown process.
  - The `GracefulShutdownHook` handles the application shutdown logic and health checks during shutdown.
  - The `GracefulShutdownHealthCheck` provides a health indicator for the application's readiness state.

- **Modified Application Logic**:
  - The `Application` class was updated to register a custom shutdown hook that manages the graceful shutdown process.

- **Testing Enhancements**:
  - Added unit tests for the `GracefulShutdownHealthCheck` and `GracefulShutdownHook` to ensure their functionality during the shutdown process.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
