### PR TITLE
DMP-5284 darts-gateways builds failing sonar coverage too low

### DIFF
--- a/.github/workflows/swagger.yml
+++ b/.github/workflows/swagger.yml
@@ -25,13 +25,15 @@ jobs:
       - name: Run Swagger Publisher
         run: ./gradlew integration --tests uk.gov.hmcts.darts.common.config.SwaggerPublisherTest
       - name: Commit to repository
+        env:
+          SWAGGER_TOKEN: ${{ secrets.SWAGGER_PUBLISHER_API_TOKEN }}
         run: |
           mkdir swagger-staging
           cd swagger-staging
           git init
           git config user.email "github-actions@users.noreply.github.com"
           git config user.name "Darts Gateway GitHub action"
-          git remote add upstream https://${{ secrets.SWAGGER_PUBLISHER_API_TOKEN }}@github.com/hmcts/cnp-api-docs.git
+          git remote add upstream https://"SWAGGER_TOKEN"@github.com/hmcts/cnp-api-docs.git
           git pull upstream master
           repo=`echo "$GITHUB_REPOSITORY" | cut -f2- -d/`
           echo "$(cat /tmp/swagger-specs.json)" > "docs/specs/$repo.json"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-5284

### Change description ###

Fixed sonar issue 'Avoid expanding secrets in a run block'

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
