### PR TITLE
DMP-5419 Update java-logging to version 8.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -405,7 +405,7 @@ dependencies {
     }
     implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.6.0'
 
-    implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '6.1.9'
+    implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '8.0.0'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: log4JVersion
     implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: log4JVersion
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.5.22'


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-5419

### Change description ###

Updated java-logging version before current version is deprecated

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
